### PR TITLE
feat(ui): add squeeze and bounce animations to seekbar, brightness and volume slider

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/AppearancePreferences.kt
@@ -27,6 +27,7 @@ class AppearancePreferences(
   val useSystemFont = preferenceStore.getBoolean("use_system_font", false)
   val unlimitedNameLines = preferenceStore.getBoolean("unlimited_name_lines", false)
   val hidePlayerButtonsBackground = preferenceStore.getBoolean("hide_player_buttons_background", false)
+  val enableBounceAnimation = preferenceStore.getBoolean("enable_bounce_animation", false)
 
   val showHiddenFiles = preferenceStore.getBoolean("show_hidden_files", false)
   val showUnplayedOldVideoLabel = preferenceStore.getBoolean("show_unplayed_old_video_label", true)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -185,6 +185,17 @@ class PlayerViewModel(
   // Audio state
   val currentVolume = MutableStateFlow(host.audioManager.getStreamVolume(AudioManager.STREAM_MUSIC))
   private val volumeBoostCap by MPVLib.propInt["volume-max"].collectAsState(viewModelScope)
+  
+  // Gesture state for seekbar bouncing animation
+  private val _isGestureSeeking = MutableStateFlow(false)
+  val isGestureSeeking: StateFlow<Boolean> = _isGestureSeeking.asStateFlow()
+
+  fun setGestureSeeking(isSeeking: Boolean) {
+    _isGestureSeeking.value = isSeeking
+  }
+
+  // Gesture state for vertical bouncing animation
+  val isVerticalGestureActive = MutableStateFlow(false)
 
   init {
     // Poll precise position only when playing

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
@@ -485,6 +485,7 @@ fun GestureHandler(
                       "vertical" -> {
                         if ((brightnessGesture || volumeGesture) && !isLongPressing) {
                           isVerticalGestureActive = true
+                          viewModel.isVerticalGestureActive.value = true
                           startingY = 0f
                           mpvVolumeStartingY = 0f
                           originalVolume = currentVolume
@@ -661,6 +662,7 @@ fun GestureHandler(
                   "vertical" -> {
                     if (brightnessGesture || volumeGesture) {
                       isVerticalGestureActive = false
+                      viewModel.isVerticalGestureActive.value = false
                       startingY = 0f
                       lastVolumeValue = currentVolume
                       lastMPVVolumeValue = currentMPVVolume ?: 100
@@ -708,6 +710,7 @@ fun GestureHandler(
             "vertical" -> {
               if (brightnessGesture || volumeGesture) {
                 isVerticalGestureActive = false
+                viewModel.isVerticalGestureActive.value = false
                 startingY = 0f
                 lastVolumeValue = currentVolume
                 lastMPVVolumeValue = currentMPVVolume ?: 100
@@ -933,6 +936,7 @@ fun GestureHandler(
                     } else if (horizontalSwipeToSeek) {
                       gestureType = "horizontal_seek"
                       hasStartedSeeking = true
+                      viewModel.setGestureSeeking(true)
                       initialVideoPosition = position?.toFloat() ?: 0f
                       
                       // Show seekbar if preference enabled
@@ -998,6 +1002,7 @@ fun GestureHandler(
               // Multi-finger detected, cancel horizontal seek
               if (hasStartedSeeking) {
                 hasStartedSeeking = false
+                viewModel.setGestureSeeking(false)
                 // Clean up seeking state without showing controls
                 viewModel.playerUpdate.update { PlayerUpdates.None }
                 viewModel.hideSeekBar()
@@ -1013,6 +1018,7 @@ fun GestureHandler(
               delay(300)
               viewModel.playerUpdate.update { PlayerUpdates.None }
               viewModel.hideSeekBar()
+              viewModel.setGestureSeeking(false)
             }
           }
         }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
@@ -194,12 +194,15 @@ fun PlayerControls(
   val playerTimeToDisappear by playerPreferences.playerTimeToDisappear.collectAsState()
   val chapters by viewModel.chapters.collectAsState(persistentListOf())
   val playlistMode by playerPreferences.playlistMode.collectAsState()
-    val haptic = LocalHapticFeedback.current
+  val haptic = LocalHapticFeedback.current
 
-    val customButtons by viewModel.customButtons.collectAsState()
+  val customButtons by viewModel.customButtons.collectAsState()
     
   val abLoopA by viewModel.abLoopA.collectAsState()
   val abLoopB by viewModel.abLoopB.collectAsState()
+
+  val isGestureSeeking by viewModel.isGestureSeeking.collectAsState()
+  val isVerticalGestureActive by viewModel.isVerticalGestureActive.collectAsState()
 
   val onOpenSheet: (Sheets) -> Unit = {
     viewModel.sheetShown.update { _ -> it }
@@ -386,7 +389,7 @@ fun PlayerControls(
               top.linkTo(parent.top, spacing.larger)
               bottom.linkTo(parent.bottom, spacing.extraLarge)
             },
-        ) { BrightnessSlider(brightness, 0f..1f) }
+        ) { BrightnessSlider(brightness, 0f..1f, isActive = isVerticalGestureActive) }
 
         AnimatedVisibility(
           isVolumeSliderShown,
@@ -427,6 +430,7 @@ fun PlayerControls(
             range = 0..viewModel.maxVolume,
             boostRange = if (showBoost) 0..effBoostCap else null,
             displayAsPercentage = displayVolumeAsPercentage,
+            isActive = isVerticalGestureActive
           )
         }
 
@@ -1170,6 +1174,7 @@ fun PlayerControls(
             seekbarStyle = seekbarStyle,
             loopStart = abLoopA?.toFloat(),
             loopEnd = abLoopB?.toFloat(),
+            isGestureSeeking = isGestureSeeking
           )
         }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.rememberInfiniteTransition

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -103,15 +103,32 @@ fun SeekbarWithTimers(
 
   // Determine if the seekbar should be actively squeezed
   val shouldSqueeze = isUserInteracting || isGestureSeeking
-  // Calculate spring bounce animation for Y-axis (78%)
-  val squeezeScale by animateFloatAsState(
-    targetValue = if (shouldSqueeze) 0.75f else 1f,
-    animationSpec = spring(
-      dampingRatio = Spring.DampingRatioMediumBouncy,
-      stiffness = Spring.StiffnessLow
-    ),
-    label = "seekbar_squeeze"
-  )
+  
+  val squeezeAnim = remember { Animatable(1f) }
+
+  // Trigger animation whenever the interaction state change
+  LaunchedEffect(shouldSqueeze) {
+    if (shouldSqueeze) {
+      squeezeAnim.animateTo(
+        targetValue = 0.75f,
+        animationSpec = spring(
+          dampingRatio = Spring.DampingRatioNoBouncy,
+          stiffness = Spring.StiffnessMedium
+        )
+      )
+    } else {
+      kotlinx.coroutines.delay(150)
+      squeezeAnim.animateTo(
+        targetValue = 1f,
+        animationSpec = spring(
+          dampingRatio = 0.4f,
+          stiffness = Spring.StiffnessLow
+        )
+      )
+    }
+  }
+
+  val squeezeScale = squeezeAnim.value
 
   // Only animate position updates when user is not interacting
   LaunchedEffect(position) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -2,6 +2,10 @@ package app.marlboroadvance.mpvex.ui.player.controls.components
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.animateFloat
@@ -85,6 +89,7 @@ fun SeekbarWithTimers(
   seekbarStyle: SeekbarStyle = SeekbarStyle.Wavy,
   loopStart: Float? = null,
   loopEnd: Float? = null,
+  isGestureSeeking: Boolean = false,
   modifier: Modifier = Modifier,
 ) {
   val clickEvent = LocalPlayerButtonsClickEvent.current
@@ -95,6 +100,19 @@ fun SeekbarWithTimers(
   val animatedPosition = remember { Animatable(position) }
   val scope = rememberCoroutineScope()
   var lastInteractionTime by remember { mutableLongStateOf(0L) }
+
+  // Determine if the seekbar should be actively squeezed
+  val shouldSqueeze = isUserInteracting || isGestureSeeking
+  
+  // Calculate spring bounce animation for Y-axis (78%)
+  val squeezeScale by animateFloatAsState(
+    targetValue = if (shouldSqueeze) 0.78f else 1f,
+    animationSpec = spring(
+      dampingRatio = 0.75f,
+      stiffness = Spring.StiffnessMediumLow
+    ),
+    label = "seekbar_squeeze"
+  )
 
   // Only animate position updates when user is not interacting
   LaunchedEffect(position) {
@@ -139,7 +157,10 @@ fun SeekbarWithTimers(
       modifier =
         Modifier
           .weight(1f)
-          .height(48.dp),
+          .height(48.dp)
+          .graphicsLayer {
+            scaleY = squeezeScale
+          },
       contentAlignment = Alignment.Center,
     ) {
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -103,13 +103,12 @@ fun SeekbarWithTimers(
 
   // Determine if the seekbar should be actively squeezed
   val shouldSqueeze = isUserInteracting || isGestureSeeking
-  
   // Calculate spring bounce animation for Y-axis (78%)
   val squeezeScale by animateFloatAsState(
-    targetValue = if (shouldSqueeze) 0.78f else 1f,
+    targetValue = if (shouldSqueeze) 0.75f else 1f,
     animationSpec = spring(
-      dampingRatio = 0.75f,
-      stiffness = Spring.StiffnessMediumLow
+      dampingRatio = Spring.DampingRatioMediumBouncy,
+      stiffness = Spring.StiffnessLow
     ),
     label = "seekbar_squeeze"
   )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/Seekbar.kt
@@ -69,6 +69,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import app.marlboroadvance.mpvex.preferences.AppearancePreferences
 import org.koin.compose.koinInject
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
@@ -100,13 +101,21 @@ fun SeekbarWithTimers(
   val scope = rememberCoroutineScope()
   var lastInteractionTime by remember { mutableLongStateOf(0L) }
 
+  // Read Toggle for Bounce Animation from Preferences
+  val appearancePrefs = koinInject<AppearancePreferences>()
+  val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
+
   // Determine if the seekbar should be actively squeezed
   val shouldSqueeze = isUserInteracting || isGestureSeeking
   
   val squeezeAnim = remember { Animatable(1f) }
 
   // Trigger animation whenever the interaction state change
-  LaunchedEffect(shouldSqueeze) {
+  LaunchedEffect(shouldSqueeze, enableBounceAnimation) {
+    if (!enableBounceAnimation) {
+      squeezeAnim.snapTo(1f)
+      return@LaunchedEffect
+    }
     if (shouldSqueeze) {
       squeezeAnim.animateTo(
         targetValue = 0.75f,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
@@ -22,6 +22,9 @@ import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.BrightnessHigh
 import androidx.compose.material.icons.filled.BrightnessLow
 import androidx.compose.material.icons.filled.BrightnessMedium
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -55,13 +58,33 @@ fun VerticalSlider(
   modifier: Modifier = Modifier,
   overflowValue: Float? = null,
   overflowRange: ClosedFloatingPointRange<Float>? = null,
+  isActive: Boolean = false
 ) {
   val coercedValue = value.coerceIn(range)
+
+  // Calculate dynamic track width
+  val trackWidth by animateDpAsState(
+    targetValue = if (isActive) 32.dp else 22.dp,
+    animationSpec = tween(
+      durationMillis = 250,
+      easing = FastOutSlowInEasing
+    ),
+    label = "track_width"
+  )
+
+  // Outer fixed-width container prevents layout shifts
   Box(
     modifier =
       modifier
-        .height(120.dp)
-        .aspectRatio(0.2f)
+      .height(120.dp)
+      .width(32.dp),
+    contentAlignment = Alignment.BottomCenter
+  ) {
+    // Inner track that actually animates
+    Box(
+      modifier = Modifier
+        .fillMaxHeight()
+        .width(trackWidth)
         .clip(RoundedCornerShape(16.dp))
         .background(MaterialTheme.colorScheme.background)
         .border(
@@ -69,26 +92,27 @@ fun VerticalSlider(
           color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
           shape = RoundedCornerShape(16.dp),
         ),
-    contentAlignment = Alignment.BottomCenter,
-  ) {
-    val targetHeight by animateFloatAsState(percentage(coercedValue, range), label = "vsliderheight")
-    Box(
-      Modifier
-        .fillMaxWidth()
-        .fillMaxHeight(targetHeight)
-        .background(MaterialTheme.colorScheme.tertiary),
-    )
-    if (overflowRange != null && overflowValue != null) {
-      val overflowHeight by animateFloatAsState(
-        percentage(overflowValue, overflowRange),
-        label = "vslideroverflowheight",
-      )
+      contentAlignment = Alignment.BottomCenter,
+    ) {
+      val targetHeight by animateFloatAsState(percentage(coercedValue, range), label = "vsliderheight")
       Box(
         Modifier
           .fillMaxWidth()
-          .fillMaxHeight(overflowHeight)
-          .background(MaterialTheme.colorScheme.errorContainer),
+          .fillMaxHeight(targetHeight)
+          .background(MaterialTheme.colorScheme.tertiary),
       )
+      if (overflowRange != null && overflowValue != null) {
+        val overflowHeight by animateFloatAsState(
+          percentage(overflowValue, overflowRange),
+          label = "vslideroverflowheight",
+        )
+        Box(
+          Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(overflowHeight)
+            .background(MaterialTheme.colorScheme.errorContainer),
+        )
+      }
     }
   }
 }
@@ -100,13 +124,32 @@ fun VerticalSlider(
   modifier: Modifier = Modifier,
   overflowValue: Int? = null,
   overflowRange: ClosedRange<Int>? = null,
+  isActive: Boolean = false
 ) {
   val coercedValue = value.coerceIn(range)
+
+  // Calculate dynamic track width
+  val trackWidth by animateDpAsState(
+    targetValue = if (isActive) 32.dp else 22.dp,
+    animationSpec = tween(
+      durationMillis = 250,
+      easing = FastOutSlowInEasing
+    ),
+    label = "track_width"
+  )
+
+  // Outer fixed-width container
   Box(
-    modifier =
-      modifier
-        .height(120.dp)
-        .aspectRatio(0.2f)
+    modifier = modifier
+      .height(120.dp)
+      .width(32.dp),
+    contentAlignment = Alignment.BottomCenter
+  ) {
+    // Inner track that actually animates
+    Box(
+      modifier = Modifier
+        .fillMaxHeight()
+        .width(trackWidth)
         .clip(RoundedCornerShape(16.dp))
         .background(MaterialTheme.colorScheme.background)
         .border(
@@ -114,26 +157,27 @@ fun VerticalSlider(
           color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
           shape = RoundedCornerShape(16.dp),
         ),
-    contentAlignment = Alignment.BottomCenter,
-  ) {
-    val targetHeight by animateFloatAsState(percentage(coercedValue, range), label = "vsliderheight")
-    Box(
-      Modifier
-        .fillMaxWidth()
-        .fillMaxHeight(targetHeight)
-        .background(MaterialTheme.colorScheme.tertiary),
-    )
-    if (overflowRange != null && overflowValue != null) {
-      val overflowHeight by animateFloatAsState(
-        percentage(overflowValue, overflowRange),
-        label = "vslideroverflowheight",
-      )
+      contentAlignment = Alignment.BottomCenter,
+    ) {
+      val targetHeight by animateFloatAsState(percentage(coercedValue, range), label = "vsliderheight")
       Box(
         Modifier
           .fillMaxWidth()
-          .fillMaxHeight(overflowHeight)
-          .background(MaterialTheme.colorScheme.errorContainer),
+          .fillMaxHeight(targetHeight)
+          .background(MaterialTheme.colorScheme.tertiary),
       )
+      if (overflowRange != null && overflowValue != null) {
+        val overflowHeight by animateFloatAsState(
+          percentage(overflowValue, overflowRange),
+          label = "vslideroverflowheight",
+        )
+        Box(
+          Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(overflowHeight)
+            .background(MaterialTheme.colorScheme.errorContainer),
+        )
+      }
     }
   }
 }
@@ -143,6 +187,7 @@ fun BrightnessSlider(
   brightness: Float,
   range: ClosedFloatingPointRange<Float>,
   modifier: Modifier = Modifier,
+  isActive: Boolean = false
 ) {
   val coercedBrightness = brightness.coerceIn(range)
   Surface(
@@ -166,6 +211,7 @@ fun BrightnessSlider(
       VerticalSlider(
         coercedBrightness,
         range,
+        isActive = isActive
       )
       Icon(
         when (percentage(coercedBrightness, range)) {
@@ -188,6 +234,7 @@ fun VolumeSlider(
   boostRange: ClosedRange<Int>?,
   modifier: Modifier = Modifier,
   displayAsPercentage: Boolean = false,
+  isActive: Boolean = false
 ) {
   val percentage = (percentage(volume, range) * 100).roundToInt()
   Surface(
@@ -215,6 +262,7 @@ fun VolumeSlider(
         if (displayAsPercentage) 0..100 else range,
         overflowValue = boostVolume,
         overflowRange = boostRange,
+        isActive = isActive
       )
       Icon(
         when (percentage) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
@@ -28,6 +28,9 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.animation.core.FastOutSlowInEasing
+import org.koin.compose.koinInject
+import app.marlboroadvance.mpvex.preferences.AppearancePreferences
+import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -65,12 +68,19 @@ fun VerticalSlider(
 ) {
   val coercedValue = value.coerceIn(range)
 
+  // Read Toggle for Bounce Animation from Preferences
+  val appearancePrefs = koinInject<AppearancePreferences>()
+  val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
+
   val trackWidthAnim = remember { Animatable(22f) }
 
   // Listen for changes to the interaction state (touching vs. released)
-  LaunchedEffect(isActive) {
+  LaunchedEffect(isActive, enableBounceAnimation) {
+    if (!enableBounceAnimation) {
+      trackWidthAnim.snapTo(22f)
+      return@LaunchedEffect
+    }
     if (isActive) {
-      // Instant, tight reaction on touch
       trackWidthAnim.animateTo(
         targetValue = 32f,
         animationSpec = spring(
@@ -148,11 +158,19 @@ fun VerticalSlider(
 ) {
   val coercedValue = value.coerceIn(range)
 
-  val trackWidthAnim = remember { androidx.compose.animation.core.Animatable(22f) }
+  // Read Toggle for Bounce Animation from Preferences
+  val appearancePrefs = koinInject<AppearancePreferences>()
+  val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
 
-  LaunchedEffect(isActive) {
+  val trackWidthAnim = remember { Animatable(22f) }
+
+  // Listen for changes to the interaction state (touching vs. released)
+  LaunchedEffect(isActive, enableBounceAnimation) {
+    if (!enableBounceAnimation) {
+      trackWidthAnim.snapTo(22f)
+      return@LaunchedEffect
+    }
     if (isActive) {
-      // Instant, tight reaction on touch
       trackWidthAnim.animateTo(
         targetValue = 32f,
         animationSpec = spring(
@@ -161,7 +179,6 @@ fun VerticalSlider(
         )
       )
     } else {
-      // Linger and bounce heavily on release
       kotlinx.coroutines.delay(150)
       trackWidthAnim.animateTo(
         targetValue = 22f,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
@@ -22,7 +22,7 @@ import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.BrightnessHigh
 import androidx.compose.material.icons.filled.BrightnessLow
 import androidx.compose.material.icons.filled.BrightnessMedium
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
 import androidx.compose.runtime.LaunchedEffect
@@ -65,7 +65,7 @@ fun VerticalSlider(
 ) {
   val coercedValue = value.coerceIn(range)
 
-  val trackWidthAnim = remember { androidx.compose.animation.core.Animatable(22f) }
+  val trackWidthAnim = remember { Animatable(22f) }
 
   // Listen for changes to the interaction state (touching vs. released)
   LaunchedEffect(isActive) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
@@ -23,7 +23,8 @@ import androidx.compose.material.icons.filled.BrightnessHigh
 import androidx.compose.material.icons.filled.BrightnessLow
 import androidx.compose.material.icons.filled.BrightnessMedium
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -65,9 +66,9 @@ fun VerticalSlider(
   // Calculate dynamic track width
   val trackWidth by animateDpAsState(
     targetValue = if (isActive) 32.dp else 22.dp,
-    animationSpec = tween(
-      durationMillis = 250,
-      easing = FastOutSlowInEasing
+    animationSpec = spring(
+      dampingRatio = Spring.DampingRatioMediumBouncy,
+      stiffness = Spring.StiffnessLow
     ),
     label = "track_width"
   )
@@ -131,9 +132,9 @@ fun VerticalSlider(
   // Calculate dynamic track width
   val trackWidth by animateDpAsState(
     targetValue = if (isActive) 32.dp else 22.dp,
-    animationSpec = tween(
-      durationMillis = 250,
-      easing = FastOutSlowInEasing
+    animationSpec = spring(
+      dampingRatio = Spring.DampingRatioMediumBouncy,
+      stiffness = Spring.StiffnessLow
     ),
     label = "track_width"
   )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/VerticalSliders.kt
@@ -25,6 +25,8 @@ import androidx.compose.material.icons.filled.BrightnessMedium
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -63,15 +65,32 @@ fun VerticalSlider(
 ) {
   val coercedValue = value.coerceIn(range)
 
-  // Calculate dynamic track width
-  val trackWidth by animateDpAsState(
-    targetValue = if (isActive) 32.dp else 22.dp,
-    animationSpec = spring(
-      dampingRatio = Spring.DampingRatioMediumBouncy,
-      stiffness = Spring.StiffnessLow
-    ),
-    label = "track_width"
-  )
+  val trackWidthAnim = remember { androidx.compose.animation.core.Animatable(22f) }
+
+  // Listen for changes to the interaction state (touching vs. released)
+  LaunchedEffect(isActive) {
+    if (isActive) {
+      // Instant, tight reaction on touch
+      trackWidthAnim.animateTo(
+        targetValue = 32f,
+        animationSpec = spring(
+          dampingRatio = Spring.DampingRatioNoBouncy,
+          stiffness = Spring.StiffnessMedium
+        )
+      )
+    } else {
+      kotlinx.coroutines.delay(150)
+      trackWidthAnim.animateTo(
+        targetValue = 22f,
+        animationSpec = spring(
+          dampingRatio = 0.4f,
+          stiffness = Spring.StiffnessLow
+        )
+      )
+    }
+  }
+
+  val trackWidth = trackWidthAnim.value.dp
 
   // Outer fixed-width container prevents layout shifts
   Box(
@@ -129,15 +148,32 @@ fun VerticalSlider(
 ) {
   val coercedValue = value.coerceIn(range)
 
-  // Calculate dynamic track width
-  val trackWidth by animateDpAsState(
-    targetValue = if (isActive) 32.dp else 22.dp,
-    animationSpec = spring(
-      dampingRatio = Spring.DampingRatioMediumBouncy,
-      stiffness = Spring.StiffnessLow
-    ),
-    label = "track_width"
-  )
+  val trackWidthAnim = remember { androidx.compose.animation.core.Animatable(22f) }
+
+  LaunchedEffect(isActive) {
+    if (isActive) {
+      // Instant, tight reaction on touch
+      trackWidthAnim.animateTo(
+        targetValue = 32f,
+        animationSpec = spring(
+          dampingRatio = Spring.DampingRatioNoBouncy,
+          stiffness = Spring.StiffnessMedium
+        )
+      )
+    } else {
+      // Linger and bounce heavily on release
+      kotlinx.coroutines.delay(150)
+      trackWidthAnim.animateTo(
+        targetValue = 22f,
+        animationSpec = spring(
+          dampingRatio = 0.4f,
+          stiffness = Spring.StiffnessLow
+        )
+      )
+    }
+  }
+
+  val trackWidth = trackWidthAnim.value.dp
 
   // Outer fixed-width container
   Box(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
@@ -556,6 +556,7 @@ fun InteractionTab() {
   val playerPreferences = koinInject<PlayerPreferences>()
 
   val hideBackground by appearancePreferences.hidePlayerButtonsBackground.collectAsState()
+  val enableBounceAnimation by appearancePreferences.enableBounceAnimation.collectAsState()
   val preventSeekbarTap by gesturePreferences.preventSeekbarTap.collectAsState()
   val useSingleTapForCenter by gesturePreferences.useSingleTapForCenter.collectAsState()
   val useSingleTapForLeftRight by gesturePreferences.useSingleTapForLeftRight.collectAsState()
@@ -605,6 +606,13 @@ fun InteractionTab() {
       description = "Use single tap for gesture action",
       checked = useSingleTapForLeftRight,
       onCheckedChange = { gesturePreferences.useSingleTapForLeftRight.set(it) }
+    )
+
+    InteractionSwitch(
+      label = "Bounce animation",
+      description = "Seekbar and volume/brightness sliders animate with a bounce effect",
+      checked = enableBounceAnimation,
+      onCheckedChange = { appearancePreferences.enableBounceAnimation.set(it) }
     )
 
     InteractionSwitch(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
@@ -294,6 +294,7 @@ object PlayerControlsPreferencesScreen : Screen {
           }
           
           item {
+            val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
             val hidePlayerButtonsBackground by appearancePrefs.hidePlayerButtonsBackground.collectAsState()
             val playerAlwaysDarkMode by appearancePrefs.playerAlwaysDarkMode.collectAsState()
             val playerTimeToDisappear by playerPrefs.playerTimeToDisappear.collectAsState()
@@ -304,6 +305,23 @@ object PlayerControlsPreferencesScreen : Screen {
             var customTimeValue by remember { mutableStateOf("") }
             
             PreferenceCard {
+              SwitchPreference(
+                value = enableBounceAnimation,
+                onValueChange = { appearancePrefs.enableBounceAnimation.set(it) },
+                title = {
+                  Text(
+                    text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_title)
+                  ) 
+                },
+                summary = { 
+                  Text(
+                    text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_summary)
+                  ) 
+                },
+              )
+              
+              PreferenceDivider()
+
               SwitchPreference(
                 value = hidePlayerButtonsBackground,
                 onValueChange = { appearancePrefs.hidePlayerButtonsBackground.set(it) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="pref_appearance_material_you_summary_disabled">Only available on Android 12 and above</string>
     <string name="pref_appearance_unlimited_name_lines_title">Show full names</string>
     <string name="pref_appearance_unlimited_name_lines_summary">Show full folder and video names without truncation</string>
+    <string name="pref_appearance_enable_bounce_animation_title">Enable bouncy animations</string>
+    <string name="pref_appearance_enable_bounce_animation_summary">Seekbar and volume/brightness sliders animate with a bounce effect</string>
     <string name="pref_appearance_hide_player_buttons_background_title">Hide player buttons background</string>
     <string name="pref_appearance_hide_player_buttons_background_summary">Hide the background of all player control buttons</string>
     <string name="pref_appearance_use_system_font_title">Use system font</string>


### PR DESCRIPTION
**Why this PR**
The currect player controls lack visual feedback during touch interactions and gesture scrubbing. This PR introduces responsive, squeeze and bounce animations to the seekbar, brightness and volume sliders to make the UI more dynamic and responsize to user input