### PR TITLE
feat(player): persist aspect ratio settings across sessions

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -74,6 +74,15 @@ class PlayerPreferences(
 
   val keepScreenOnWhenPaused = preferenceStore.getBoolean("keep_screen_on_when_paused", false)
 
+  // Persist aspect ratio setting (default to Fit)
+  val defaultVideoAspect = preferenceStore.getEnum("default_video_aspect", VideoAspect.Fit)
+  val defaultCustomAspectRatio = preferenceStore.getObject(
+    key = "default_custom_aspect_ratio",
+    defaultValue = -1.0,
+    serializer = { it.toString() },
+    deserializer = { it.toDoubleOrNull() ?: -1.0 }
+  )
+
   // Custom Buttons - JSON List
   val customButtons = preferenceStore.getString("custom_buttons_json", "[]")
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -1896,6 +1896,8 @@ class PlayerActivity :
       setIntentExtras(intent.extras)
       pendingIntentExtras = false
     }
+    // Reset aspect ration to preferred and pan to neutral
+    viewModel.resetVisualPreferences()
 
     lifecycleScope.launch(Dispatchers.IO) {
       // Load playback state (will skip track restoration if preferred language configured)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -197,6 +197,8 @@ class PlayerActivity :
   private var wasPlayingBeforePause = false // Track if video was playing before pause
   private var pendingIntentExtras = false // Track if intent extras should be applied to next loaded file
 
+  @Volatile private var needsAspectReapply = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
+
   // ==================== Background Playback ====================
 
   /**
@@ -1858,6 +1860,12 @@ class PlayerActivity :
         if (!isReady) {
           isReady = true
         }
+        if (needsAspectReapply) {
+          needsAspectReapply = false
+          runOnUiThread {
+            viewModel.resetVisualPreferences()
+          }
+        }
       }
     }
   }
@@ -1898,6 +1906,7 @@ class PlayerActivity :
     }
     // Reset aspect ration to preferred and pan to neutral
     viewModel.resetVisualPreferences()
+    needsAspectReapply = true
 
     lifecycleScope.launch(Dispatchers.IO) {
       // Load playback state (will skip track restoration if preferred language configured)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -1912,6 +1912,20 @@ class PlayerActivity :
           viewModel.setVideoZoom(zoomPreference)
         }
       }
+      
+      // Apply saved aspect ratio setting
+      withContext(Dispatchers.Main) {
+        val savedAspect = playerPreferences.defaultVideoAspect.get()
+        val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
+        
+        if (savedCustomRatio > 0) {
+          // Apply custom aspect ratio
+          viewModel.setCustomAspectRatio(savedCustomRatio)
+        } else {
+          // Apply standard aspect mode (Fit, Crop, or Stretch)
+          viewModel.changeVideoAspect(savedAspect, showUpdate = false)
+        }
+      }
     }
 
     // Save to recently played when video actually loads and plays

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -1913,19 +1913,6 @@ class PlayerActivity :
         }
       }
       
-      // Apply saved aspect ratio setting
-      withContext(Dispatchers.Main) {
-        val savedAspect = playerPreferences.defaultVideoAspect.get()
-        val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
-        
-        if (savedCustomRatio > 0) {
-          // Apply custom aspect ratio
-          viewModel.setCustomAspectRatio(savedCustomRatio)
-        } else {
-          // Apply standard aspect mode (Fit, Crop, or Stretch)
-          viewModel.changeVideoAspect(savedAspect, showUpdate = false)
-        }
-      }
     }
 
     // Save to recently played when video actually loads and plays

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -540,37 +540,6 @@ class PlayerViewModel(
       _subtitleManager.clearExternalSubtitles()
       // Scan for previously downloaded/added subtitles
       scanLocalSubtitles(mediaTitle)
-
-      // --- ADDED: Reset visual states for the new file for Ambient Mode Function by @Chinna95P ---
-
-      // 1. Reset Aspect Ratio to saved preference
-      val savedAspect = playerPreferences.defaultVideoAspect.get()
-      val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
-
-      if (savedCustomRatio > 0) {
-        // Restore user preferred custom aspect ratio
-        setCustomAspectRatio(savedCustomRatio)
-      } else {
-        // Restore standard aspect ratio mode (Fit, Crop, or Stretch)
-        changeVideoAspect(savedAspect, showUpdate = false)
-      }
-
-      // 2. Reset Video Zoom
-      if (_videoZoom.value != 0f) {
-          _videoZoom.value = 0f
-          runCatching { MPVLib.setPropertyDouble("video-zoom", 0.0) }
-      }
-
-      // 3. Reset Video Pan
-      if (_videoPanX.value != 0f || _videoPanY.value != 0f) {
-          _videoPanX.value = 0f
-          _videoPanY.value = 0f
-          runCatching {
-              MPVLib.setPropertyDouble("video-pan-x", 0.0)
-              MPVLib.setPropertyDouble("video-pan-y", 0.0)
-          }
-      }
-      // ---------------------------------------------------
     }
   }
 
@@ -903,6 +872,30 @@ class PlayerViewModel(
   }
 
   // ==================== Video Aspect ====================
+
+
+  // Restores the user's preferred video aspect ratio and resets pan to center
+  fun resetVisualPreferences() {
+    
+    // 1. Apply saved aspect ratio preference
+    val savedAspect = playerPreferences.defaultVideoAspect.get()
+    val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
+
+    if (savedCustomRatio > 0) {
+      setCustomAspectRatio(savedCustomRatio)
+    } else {
+      changeVideoAspect(savedAspect, showUpdate = false)
+    }
+    // 2. Reset pan to neutral for the new file
+    if (_videoPanX.value != 0f || _videoPanY.value != 0f) {
+      _videoPanX.value = 0f
+      _videoPanY.value = 0f
+      runCatching {
+        MPVLib.setPropertyDouble("video-pan-x", 0.0)
+        MPVLib.setPropertyDouble("video-pan-y", 0.0)
+      }
+    }
+  }
 
   fun changeVideoAspect(
     aspect: VideoAspect,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -190,9 +190,9 @@ class PlayerViewModel(
     // Poll precise position only when playing
     viewModelScope.launch {
       while (isActive) {
-        val time = MPVLib.getPropertyDouble("time-pos")
-        if (time != null) {
-          _precisePosition.value = time.toFloat()
+          val time = MPVLib.getPropertyDouble("time-pos")
+          if (time != null) {
+            _precisePosition.value = time.toFloat()
         }
         delay(16) // ~60fps updates
       }
@@ -289,12 +289,12 @@ class PlayerViewModel(
   private val _videoZoom = MutableStateFlow(0f)
   val videoZoom: StateFlow<Float> = _videoZoom.asStateFlow()
 
-  // Video aspect ratio (not persisted, resets to Fit for each video)
-  private val _videoAspect = MutableStateFlow(VideoAspect.Fit)
+ // Video aspect ratio (now persisted via preferences)
+  private val _videoAspect = MutableStateFlow(playerPreferences.defaultVideoAspect.get())
   val videoAspect: StateFlow<VideoAspect> = _videoAspect.asStateFlow()
 
   // Current aspect ratio value (for custom ratios and tracking)
-  private val _currentAspectRatio = MutableStateFlow(-1.0)
+  private val _currentAspectRatio = MutableStateFlow(playerPreferences.defaultCustomAspectRatio.get())
   val currentAspectRatio: StateFlow<Double> = _currentAspectRatio.asStateFlow()
 
   // Timer
@@ -543,12 +543,48 @@ class PlayerViewModel(
 
       // --- ADDED: Reset visual states for the new file for Ambient Mode Function by @Chinna95P ---
       
-      // 1. Reset Aspect Ratio UI state and MPV properties to "Fit"
-      _videoAspect.value = VideoAspect.Fit
-      _currentAspectRatio.value = -1.0
-      runCatching {
-        MPVLib.setPropertyDouble("panscan", 0.0)
-        MPVLib.setPropertyDouble("video-aspect-override", -1.0)
+      // 1. Reset Aspect Ratio to saved preference
+      val savedAspect = playerPreferences.defaultVideoAspect.get()
+      val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
+      
+      if (savedCustomRatio > 0) {
+        // Apply saved custom aspect ratio
+        _currentAspectRatio.value = savedCustomRatio
+        runCatching {
+          MPVLib.setPropertyDouble("panscan", 0.0)
+          MPVLib.setPropertyDouble("video-aspect-override", savedCustomRatio)
+        }
+      } else {
+        // Apply saved standard aspect mode (Fit, Crop, or Stretch)
+        _videoAspect.value = savedAspect
+        _currentAspectRatio.value = -1.0
+        runCatching {
+          when (savedAspect) {
+            VideoAspect.Fit -> {
+              MPVLib.setPropertyDouble("panscan", 0.0)
+              MPVLib.setPropertyDouble("video-aspect-override", -1.0)
+            }
+            VideoAspect.Crop -> {
+              MPVLib.setPropertyDouble("video-aspect-override", -1.0)
+              MPVLib.setPropertyDouble("panscan", 1.0)
+            }
+            VideoAspect.Stretch -> {
+              @Suppress("DEPRECATION")
+              val dm = DisplayMetrics()
+              @Suppress("DEPRECATION")
+              host.hostWindowManager.defaultDisplay.getRealMetrics(dm)
+              val rotate = MPVLib.getPropertyInt("video-params/rotate") ?: 0
+              val isVideoRotated = (rotate % 180 == 90)
+              val screenRatio = if (isVideoRotated) {
+                dm.heightPixels.toDouble() / dm.widthPixels.toDouble()
+              } else {
+                dm.widthPixels.toDouble() / dm.heightPixels.toDouble()
+              }
+              MPVLib.setPropertyDouble("video-aspect-override", screenRatio)
+              MPVLib.setPropertyDouble("panscan", 0.0)
+            }
+          }
+        }
       }
 
       // 2. Reset Video Zoom
@@ -942,9 +978,11 @@ class PlayerViewModel(
       }
     }
 
-    // Update the state
+    // Update the state and persist to preferences
     _videoAspect.value = aspect
     _currentAspectRatio.value = -1.0 // Reset custom ratio when using standard modes
+    playerPreferences.defaultVideoAspect.set(aspect)
+    playerPreferences.defaultCustomAspectRatio.set(-1.0)
 
     // Notify the UI
     if (showUpdate) {
@@ -956,6 +994,7 @@ class PlayerViewModel(
     MPVLib.setPropertyDouble("panscan", 0.0)
     MPVLib.setPropertyDouble("video-aspect-override", ratio)
     _currentAspectRatio.value = ratio
+    playerPreferences.defaultCustomAspectRatio.set(ratio)
     playerUpdate.value = PlayerUpdates.AspectRatio
   }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -190,9 +190,9 @@ class PlayerViewModel(
     // Poll precise position only when playing
     viewModelScope.launch {
       while (isActive) {
-          val time = MPVLib.getPropertyDouble("time-pos")
-          if (time != null) {
-            _precisePosition.value = time.toFloat()
+        val time = MPVLib.getPropertyDouble("time-pos")
+        if (time != null) {
+          _precisePosition.value = time.toFloat()
         }
         delay(16) // ~60fps updates
       }
@@ -203,16 +203,16 @@ class PlayerViewModel(
       MPVLib.propInt["duration"].collect { _ ->
         val dur = MPVLib.getPropertyDouble("duration")
         if (dur != null && dur > 0) {
-            _preciseDuration.value = dur.toFloat()
-            
-            // --- AMBIENT FIX: Adapt shader to new file dimensions ---
-            ambientModeManager.resetAmbientMode()
-            viewModelScope.launch {
-                // Slight delay ensures MPV's video-params (w/h/crop) are fully populated
-                delay(250) 
-                ambientModeManager.updateAmbientStretch()
-            }
-            // --------------------------------------------------------
+          _preciseDuration.value = dur.toFloat()
+
+          // --- AMBIENT FIX: Adapt shader to new file dimensions ---
+          ambientModeManager.resetAmbientMode()
+          viewModelScope.launch {
+            // Slight delay ensures MPV's video-params (w/h/crop) are fully populated
+            delay(250)
+            ambientModeManager.updateAmbientStretch()
+          }
+          // --------------------------------------------------------
         }
       }
     }
@@ -542,49 +542,17 @@ class PlayerViewModel(
       scanLocalSubtitles(mediaTitle)
 
       // --- ADDED: Reset visual states for the new file for Ambient Mode Function by @Chinna95P ---
-      
+
       // 1. Reset Aspect Ratio to saved preference
       val savedAspect = playerPreferences.defaultVideoAspect.get()
       val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
-      
+
       if (savedCustomRatio > 0) {
-        // Apply saved custom aspect ratio
-        _currentAspectRatio.value = savedCustomRatio
-        runCatching {
-          MPVLib.setPropertyDouble("panscan", 0.0)
-          MPVLib.setPropertyDouble("video-aspect-override", savedCustomRatio)
-        }
+        // Restore user preferred custom aspect ratio
+        setCustomAspectRatio(savedCustomRatio)
       } else {
-        // Apply saved standard aspect mode (Fit, Crop, or Stretch)
-        _videoAspect.value = savedAspect
-        _currentAspectRatio.value = -1.0
-        runCatching {
-          when (savedAspect) {
-            VideoAspect.Fit -> {
-              MPVLib.setPropertyDouble("panscan", 0.0)
-              MPVLib.setPropertyDouble("video-aspect-override", -1.0)
-            }
-            VideoAspect.Crop -> {
-              MPVLib.setPropertyDouble("video-aspect-override", -1.0)
-              MPVLib.setPropertyDouble("panscan", 1.0)
-            }
-            VideoAspect.Stretch -> {
-              @Suppress("DEPRECATION")
-              val dm = DisplayMetrics()
-              @Suppress("DEPRECATION")
-              host.hostWindowManager.defaultDisplay.getRealMetrics(dm)
-              val rotate = MPVLib.getPropertyInt("video-params/rotate") ?: 0
-              val isVideoRotated = (rotate % 180 == 90)
-              val screenRatio = if (isVideoRotated) {
-                dm.heightPixels.toDouble() / dm.widthPixels.toDouble()
-              } else {
-                dm.widthPixels.toDouble() / dm.heightPixels.toDouble()
-              }
-              MPVLib.setPropertyDouble("video-aspect-override", screenRatio)
-              MPVLib.setPropertyDouble("panscan", 0.0)
-            }
-          }
-        }
+        // Restore standard aspect ratio mode (Fit, Crop, or Stretch)
+        changeVideoAspect(savedAspect, showUpdate = false)
       }
 
       // 2. Reset Video Zoom

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -873,9 +873,13 @@ class PlayerViewModel(
 
   // ==================== Video Aspect ====================
 
+  private var _cachedVideoRotation = 0
 
   // Restores the user's preferred video aspect ratio and resets pan to center
   fun resetVisualPreferences() {
+
+    // Cache the video rotation once it's available (used by stretch mode)
+    _cachedVideoRotation = MPVLib.getPropertyInt("video-params/rotate") ?: 0
     
     // 1. Apply saved aspect ratio preference
     val savedAspect = playerPreferences.defaultVideoAspect.get()
@@ -919,9 +923,7 @@ class PlayerViewModel(
         @Suppress("DEPRECATION")
         host.hostWindowManager.defaultDisplay.getRealMetrics(dm)
         
-        // Get video rotation from metadata
-        val rotate = MPVLib.getPropertyInt("video-params/rotate") ?: 0
-        val isVideoRotated = (rotate % 180 == 90) // 90° or 270° rotation
+        val isVideoRotated = (_cachedVideoRotation % 180 == 90)
         
         // Calculate screen ratio, inverting if video is rotated
         val screenRatio = if (isVideoRotated) {


### PR DESCRIPTION
this is a exact copy of commit https://github.com/marlboro-advance/mpvEx/commit/9a34121beeb5012d7c10177e99f121ef5b1ae41f


@easoyeb need help with something. is it safe to removing  the reset part for savedaspectratio in `playerViewModel.kt` under `setMediaTitle()` is just re-chekcing the saved `savedAspect`, `savedCustomRatio` from `playeractivity.kt`