### PR TITLE
feat: add system font toggle in appearance settings

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
@@ -24,6 +24,7 @@ class AppearancePreferences(
   val appTheme = preferenceStore.getEnum("app_theme", AppTheme.Default)
   val materialYou = preferenceStore.getBoolean("material_you", true)
   val amoledMode = preferenceStore.getBoolean("amoled_mode", false)
+  val useSystemFont = preferenceStore.getBoolean("use_system_font", false)
   val unlimitedNameLines = preferenceStore.getBoolean("unlimited_name_lines", false)
   val hidePlayerButtonsBackground = preferenceStore.getBoolean("hide_player_buttons_background", false)
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
@@ -142,6 +142,25 @@ object AppearancePreferencesScreen : Screen {
 
                             PreferenceDivider()
 
+                            // System font toggle
+                            val useSystemFont by preferences.useSystemFont.collectAsState()
+
+                            SwitchPreference(
+                                value = useSystemFont,
+                                onValueChange = { newValue ->
+                                    preferences.useSystemFont.set(newValue)
+                                },
+                                title = { Text(text = stringResource(id = R.string.pref_appearance_use_system_font_title)) },
+                                summary = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_use_system_font_summary),
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                },
+                            )
+
+                            PreferenceDivider()
+
                             val hidePlayerButtonsBackground by preferences.hidePlayerButtonsBackground.collectAsState()
                             SwitchPreference(
                                 value = hidePlayerButtonsBackground,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/theme/Theme.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/theme/Theme.kt
@@ -333,6 +333,7 @@ fun MpvexTheme(content: @Composable () -> Unit) {
   val darkMode by preferences.darkMode.collectAsState()
   val amoledMode by preferences.amoledMode.collectAsState()
   val appTheme by preferences.appTheme.collectAsState()
+  val useSystemFont by preferences.useSystemFont.collectAsState()
   val darkTheme = isSystemInDarkTheme()
   val context = LocalContext.current
 
@@ -375,7 +376,7 @@ fun MpvexTheme(content: @Composable () -> Unit) {
         ThemeTransitionContent {
             MaterialTheme(
                 colorScheme = colorScheme,
-                typography = AppTypography,
+                typography = getTypography(useSystemFont),
                 content = content,
                 motionScheme = MotionScheme.expressive(),
             )
@@ -391,6 +392,7 @@ fun MpvexPlayerTheme(content: @Composable () -> Unit) {
     val darkMode by preferences.darkMode.collectAsState()
     val amoledMode by preferences.amoledMode.collectAsState()
     val appTheme by preferences.appTheme.collectAsState()
+    val useSystemFont by preferences.useSystemFont.collectAsState()
     val darkTheme = isSystemInDarkTheme()
     val context = LocalContext.current
 
@@ -437,7 +439,7 @@ fun MpvexPlayerTheme(content: @Composable () -> Unit) {
         ThemeTransitionContent {
             MaterialTheme(
                 colorScheme = colorScheme,
-                typography = AppTypography,
+                typography = getTypography(useSystemFont),
                 content = content,
                 motionScheme = MotionScheme.expressive(),
             )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/theme/Type.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/theme/Type.kt
@@ -76,3 +76,7 @@ val AppTypography = Typography().run {
     labelSmall = labelSmall.copy(fontFamily = GoogleSansFlex),
   )
 }
+
+fun getTypography(useSystemFont: Boolean): Typography {
+    return if (useSystemFont) Typography() else AppTypography
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="pref_appearance_unlimited_name_lines_summary">Show full folder and video names without truncation</string>
     <string name="pref_appearance_hide_player_buttons_background_title">Hide player buttons background</string>
     <string name="pref_appearance_hide_player_buttons_background_summary">Hide the background of all player control buttons</string>
+    <string name="pref_appearance_use_system_font_title">Use system font</string>
+    <string name="pref_appearance_use_system_font_summary">Use your device\'s default font instead of the app font</string>  
     <string name="pref_appearance_category_file_browser">File Browser</string>
     <string name="pref_appearance_show_hidden_files_title">Show Hidden Files</string>
     <string name="pref_appearance_show_hidden_files_summary">Show hidden folders starting with a dot (.) including android, data, system folders and .nomedia files</string>


### PR DESCRIPTION
Adds a toggle in Appearance settings that lets users switch between the apps custom Google Sans Flex font and their device's default system font.


###  Behavior
- **Default:** app font (Google Sans Flex) is used as before, no behavior change for existing users
- **Toggled on:** device's default system font is applied app-wide instantly without restart


- [x] Tested manually