### PR TITLE
Add playlist previous/next actions

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/di/DomainModule.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/di/DomainModule.kt
@@ -2,6 +2,7 @@ package app.marlboroadvance.mpvex.di
 
 import app.marlboroadvance.mpvex.domain.anime4k.Anime4KManager
 import app.marlboroadvance.mpvex.repository.wyzie.WyzieSearchRepository
+import app.marlboroadvance.mpvex.ui.player.PlaybackManager
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import org.koin.android.ext.koin.androidContext
@@ -17,4 +18,5 @@ val domainModule = module {
     }
     single { Anime4KManager(androidContext()) }
     single { WyzieSearchRepository(androidContext(), get(), get(), get()) }
+    single { PlaybackManager(get()) }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/GesturePreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/GesturePreferences.kt
@@ -17,8 +17,8 @@ class GesturePreferences(
   val useRelativeSeeking = preferenceStore.getBoolean("use_relative_seeking", true)
   val useSingleTapForLeftRight = preferenceStore.getBoolean("use_single_tap_for_left_right", false)
   val reverseDoubleTap = preferenceStore.getBoolean("reverse_double_tap", false)
-  val mediaPreviousGesture = preferenceStore.getEnum("meda_previous_gesture", SingleActionGesture.Seek)
+  val mediaPreviousGesture = preferenceStore.getEnum("media_previous_gesture", SingleActionGesture.PlaylistPrev)
   val mediaPlayGesture = preferenceStore.getEnum("media_play_gesture", SingleActionGesture.PlayPause)
-  val mediaNextGesture = preferenceStore.getEnum("media_next_gesture", SingleActionGesture.Seek)
+  val mediaNextGesture = preferenceStore.getEnum("media_next_gesture", SingleActionGesture.PlaylistNext)
   val tapThumbnailToSelect = preferenceStore.getBoolean("tap_thumbnail_to_select", false)
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
@@ -67,12 +67,27 @@ class MediaPlaybackService :
   private val binder = MediaPlaybackBinder()
   private lateinit var mediaSession: MediaSessionCompat
   private val playerPreferences: PlayerPreferences by inject()
+  private val gesturePreferences: GesturePreferences by inject()
 
   private var mediaTitle = ""
   private var mediaArtist = ""
   private var paused = false
   private var lastNotificationUpdateTime = 0L
   private val notificationUpdateIntervalMs = 1000L // Update notification every 1 second
+
+  /**
+   * Listener for playback actions that the service cannot handle alone (like playlist navigation).
+   */
+  interface ServiceListener {
+    fun onNextRequested()
+    fun onPreviousRequested()
+  }
+
+  private var listener: ServiceListener? = null
+
+  fun setListener(listener: ServiceListener?) {
+    this.listener = listener
+  }
 
   inner class MediaPlaybackBinder : Binder() {
     fun getService() = this@MediaPlaybackService
@@ -202,20 +217,42 @@ class MediaPlaybackService :
 
             override fun onSkipToNext() {
               Log.d(TAG, "onSkipToNext called")
-              // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
-              val duration = MPVLib.getPropertyInt("duration") ?: 0
-              val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
-              val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
-              MPVLib.command("seek", "10", seekMode)
+              when (gesturePreferences.mediaNextGesture.get()) {
+                SingleActionGesture.PlaylistNext -> {
+                  listener?.onNextRequested() ?: run {
+                    // Fallback if no listener
+                    MPVLib.command("playlist-next")
+                  }
+                }
+                SingleActionGesture.Seek -> {
+                  // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
+                  val duration = MPVLib.getPropertyInt("duration") ?: 0
+                  val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
+                  val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
+                  MPVLib.command("seek", "10", seekMode)
+                }
+                else -> { /* Handle other gestures if needed */ }
+              }
             }
 
             override fun onSkipToPrevious() {
               Log.d(TAG, "onSkipToPrevious called")
-              // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
-              val duration = MPVLib.getPropertyInt("duration") ?: 0
-              val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
-              val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
-              MPVLib.command("seek", "-10", seekMode)
+              when (gesturePreferences.mediaPreviousGesture.get()) {
+                SingleActionGesture.PlaylistPrev -> {
+                  listener?.onPreviousRequested() ?: run {
+                    // Fallback if no listener
+                    MPVLib.command("playlist-prev")
+                  }
+                }
+                SingleActionGesture.Seek -> {
+                  // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
+                  val duration = MPVLib.getPropertyInt("duration") ?: 0
+                  val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
+                  val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
+                  MPVLib.command("seek", "-10", seekMode)
+                }
+                else -> { /* Handle other gestures if needed */ }
+              }
             }
 
             override fun onSeekTo(pos: Long) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
@@ -27,6 +27,7 @@ import `is`.xyz.mpv.MPVNode
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.ui.player.SingleActionGesture
+import kotlinx.coroutines.cancel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -70,6 +71,9 @@ class MediaPlaybackService :
   private lateinit var mediaSession: MediaSessionCompat
   private val playerPreferences: PlayerPreferences by inject()
   private val gesturePreferences: GesturePreferences by inject()
+  private val playbackManager: PlaybackManager by inject()
+
+  private val serviceScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main)
 
   private var mediaTitle = ""
   private var mediaArtist = ""
@@ -227,11 +231,7 @@ class MediaPlaybackService :
                   }
                 }
                 SingleActionGesture.Seek -> {
-                  // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
-                  val duration = MPVLib.getPropertyInt("duration") ?: 0
-                  val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
-                  val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
-                  MPVLib.command("seek", "10", seekMode)
+                  playbackManager.seekBy(serviceScope, 10)
                 }
                 else -> { /* Handle other gestures if needed */ }
               }
@@ -247,11 +247,7 @@ class MediaPlaybackService :
                   }
                 }
                 SingleActionGesture.Seek -> {
-                  // Use precise seeking for videos shorter than 2 minutes (120 seconds) or if preference is enabled
-                  val duration = MPVLib.getPropertyInt("duration") ?: 0
-                  val shouldUsePreciseSeeking = playerPreferences.usePreciseSeeking.get() || duration < 120
-                  val seekMode = if (shouldUsePreciseSeeking) "relative+exact" else "relative+keyframes"
-                  MPVLib.command("seek", "-10", seekMode)
+                  playbackManager.seekBy(serviceScope, -10)
                 }
                 else -> { /* Handle other gestures if needed */ }
               }
@@ -471,7 +467,10 @@ class MediaPlaybackService :
       Log.d(TAG, "Service destroyed")
 
       isServiceRunning = false
-      
+
+      // Cancel coroutine scope
+      serviceScope.cancel()
+
       // Remove MPV observer safely
       try {
         MPVLib.removeObserver(this)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
@@ -25,6 +25,8 @@ import app.marlboroadvance.mpvex.R
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.MPVNode
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
+import app.marlboroadvance.mpvex.preferences.GesturePreferences
+import app.marlboroadvance.mpvex.ui.player.SingleActionGesture
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlaybackManager.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlaybackManager.kt
@@ -12,8 +12,7 @@ import kotlinx.coroutines.launch
  * Manages playback operations like seeking and speed control.
  */
 class PlaybackManager(
-    private val playerPreferences: PlayerPreferences,
-    private val scope: CoroutineScope
+    private val playerPreferences: PlayerPreferences
 ) {
     companion object {
         private const val TAG = "PlaybackManager"
@@ -23,7 +22,7 @@ class PlaybackManager(
      * Performs an absolute seek to the specified position.
      * Clamps the position between 0 and duration, and optionally within AB loop.
      */
-    fun seekTo(position: Int, abLoopA: Double?, abLoopB: Double?) {
+    fun seekTo(scope: CoroutineScope, position: Int, abLoopA: Double?, abLoopB: Double?) {
         scope.launch(Dispatchers.IO) {
             val maxDuration = MPVLib.getPropertyInt("duration") ?: 0
             if (maxDuration <= 0) return@launch
@@ -47,7 +46,7 @@ class PlaybackManager(
     /**
      * Performs a relative seek immediately.
      */
-    fun seekBy(offset: Int) {
+    fun seekBy(scope: CoroutineScope, offset: Int) {
         if (offset == 0) return
         
         scope.launch(Dispatchers.IO) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -121,6 +121,11 @@ class PlayerActivity :
   private val playerPreferences: PlayerPreferences by inject()
 
   /**
+   * Preferences for gesture settings.
+   */
+  private val gesturePreferences: GesturePreferences by inject()
+
+  /**
    * Preferences for audio settings.
    */
   private val audioPreferences: AudioPreferences by inject()
@@ -2805,6 +2810,26 @@ class PlayerActivity :
                 updateMediaSessionPlaybackState(isPlaying = false)
               }
 
+              override fun onSkipToNext() {
+                when (gesturePreferences.mediaNextGesture.get()) {
+                  SingleActionGesture.PlaylistNext -> playNext()
+                  SingleActionGesture.Seek -> {
+                    viewModel.handleRightDoubleTap()
+                  }
+                  else -> {}
+                }
+              }
+
+              override fun onSkipToPrevious() {
+                when (gesturePreferences.mediaPreviousGesture.get()) {
+                  SingleActionGesture.PlaylistPrev -> playPrevious()
+                  SingleActionGesture.Seek -> {
+                    viewModel.handleLeftDoubleTap()
+                  }
+                  else -> {}
+                }
+              }
+
               override fun onSeekTo(pos: Long) {
                 viewModel.seekTo((pos / 1000).toInt())
                 updateMediaSessionPlaybackState(isPlaying = viewModel.paused == false)
@@ -2820,7 +2845,9 @@ class PlayerActivity :
             PlaybackState.ACTION_PLAY or
               PlaybackState.ACTION_PAUSE or
               PlaybackState.ACTION_PLAY_PAUSE or
-              PlaybackState.ACTION_SEEK_TO,
+              PlaybackState.ACTION_SEEK_TO or
+              PlaybackState.ACTION_SKIP_TO_NEXT or
+              PlaybackState.ACTION_SKIP_TO_PREVIOUS,
           )
       mediaSessionInitialized = true
     }.onFailure { e ->

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -85,7 +85,8 @@ import java.io.File
 @Suppress("TooManyFunctions", "LargeClass")
 class PlayerActivity :
   AppCompatActivity(),
-  PlayerHost {
+  PlayerHost,
+  MediaPlaybackService.ServiceListener {
   // ==================== ViewModels and Bindings ====================
 
   /**
@@ -2924,12 +2925,14 @@ class PlayerActivity :
       ) {
         val binder = service as? MediaPlaybackService.MediaPlaybackBinder ?: return
         mediaPlaybackService = binder.getService()
+        mediaPlaybackService?.setListener(this@PlayerActivity)
         serviceBound = true
         Log.d(TAG, "Service connected")
       }
 
       override fun onServiceDisconnected(name: ComponentName?) {
         Log.d(TAG, "Service disconnected")
+        mediaPlaybackService?.setListener(null)
         mediaPlaybackService = null
         serviceBound = false
       }
@@ -3055,6 +3058,16 @@ class PlayerActivity :
     set(value) {
       requestedOrientation = value
     }
+
+  // ==================== ServiceListener ====================
+
+  override fun onNextRequested() {
+    viewModel.playNext()
+  }
+
+  override fun onPreviousRequested() {
+    viewModel.playPrevious()
+  }
 
   // ==================== Playlist Management ====================
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -42,6 +42,7 @@ import app.marlboroadvance.mpvex.preferences.AdvancedPreferences
 import app.marlboroadvance.mpvex.preferences.AppearancePreferences
 import app.marlboroadvance.mpvex.preferences.AudioPreferences
 import app.marlboroadvance.mpvex.preferences.BrowserPreferences
+import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.SubtitlesPreferences
 import app.marlboroadvance.mpvex.database.repository.VideoMetadataCacheRepository
@@ -52,6 +53,7 @@ import app.marlboroadvance.mpvex.utils.media.HttpUtils
 import app.marlboroadvance.mpvex.utils.media.SubtitleOps
 import app.marlboroadvance.mpvex.utils.storage.FileTypeUtils
 import app.marlboroadvance.mpvex.utils.storage.FileFilterUtils
+import app.marlboroadvance.mpvex.ui.player.SingleActionGesture
 import com.github.k1rakishou.fsaf.FileManager
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.MPVNode

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerEnums.kt
@@ -35,6 +35,8 @@ enum class SingleActionGesture(
   SubSeek(R.string.pref_gesture_double_tap_subseek),
   PlayPause(R.string.pref_gesture_double_tap_play),
   Custom(R.string.pref_gesture_double_tap_custom),
+  PlaylistNext(R.string.pref_gesture_media_next),
+  PlaylistPrev(R.string.pref_gesture_media_previous),
 }
 
 enum class CustomKeyCodes(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -137,10 +137,7 @@ class PlayerViewModel(
   /**
    * Manager for playback operations (seeking, speed).
    */
-  private val _playbackManager = PlaybackManager(
-    playerPreferences = playerPreferences,
-    scope = viewModelScope
-  )
+  private val _playbackManager: PlaybackManager by inject()
   val playbackManager: PlaybackManager get() = _playbackManager
 
   // Subtitle state delegates
@@ -719,11 +716,11 @@ class PlayerViewModel(
   // ==================== Seeking ====================
 
   fun seekBy(offset: Int) {
-    _playbackManager.seekBy(offset)
+    _playbackManager.seekBy(viewModelScope, offset)
   }
 
   fun seekTo(position: Int) {
-    _playbackManager.seekTo(position, _abLoopA.value, _abLoopB.value)
+    _playbackManager.seekTo(viewModelScope, position, _abLoopA.value, _abLoopB.value)
   }
 
   fun setPlaybackSpeed(speed: Float) {
@@ -1070,84 +1067,57 @@ class PlayerViewModel(
 
   // ==================== Gesture Handling ====================
 
-  fun handleLeftDoubleTap() {
-    when (gesturePreferences.leftSingleActionGesture.get()) {
-      SingleActionGesture.Seek -> leftSeek()
-      SingleActionGesture.SubSeek -> leftSubSeek()
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapLeft.keyCode)
+  private fun executeGestureAction(
+    action: SingleActionGesture,
+    isLeft: Boolean = false,
+    isRight: Boolean = false,
+  ) {
+    when (action) {
+      SingleActionGesture.Seek -> {
+        if (isLeft) leftSeek() else if (isRight) rightSeek()
       }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
+      SingleActionGesture.SubSeek -> {
+        if (isLeft) leftSubSeek() else if (isRight) rightSubSeek()
+      }
+      SingleActionGesture.PlayPause -> pauseUnpause()
+      SingleActionGesture.Custom -> {
+        viewModelScope.launch(Dispatchers.IO) {
+          val keyCode = when {
+            isLeft -> CustomKeyCodes.DoubleTapLeft.keyCode
+            isRight -> CustomKeyCodes.DoubleTapRight.keyCode
+            else -> CustomKeyCodes.DoubleTapCenter.keyCode
+          }
+          MPVLib.command("keypress", keyCode)
+        }
+      }
+      SingleActionGesture.PlaylistNext -> playNext()
+      SingleActionGesture.PlaylistPrev -> playPrevious()
       SingleActionGesture.None -> {}
     }
+  }
+
+  fun handleLeftDoubleTap() {
+    executeGestureAction(gesturePreferences.leftSingleActionGesture.get(), isLeft = true)
   }
 
   fun handleCenterDoubleTap() {
-    when (gesturePreferences.centerSingleActionGesture.get()) {
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapCenter.keyCode)
-      }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
-      SingleActionGesture.Seek, SingleActionGesture.SubSeek, SingleActionGesture.None -> {}
-    }
+    executeGestureAction(gesturePreferences.centerSingleActionGesture.get())
   }
 
   fun handleCenterSingleTap() {
-    when (gesturePreferences.centerSingleActionGesture.get()) {
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapCenter.keyCode)
-      }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
-      SingleActionGesture.Seek, SingleActionGesture.SubSeek, SingleActionGesture.None -> {}
-    }
+    executeGestureAction(gesturePreferences.centerSingleActionGesture.get())
   }
 
   fun handleLeftSingleTap() {
-    when (gesturePreferences.leftSingleActionGesture.get()) {
-      SingleActionGesture.Seek -> leftSeek()
-      SingleActionGesture.SubSeek -> leftSubSeek()
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapLeft.keyCode)
-      }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
-      SingleActionGesture.None -> {}
-    }
+    executeGestureAction(gesturePreferences.leftSingleActionGesture.get(), isLeft = true)
   }
 
   fun handleRightSingleTap() {
-    when (gesturePreferences.rightSingleActionGesture.get()) {
-      SingleActionGesture.Seek -> rightSeek()
-      SingleActionGesture.SubSeek -> rightSubSeek()
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapRight.keyCode)
-      }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
-      SingleActionGesture.None -> {}
-    }
+    executeGestureAction(gesturePreferences.rightSingleActionGesture.get(), isRight = true)
   }
 
   fun handleRightDoubleTap() {
-    when (gesturePreferences.rightSingleActionGesture.get()) {
-      SingleActionGesture.Seek -> rightSeek()
-      SingleActionGesture.SubSeek -> rightSubSeek()
-      SingleActionGesture.PlayPause -> pauseUnpause()
-      SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
-        MPVLib.command("keypress", CustomKeyCodes.DoubleTapRight.keyCode)
-      }
-      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
-      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
-      SingleActionGesture.None -> {}
-    }
+    executeGestureAction(gesturePreferences.rightSingleActionGesture.get(), isRight = true)
   }
 
   // ==================== Video Zoom ====================

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -1078,6 +1078,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapLeft.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.None -> {}
     }
   }
@@ -1088,6 +1090,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapCenter.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.Seek, SingleActionGesture.SubSeek, SingleActionGesture.None -> {}
     }
   }
@@ -1098,6 +1102,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapCenter.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.Seek, SingleActionGesture.SubSeek, SingleActionGesture.None -> {}
     }
   }
@@ -1110,6 +1116,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapLeft.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.None -> {}
     }
   }
@@ -1122,6 +1130,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapRight.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.None -> {}
     }
   }
@@ -1134,6 +1144,8 @@ class PlayerViewModel(
       SingleActionGesture.Custom -> viewModelScope.launch(Dispatchers.IO) {
         MPVLib.command("keypress", CustomKeyCodes.DoubleTapRight.keyCode)
       }
+      SingleActionGesture.PlaylistNext -> MPVLib.command("playlist-next")
+      SingleActionGesture.PlaylistPrev -> MPVLib.command("playlist-prev")
       SingleActionGesture.None -> {}
     }
   }


### PR DESCRIPTION
Fixed https://github.com/sfsakhawat999/mpvRex/issues/41

Currently media buttons are hardcoded to seek action, but there should be a possibility to choose playlist next or previous actions too. This PR was done with help of Gemini.