### PR TITLE
feat: add toggle to disable external media button controls

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -88,5 +88,7 @@ class PlayerPreferences(
 
   // Ambience Mode
   val isAmbientEnabled = preferenceStore.getBoolean("ambient_enabled", false)
-  
+
+  // External media controls
+  val disableMediaButtons = preferenceStore.getBoolean("disable_media_buttons", false)
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/MediaPlaybackService.kt
@@ -136,8 +136,11 @@ class MediaPlaybackService :
 
     // Handle media button events
     intent?.let {
-      MediaButtonReceiver.handleIntent(mediaSession, it)
-      
+      if (it.action == Intent.ACTION_MEDIA_BUTTON && playerPreferences.disableMediaButtons.get()) {
+        Log.d(TAG, "Ignoring external media button intent due to user preference")
+      } else {
+        MediaButtonReceiver.handleIntent(mediaSession, it)
+      }
       // Get media info from intent extras if available
       val title = it.getStringExtra("media_title")
       val artist = it.getStringExtra("media_artist")
@@ -206,38 +209,44 @@ class MediaPlaybackService :
       MediaSessionCompat(this, TAG).apply {
         setCallback(
           object : MediaSessionCompat.Callback() {
+            private fun canHandle() = !playerPreferences.disableMediaButtons.get()
+
             override fun onPlay() {
+              if (!canHandle()) return
               Log.d(TAG, "onPlay called")
               MPVLib.setPropertyBoolean("pause", false)
             }
 
             override fun onPause() {
+              if (!canHandle()) return
               Log.d(TAG, "onPause called")
               MPVLib.setPropertyBoolean("pause", true)
             }
 
             override fun onStop() {
+              if (!canHandle()) return
               Log.d(TAG, "onStop called")
               stopSelf()
             }
 
             override fun onSkipToNext() {
+              if (!canHandle()) return
               Log.d(TAG, "onSkipToNext called")
               listener?.onNextRequested() ?: run {
-                // Fallback if no listener
                 MPVLib.command("playlist-next")
               }
             }
 
             override fun onSkipToPrevious() {
+              if (!canHandle()) return
               Log.d(TAG, "onSkipToPrevious called")
               listener?.onPreviousRequested() ?: run {
-                // Fallback if no listener
                 MPVLib.command("playlist-prev")
               }
             }
 
             override fun onSeekTo(pos: Long) {
+              if (!canHandle()) return
               Log.d(TAG, "onSeekTo called: $pos")
               MPVLib.setPropertyDouble("time-pos", pos / 1000.0)
             }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -2766,18 +2766,32 @@ class PlayerActivity :
       }
 
       KeyEvent.KEYCODE_MEDIA_STOP -> {
+        if (playerPreferences.disableMediaButtons.get()) return true
         finishAndRemoveTask()
         return true
       }
 
       KeyEvent.KEYCODE_MEDIA_REWIND -> {
+        if (playerPreferences.disableMediaButtons.get()) return true
         viewModel.handleLeftDoubleTap()
         return true
       }
 
       KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> {
+        if (playerPreferences.disableMediaButtons.get()) return true
         viewModel.handleRightDoubleTap()
         return true
+      }
+
+      KeyEvent.KEYCODE_MEDIA_PLAY,
+      KeyEvent.KEYCODE_MEDIA_PAUSE,
+      KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+      KeyEvent.KEYCODE_MEDIA_NEXT,
+      KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+        if (playerPreferences.disableMediaButtons.get()) return true
+        
+        event?.let { player.onKey(it) }
+        return super.onKeyDown(keyCode, event)
       }
 
       else -> {
@@ -2823,25 +2837,32 @@ class PlayerActivity :
         MediaSession(this, TAG).apply {
           setCallback(
             object : MediaSession.Callback() {
+              private fun canHandle() = !playerPreferences.disableMediaButtons.get()
+
               override fun onPlay() {
+                if (!canHandle()) return
                 viewModel.unpause()
                 updateMediaSessionPlaybackState(isPlaying = true)
               }
 
               override fun onPause() {
+                if (!canHandle()) return
                 viewModel.pause()
                 updateMediaSessionPlaybackState(isPlaying = false)
               }
 
               override fun onSkipToNext() {
+                if (!canHandle()) return
                 viewModel.handleMediaNext()
               }
 
               override fun onSkipToPrevious() {
+                if (!canHandle()) return
                 viewModel.handleMediaPrevious()
               }
 
               override fun onSeekTo(pos: Long) {
+                if (!canHandle()) return
                 viewModel.seekTo((pos / 1000).toInt())
                 updateMediaSessionPlaybackState(isPlaying = viewModel.paused == false)
               }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -368,6 +368,21 @@ object PlayerPreferencesScreen : Screen {
 
           item {
             PreferenceCard {
+              val disableMediaButtons by preferences.disableMediaButtons.collectAsState()
+              SwitchPreference(
+                value = disableMediaButtons,
+                onValueChange = preferences.disableMediaButtons::set,
+                title = { Text(stringResource(id = R.string.pref_player_controls_disable_media_buttons_title)) },
+                summary = {
+                  Text(
+                    text = stringResource(R.string.pref_player_controls_disable_media_buttons_summary),
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
+              
+              PreferenceDivider()
+              
               val allowGesturesInPanels by preferences.allowGesturesInPanels.collectAsState()
               SwitchPreference(
                 value = allowGesturesInPanels,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,8 @@
     <string name="pref_player_gestures_hold_for_multiple_speed">Hold for multi - x speed</string>
 
     <string name="pref_player_controls">Controls</string>
+    <string name="pref_player_controls_disable_media_buttons_title">Disable media buttons</string>
+    <string name="pref_player_controls_disable_media_buttons_summary">Ignore playback commands from headset and Bluetooth devices, etc</string>
     <string name="pref_player_controls_allow_gestures_in_panels">Allow gestures in panels</string>
     <string name="pref_player_controls_display_volume_as_percentage">Display volume as percentage</string>
     <string name="pref_player_controls_show_loading_circle">Show loading circle</string>


### PR DESCRIPTION
Closes #56

This adds a toggle that acts as a kill switch for external media commands. When enabled, the player completely ignores play, pause, next, and previous commands sent by external hardware. This includes Bluetooth headsets, wired headphones, smartwatches, and car media controls. 

- Confirmed working with Bluetooth headsets.

While the UI specifically says "headset and Bluetooth" because it is the most common user scenario, Android's `MediaSession` and `KeyEvent` APIs do not differentiate between transport methods. The backend implementation drops all ACTION_MEDIA_BUTTON intents and all KEYCODE_MEDIA_* events. Consequently, this toggle disables all external hardware media buttons, not just Bluetooth devices.