### PR TITLE
fix: save and restore external subtitles across sessions

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -2343,8 +2343,9 @@ class PlayerActivity :
       val externalSubUris = state.externalSubtitles.split("|").filter { it.isNotBlank() }
       Log.d(TAG, "Restoring ${externalSubUris.size} external subtitle(s)")
 
+      val lastUri = externalSubUris.last()
       for (subUri in externalSubUris) {
-        viewModel.addSubtitle(Uri.parse(subUri), select = false, silent = true)
+        viewModel.addSubtitle(Uri.parse(subUri), select = subUri == lastUri, silent = true)
       }
     }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -307,11 +307,7 @@ class PlayerViewModel(
   private var lastAutoSelectedMediaTitle: String? = null
 
   // External subtitle tracking
-  private val _externalSubtitles = mutableListOf<String>()
-  val externalSubtitles: List<String> get() = _externalSubtitles.toList()
-  
-  // Mapping from mpv internal path/URI to the original source URI (resolves deletion issues)
-  private val mpvPathToUriMap = mutableMapOf<String, String>()
+  val externalSubtitles: List<String> get() = _subtitleManager.externalSubtitles
 
   // Repeat and Shuffle state
   private val _repeatMode = MutableStateFlow(RepeatMode.OFF)


### PR DESCRIPTION
- Remove dead _externalSubtitles and mpvPathToUriMap from PlayerViewModel
- Delegate viewModel.externalSubtitles to _subtitleManager.externalSubtitles
- On restore, select the last external subtitle

fixes #37