### PR TITLE
feat(player): add resume playback on screen unlock

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -73,6 +73,7 @@ class PlayerPreferences(
   val autoPiPOnNavigation = preferenceStore.getBoolean("auto_pip_on_navigation", false)
 
   val keepScreenOnWhenPaused = preferenceStore.getBoolean("keep_screen_on_when_paused", false)
+  val resumeOnUnlock = preferenceStore.getBoolean("resume_on_unlock", false)
 
   // Persist aspect ratio setting (default to Fit)
   val defaultVideoAspect = preferenceStore.getEnum("default_video_aspect", VideoAspect.Fit)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerActivity.kt
@@ -202,7 +202,6 @@ class PlayerActivity :
   private var noisyReceiverRegistered = false
   private var mpvInitialized = false // Track MPV initialization state
   private var savePlaybackStateJob: kotlinx.coroutines.Job? = null // Track ongoing save job
-  private var wasPlayingBeforePause = false // Track if video was playing before pause
   private var pendingIntentExtras = false // Track if intent extras should be applied to next loaded file
   private var lastVid = -1 // Track video track for background playback optimization
   private var isInBackgroundPlayback = false // Track if we are currently in background playback mode
@@ -324,6 +323,7 @@ class PlayerActivity :
     setupPlayerControls()
     setupPipHelper()
     setupMediaSession()
+    viewModel.setupScreenStateReceiver()
 
     val playlistId = intent.getIntExtra("playlist_id", -1).takeIf { it != -1 }
     val playlistIndex = intent.getIntExtra("playlist_index", 0)
@@ -700,6 +700,7 @@ class PlayerActivity :
 
   @RequiresApi(Build.VERSION_CODES.P)
   override fun onPause() {
+    viewModel.isActivityResumed = false
     runCatching {
       val isInPip = isInPictureInPictureMode
       val isInMultiWindow = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) isInMultiWindowMode else false
@@ -708,7 +709,7 @@ class PlayerActivity :
 
       if (!isInPip && !isInMultiWindow) {
         if (shouldPause) {
-          wasPlayingBeforePause = !(viewModel.paused ?: true)
+          viewModel.wasPlayingBeforePause = !(viewModel.paused ?: true)
           viewModel.pause()
         } else {
           // Background playback is active - disable video decoding to save battery
@@ -779,6 +780,7 @@ class PlayerActivity :
   }
 
   override fun onStop() {
+    viewModel.isActivityStarted = false
     runCatching {
       pipHelper.onStop()
       saveVideoPlaybackState(fileName)
@@ -809,6 +811,7 @@ class PlayerActivity :
   @RequiresApi(Build.VERSION_CODES.P)
   override fun onStart() {
     super.onStart()
+    viewModel.isActivityStarted = true
 
     runCatching {
       setupWindowFlags()
@@ -1280,7 +1283,9 @@ class PlayerActivity :
 
   override fun onResume() {
     super.onResume()
+    viewModel.isActivityResumed = true
     updateVolume()
+    viewModel.handlePendingResumeOnUnlock()
   }
 
   /**

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -94,6 +94,9 @@ class PlayerViewModel(
 
   private val browserPreferences: app.marlboroadvance.mpvex.preferences.BrowserPreferences by inject()
 
+  // Cache the application context to prevent leaking the Activity context
+  private val appContext = host.context.applicationContext
+  
   /**
    * Manager for playlist state and logic.
    */
@@ -104,7 +107,7 @@ class PlayerViewModel(
    * Manager for subtitle state and operations.
    */
   private val _subtitleManager = SubtitleManager(
-    context = host.context,
+    context = appContext,
     wyzieRepository = wyzieRepository,
     scope = viewModelScope,
     onShowToast = { showToast(it) }
@@ -115,7 +118,7 @@ class PlayerViewModel(
    * Manager for history tracking and position saving.
    */
   private val _historyManager = app.marlboroadvance.mpvex.utils.history.HistoryManager(
-    context = host.context,
+    context = appContext,
     recentlyPlayedRepository = recentlyPlayedRepository,
     playbackStateRepository = playbackStateRepository,
     advancedPreferences = advancedPreferences,
@@ -127,7 +130,7 @@ class PlayerViewModel(
    * Manager for custom user-defined buttons.
    */
   private val _customButtonManager = CustomButtonManager(
-    context = host.context,
+    context = appContext,
     playerPreferences = playerPreferences,
     advancedPreferences = advancedPreferences,
     json = json,
@@ -358,7 +361,7 @@ class PlayerViewModel(
   // ==================== Screen Unlock Resume ===============================
 
   private val _screenStateManager = ScreenStateManager(
-    context = host.context,
+    context = appContext,
     playerPreferences = playerPreferences,
     onResumePlayback = { unpause() },
     isPaused = { paused ?: true }
@@ -656,6 +659,7 @@ class PlayerViewModel(
         MPVLib.setPropertyBoolean("pause", false)
       } else {
         // We are about to pause
+        wasPlayingBeforePause = false
         MPVLib.setPropertyBoolean("pause", true)
         withContext(Dispatchers.Main) { host.abandonAudioFocus() }
       }
@@ -664,6 +668,7 @@ class PlayerViewModel(
 
   fun pause() {
     viewModelScope.launch(Dispatchers.IO) {
+      wasPlayingBeforePause = false
       MPVLib.setPropertyBoolean("pause", true)
       withContext(Dispatchers.Main) { host.abandonAudioFocus() }
     }
@@ -1891,7 +1896,7 @@ class PlayerViewModel(
   // ==================== Utility ====================
 
   fun showToast(message: String) {
-    Toast.makeText(host.context, message, Toast.LENGTH_SHORT).show()
+    Toast.makeText(appContext, message, Toast.LENGTH_SHORT).show()
   }
 
   override fun onCleared() {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -356,6 +356,70 @@ class PlayerViewModel(
   // Expose ambient mode state through the manager
   val isAmbientEnabled: StateFlow<Boolean> = ambientModeManager.isAmbientEnabled
 
+  // ==================== Screen Unlock Resume ===============================
+
+  var isActivityResumed = false
+  var isActivityStarted = false
+  var wasPlayingBeforePause = false
+
+  private var pausedByScreenOff = false
+  private var pendingResumeOnUnlock = false
+  private var screenStateReceiverRegistered = false
+
+  private val screenStateReceiver = object : android.content.BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+      when (intent?.action) {
+        Intent.ACTION_SCREEN_OFF -> {
+          // If the activity was active and playing when the screen turned off, flag it
+          if (isActivityStarted && (!(paused ?: true) || wasPlayingBeforePause)) {
+            pausedByScreenOff = true
+          }
+        }
+        Intent.ACTION_USER_PRESENT -> {
+          // Screen unlocked. If we paused due to screen off, prep for resume
+          if (pausedByScreenOff) {
+            pendingResumeOnUnlock = true
+            pausedByScreenOff = false
+
+            // If the activity is already resumed (e.g. no lock screen delay), execute immediately
+            if (isActivityResumed) {
+              handlePendingResumeOnUnlock()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fun setupScreenStateReceiver() {
+    if (!screenStateReceiverRegistered) {
+      val filter = android.content.IntentFilter().apply {
+        addAction(Intent.ACTION_SCREEN_OFF)
+        addAction(Intent.ACTION_USER_PRESENT)
+      }
+      host.context.registerReceiver(screenStateReceiver, filter)
+      screenStateReceiverRegistered = true
+    }
+  }
+
+  fun handlePendingResumeOnUnlock() {
+    if (pendingResumeOnUnlock) {
+      pendingResumeOnUnlock = false
+      if (playerPreferences.resumeOnUnlock.get()) {
+        unpause()
+      }
+    }
+  }
+
+  private fun cleanupScreenStateReceiver() {
+    if (screenStateReceiverRegistered) {
+      runCatching {
+        host.context.unregisterReceiver(screenStateReceiver)
+        screenStateReceiverRegistered = false
+      }
+    }
+  }
+
   init {
     // Track selection is now handled by TrackSelector in PlayerActivity
     
@@ -1867,6 +1931,7 @@ class PlayerViewModel(
 
   override fun onCleared() {
     super.onCleared()
+    cleanupScreenStateReceiver()
     ambientModeManager.cleanup()
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/PlayerViewModel.kt
@@ -1,7 +1,6 @@
 package app.marlboroadvance.mpvex.ui.player
 
 import android.content.Context
-import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.net.Uri
@@ -358,66 +357,32 @@ class PlayerViewModel(
 
   // ==================== Screen Unlock Resume ===============================
 
-  var isActivityResumed = false
-  var isActivityStarted = false
-  var wasPlayingBeforePause = false
+  private val _screenStateManager = ScreenStateManager(
+    context = host.context,
+    playerPreferences = playerPreferences,
+    onResumePlayback = { unpause() },
+    isPaused = { paused ?: true }
+  )
+  val screenStateManager: ScreenStateManager get() = _screenStateManager
 
-  private var pausedByScreenOff = false
-  private var pendingResumeOnUnlock = false
-  private var screenStateReceiverRegistered = false
+  var isActivityResumed: Boolean
+    get() = _screenStateManager.isActivityResumed
+    set(value) { _screenStateManager.isActivityResumed = value }
 
-  private val screenStateReceiver = object : android.content.BroadcastReceiver() {
-    override fun onReceive(context: Context?, intent: Intent?) {
-      when (intent?.action) {
-        Intent.ACTION_SCREEN_OFF -> {
-          // If the activity was active and playing when the screen turned off, flag it
-          if (isActivityStarted && (!(paused ?: true) || wasPlayingBeforePause)) {
-            pausedByScreenOff = true
-          }
-        }
-        Intent.ACTION_USER_PRESENT -> {
-          // Screen unlocked. If we paused due to screen off, prep for resume
-          if (pausedByScreenOff) {
-            pendingResumeOnUnlock = true
-            pausedByScreenOff = false
+  var isActivityStarted: Boolean
+    get() = _screenStateManager.isActivityStarted
+    set(value) { _screenStateManager.isActivityStarted = value }
 
-            // If the activity is already resumed (e.g. no lock screen delay), execute immediately
-            if (isActivityResumed) {
-              handlePendingResumeOnUnlock()
-            }
-          }
-        }
-      }
-    }
-  }
+  var wasPlayingBeforePause: Boolean
+    get() = _screenStateManager.wasPlayingBeforePause
+    set(value) { _screenStateManager.wasPlayingBeforePause = value }
 
   fun setupScreenStateReceiver() {
-    if (!screenStateReceiverRegistered) {
-      val filter = android.content.IntentFilter().apply {
-        addAction(Intent.ACTION_SCREEN_OFF)
-        addAction(Intent.ACTION_USER_PRESENT)
-      }
-      host.context.registerReceiver(screenStateReceiver, filter)
-      screenStateReceiverRegistered = true
-    }
+    _screenStateManager.setup()
   }
 
   fun handlePendingResumeOnUnlock() {
-    if (pendingResumeOnUnlock) {
-      pendingResumeOnUnlock = false
-      if (playerPreferences.resumeOnUnlock.get()) {
-        unpause()
-      }
-    }
-  }
-
-  private fun cleanupScreenStateReceiver() {
-    if (screenStateReceiverRegistered) {
-      runCatching {
-        host.context.unregisterReceiver(screenStateReceiver)
-        screenStateReceiverRegistered = false
-      }
-    }
+    _screenStateManager.handlePendingResumeOnUnlock()
   }
 
   init {
@@ -1931,7 +1896,7 @@ class PlayerViewModel(
 
   override fun onCleared() {
     super.onCleared()
-    cleanupScreenStateReceiver()
+    _screenStateManager.cleanup()
     ambientModeManager.cleanup()
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/ScreenStateManager.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/ScreenStateManager.kt
@@ -33,6 +33,17 @@ class ScreenStateManager(
             pausedByScreenOff = true
           }
         }
+        Intent.ACTION_SCREEN_ON -> {
+          // Fallback for devices without a lock screen
+          if (pausedByScreenOff) {
+            val km = context?.getSystemService(Context.KEYGUARD_SERVICE) as? android.app.KeyguardManager
+            if (km?.isKeyguardLocked == false) {
+              pendingResumeOnUnlock = true
+              pausedByScreenOff = false
+              if (isActivityResumed) handlePendingResumeOnUnlock()
+            }
+          }
+        }
         Intent.ACTION_USER_PRESENT -> {
           // Screen unlocked. If we paused due to screen off, prep for resume
           if (pausedByScreenOff) {
@@ -53,6 +64,7 @@ class ScreenStateManager(
     if (!screenStateReceiverRegistered) {
       val filter = IntentFilter().apply {
         addAction(Intent.ACTION_SCREEN_OFF)
+        addAction(Intent.ACTION_SCREEN_ON)
         addAction(Intent.ACTION_USER_PRESENT)
       }
       context.registerReceiver(screenStateReceiver, filter)
@@ -71,9 +83,9 @@ class ScreenStateManager(
 
   fun cleanup() {
     if (screenStateReceiverRegistered) {
+      screenStateReceiverRegistered = false
       runCatching {
         context.unregisterReceiver(screenStateReceiver)
-        screenStateReceiverRegistered = false
       }
     }
   }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/ScreenStateManager.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/ScreenStateManager.kt
@@ -1,0 +1,80 @@
+package app.marlboroadvance.mpvex.ui.player
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import app.marlboroadvance.mpvex.preferences.PlayerPreferences
+
+/**
+ * Manager for handling screen state events (lock/unlock) and managing
+ * automatic playback resumption.
+ */
+class ScreenStateManager(
+  private val context: Context,
+  private val playerPreferences: PlayerPreferences,
+  private val onResumePlayback: () -> Unit,
+  private val isPaused: () -> Boolean
+) {
+  var isActivityResumed = false
+  var isActivityStarted = false
+  var wasPlayingBeforePause = false
+
+  private var pausedByScreenOff = false
+  private var pendingResumeOnUnlock = false
+  private var screenStateReceiverRegistered = false
+
+  private val screenStateReceiver = object : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+      when (intent?.action) {
+        Intent.ACTION_SCREEN_OFF -> {
+          // If the activity was active and playing when the screen turned off, flag it
+          if (isActivityStarted && (!isPaused() || wasPlayingBeforePause)) {
+            pausedByScreenOff = true
+          }
+        }
+        Intent.ACTION_USER_PRESENT -> {
+          // Screen unlocked. If we paused due to screen off, prep for resume
+          if (pausedByScreenOff) {
+            pendingResumeOnUnlock = true
+            pausedByScreenOff = false
+
+            // If the activity is already resumed (e.g. no lock screen delay), execute immediately
+            if (isActivityResumed) {
+              handlePendingResumeOnUnlock()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fun setup() {
+    if (!screenStateReceiverRegistered) {
+      val filter = IntentFilter().apply {
+        addAction(Intent.ACTION_SCREEN_OFF)
+        addAction(Intent.ACTION_USER_PRESENT)
+      }
+      context.registerReceiver(screenStateReceiver, filter)
+      screenStateReceiverRegistered = true
+    }
+  }
+
+  fun handlePendingResumeOnUnlock() {
+    if (pendingResumeOnUnlock) {
+      pendingResumeOnUnlock = false
+      if (playerPreferences.resumeOnUnlock.get()) {
+        onResumePlayback()
+      }
+    }
+  }
+
+  fun cleanup() {
+    if (screenStateReceiverRegistered) {
+      runCatching {
+        context.unregisterReceiver(screenStateReceiver)
+        screenStateReceiverRegistered = false
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -189,6 +189,24 @@ object PlayerPreferencesScreen : Screen {
                   )
                 },
               )
+              
+              PreferenceDivider()
+
+              val resumeOnUnlock by preferences.resumeOnUnlock.collectAsState()
+              SwitchPreference(
+                value = resumeOnUnlock,
+                onValueChange = preferences.resumeOnUnlock::set,
+                title = { Text(stringResource(R.string.pref_player_resume_on_unlock_title)) },
+                summary = {
+                  Text(
+                    text = if (resumeOnUnlock)
+                      stringResource(R.string.pref_player_resume_on_unlock_summary_on)
+                    else
+                      stringResource(R.string.pref_player_resume_on_unlock_summary_off),
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
             }
           }
           // Seeking Section

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="pref_autoplay_next_video_summary">Automatically play next video when current ends</string>
     <string name="pref_auto_pip_title">Auto Picture-in-Picture</string>
     <string name="pref_auto_pip_summary">Automatically enter PIP mode when pressing home or back</string>
+    <string name="pref_player_resume_on_unlock_title">Resume on unlock</string>
+    <string name="pref_player_resume_on_unlock_summary_on">Resume video automatically after unlocking if it was playing before the screen locked</string>
+    <string name="pref_player_resume_on_unlock_summary_off">Keep video paused after the screen is unlocked</string>
     <string name="pref_dynamic_speed_overlay_title">Dynamic Speed Overlay</string>
     <string name="pref_dynamic_speed_overlay_summary">Show advance overlay for speed control during long press and swipe</string>
     <string name="pref_show_navigation_bar_title">Show navigation bar with controls</string>


### PR DESCRIPTION
Closes #53 

adds an opt-in setting to automatically resume video playback upon device unlock, strictly provided the video was actively playing when the screen turned off and the app remains in the foreground.