### PR TITLE
refactor(player): extract AB loop controls to floating overlay

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControls.kt
@@ -23,6 +23,9 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.filled.Close
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.foundation.Image
@@ -200,6 +203,7 @@ fun PlayerControls(
     
   val abLoopA by viewModel.abLoopA.collectAsState()
   val abLoopB by viewModel.abLoopB.collectAsState()
+  val isABLoopExpanded by viewModel.isABLoopExpanded.collectAsState()
 
   val isGestureSeeking by viewModel.isGestureSeeking.collectAsState()
   val isVerticalGestureActive by viewModel.isVerticalGestureActive.collectAsState()
@@ -315,6 +319,7 @@ fun PlayerControls(
         val (playerUpdates, playerLockHint) = createRefs()
         val (customLeftButtonsRef, customRightButtonsRef) = createRefs()
         val customButtonsPortraitRef = createRef()
+        val floatingABLoop = createRef()
 
         val bottomControlsBelowSeekbar by playerPreferences.bottomControlsBelowSeekbar.collectAsState()
 
@@ -1436,8 +1441,95 @@ fun PlayerControls(
             LockHint(text = if (update.isLocked) "Speed Locked" else "Swipe up to lock")
           }
         }
+
+        AnimatedVisibility(
+          visible = isABLoopExpanded,
+          enter = fadeIn(tween(200)) + slideInHorizontally(initialOffsetX = { it }),
+          exit = fadeOut(tween(200)) + slideOutHorizontally(targetOffsetX = { it }),
+          modifier = Modifier.constrainAs(floatingABLoop) {
+            end.linkTo(parent.end, spacing.extraLarge)
+            top.linkTo(parent.top)
+            bottom.linkTo(parent.bottom)
+            verticalBias = 0.7f
+          }
+        ) {
+          val buttonSize = 40.dp
+          Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+            modifier = Modifier.height(buttonSize),
+          ) {
+            Row(
+              horizontalArrangement = Arrangement.spacedBy(2.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.padding(horizontal = 4.dp),
+            ) {
+
+              Surface(
+                shape = CircleShape,
+                color = if (abLoopA != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
+                modifier = Modifier
+                  .height(buttonSize - 4.dp)
+                  .widthIn(min = buttonSize - 4.dp)
+                  .clip(CircleShape)
+                  .clickable(onClick = { viewModel.setLoopA() }),
+              ) {
+                Box(contentAlignment = Alignment.Center) {
+                  Text(
+                    text = if (abLoopA != null) viewModel.formatTimestamp(abLoopA!!) else "A",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (abLoopA != null) MaterialTheme.colorScheme.onTertiaryContainer else MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(horizontal = if (abLoopA != null) 8.dp else 0.dp),
+                  )
+                }
+              }
+
+              Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+                modifier = Modifier
+                  .size(buttonSize - 4.dp)
+                  .clip(CircleShape)
+                  .clickable(onClick = {
+                    viewModel.clearABLoop()
+                    viewModel.toggleABLoopExpanded()
+                  }),
+              ) {
+                Box(contentAlignment = Alignment.Center) {
+                  Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Clear Loop",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(16.dp),
+                  )
+                }
+              }
+
+              Surface(
+                shape = CircleShape,
+                color = if (abLoopB != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
+                modifier = Modifier
+                  .height(buttonSize - 4.dp)
+                  .widthIn(min = buttonSize - 4.dp)
+                  .clip(CircleShape)
+                  .clickable(onClick = { viewModel.setLoopB() }),
+              ) {
+                Box(contentAlignment = Alignment.Center) {
+                  Text(
+                    text = if (abLoopB != null) viewModel.formatTimestamp(abLoopB!!) else "B",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (abLoopB != null) MaterialTheme.colorScheme.onTertiaryContainer else MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(horizontal = if (abLoopB != null) 8.dp else 0.dp),
+                  )
+                }
+              }
+            }
+          }
+        }
       }
-    }
+     }
     }
 
     val sheetShown by viewModel.sheetShown.collectAsState()

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/PlayerControlsShared.kt
@@ -1100,7 +1100,7 @@ fun RenderPlayerButton(
       val isExpanded by viewModel.isABLoopExpanded.collectAsState()
       val loopA by viewModel.abLoopA.collectAsState()
       val loopB by viewModel.abLoopB.collectAsState()
-      val isActive = loopA != null || loopB != null
+      val isActive = loopA != null || loopB != null || isExpanded
 
       if (isMoreSheet) {
           Surface(
@@ -1111,7 +1111,10 @@ fun RenderPlayerButton(
             modifier = Modifier
               .height(buttonSize)
               .clip(CircleShape)
-              .clickable { viewModel.toggleABLoopExpanded() }
+              .clickable {
+                viewModel.toggleABLoopExpanded()
+                onOpenSheet(Sheets.None)
+              }
           ) {
             Row(
               verticalAlignment = Alignment.CenterVertically,
@@ -1131,121 +1134,24 @@ fun RenderPlayerButton(
             }
           }
       } else {
-          AnimatedContent(
-            targetState = isExpanded,
-            transitionSpec = {
-              (fadeIn(animationSpec = tween(200)) + expandHorizontally(animationSpec = tween(250)))
-                .togetherWith(fadeOut(animationSpec = tween(200)) + shrinkHorizontally(animationSpec = tween(250)))
-                .using(SizeTransform(clip = false))
-            },
-            label = "ABLoopExpandCollapse",
-          ) { expanded ->
-            if (expanded) {
-              Surface(
-                shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
-                border = if (hideBackground) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
-                modifier = Modifier.height(buttonSize),
-              ) {
-                Row(
-                  horizontalArrangement = Arrangement.spacedBy(2.dp),
-                  verticalAlignment = Alignment.CenterVertically,
-                  modifier = Modifier.padding(horizontal = 4.dp),
-                ) {
-                  // Point A Button - always transparent background
-                  Surface(
-                    shape = CircleShape,
-                    color = if (loopA != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
-                    modifier = Modifier
-                      .height(buttonSize - 4.dp)
-                      .widthIn(min = buttonSize - 4.dp)
-                      .clip(CircleShape)
-                      .clickable(onClick = { viewModel.setLoopA() }),
-                  ) {
-                    Box(contentAlignment = Alignment.Center) {
-                      Text(
-                        text = if (loopA != null) viewModel.formatTimestamp(loopA!!) else "A",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = if (loopA != null) {
-                          MaterialTheme.colorScheme.onTertiaryContainer
-                        } else {
-                          if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface
-                        },
-                        modifier = Modifier.padding(horizontal = if (loopA != null) 8.dp else 0.dp),
-                      )
-                    }
-                  }
-
-                  // Clear/Close Button - always has background
-                  Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
-                    modifier = Modifier
-                      .size(buttonSize - 4.dp)
-                      .clip(CircleShape)
-                      .clickable(onClick = {
-                        viewModel.clearABLoop()
-                        viewModel.toggleABLoopExpanded()
-                      }),
-                  ) {
-                    Box(contentAlignment = Alignment.Center) {
-                      Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Clear Loop",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(16.dp),
-                      )
-                    }
-                  }
-
-                  // Point B Button - always transparent background
-                  Surface(
-                    shape = CircleShape,
-                    color = if (loopB != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
-                    modifier = Modifier
-                      .height(buttonSize - 4.dp)
-                      .widthIn(min = buttonSize - 4.dp)
-                      .clip(CircleShape)
-                      .clickable(onClick = { viewModel.setLoopB() }),
-                  ) {
-                    Box(contentAlignment = Alignment.Center) {
-                      Text(
-                        text = if (loopB != null) viewModel.formatTimestamp(loopB!!) else "B",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = if (loopB != null) {
-                          MaterialTheme.colorScheme.onTertiaryContainer
-                        } else {
-                          if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface
-                        },
-                        modifier = Modifier.padding(horizontal = if (loopB != null) 8.dp else 0.dp),
-                      )
-                    }
-                  }
-                }
-              }
-            } else {
-              // Collapsed: Show "AB" text button
-              Surface(
-                shape = CircleShape,
-                color = if (isActive) activeSurfaceColor else surfaceColor,
-                border = if (isActive) activeBorderColor else borderColor,
-                modifier = Modifier
-                  .size(buttonSize)
-                  .clip(CircleShape)
-                  .clickable(onClick = viewModel::toggleABLoopExpanded),
-              ) {
-                Box(contentAlignment = Alignment.Center) {
-                  Text(
-                    text = "AB",
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                    color = if (isActive) activeContentColor else contentColor,
-                  )
-                }
-              }
-            }
+        Surface(
+          shape = CircleShape,
+          color = if (isActive) activeSurfaceColor else surfaceColor,
+          border = if (isActive) activeBorderColor else borderColor,
+          modifier = Modifier
+            .size(buttonSize)
+            .clip(CircleShape)
+            .clickable(onClick = viewModel::toggleABLoopExpanded),
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Text(
+              text = "AB",
+              style = MaterialTheme.typography.labelLarge,
+              fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+              color = if (isActive) activeContentColor else contentColor,
+            )
           }
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #47 

- Moved expanded AB loop UI into a floating overlay in PlayerControls.
- Simplified AB_LOOP button in PlayerControlsShared to act strictly as a state toggle.
- Removed duplicate inline AnimatedContent logic.

I initially wanted to make the AB loop controls draggable so the user could move them around the screen. However, since this might cause issues in the future, I decided to keep them in a fixed position.



## Player Sheet
Trigger from player sheet toggle
 ![Player Sheet ](https://github.com/user-attachments/assets/62ccffea-597c-4766-8117-739009e2f0cf)


## Main Screen
trigger from main screen control
 ![Main Screen ](https://github.com/user-attachments/assets/569e4a64-44b6-46e3-91a2-9ddb3cfe1748)




