### PR TITLE
feat(subtitles): implement Wyzie API key authentication

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/SubtitlesPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/SubtitlesPreferences.kt
@@ -52,6 +52,7 @@ class SubtitlesPreferences(
   val wyzieFormats = preferenceStore.getStringSet("wyzie_formats", setOf("srt", "ass"))
   val wyzieEncodings = preferenceStore.getStringSet("wyzie_encodings", setOf("utf-8"))
   val wyzieHearingImpaired = preferenceStore.getBoolean("wyzie_hi", false)
+  val wyzieApiKey = preferenceStore.getString("wyzie_api_key", "")
 }
 
 enum class SubtitleJustification(

--- a/app/src/main/java/app/marlboroadvance/mpvex/repository/wyzie/WyzieSearchRepository.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/repository/wyzie/WyzieSearchRepository.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -206,7 +207,27 @@ class WyzieSearchRepository(
     private val json: Json,
     private val preferences: SubtitlesPreferences
 ) {
-    private val baseUrl = "https://sub.wyzie.ru"
+    private val baseUrl = "https://sub.wyzie.io"
+
+    private fun buildApiRequest(url: String): Request {
+        val apiKey = preferences.wyzieApiKey.get()
+        
+        if (apiKey.isBlank()) {
+            throw IOException("Wyzie API key is missing. Please set it in Subtitle Settings.")
+        }
+        
+        val httpUrl = url.toHttpUrlOrNull()
+        val finalUrl = if (httpUrl != null) {
+            httpUrl.newBuilder()
+                .addQueryParameter("key", apiKey.trim())
+                .build()
+                .toString()
+        } else {
+            url
+        }
+        
+        return Request.Builder().url(finalUrl).build()
+    }
 
     suspend fun search(
         query: String,
@@ -260,23 +281,7 @@ class WyzieSearchRepository(
                 hi = if (hearingImpaired) true else null
             )
             
-            // The Wyzie API often returns all languages regardless of query parameters.
-            // We must strictly filter the results locally based on selected languages.
-            val filteredResults = if (languages != null && languages != "all") {
-                val allowedLangs = languages.split(",").map { it.trim() }
-                results.filter { sub -> 
-                    // Map the subtitle language code (which is sometimes lowercase, sometimes not)
-                    val subLangCode = WyzieLanguages.ALL.entries.find { 
-                        it.value.equals(sub.language, ignoreCase = true) 
-                    }?.key ?: sub.language?.lowercase()
-                    
-                    allowedLangs.contains(subLangCode)
-                }
-            } else {
-                results
-            }
-            
-            val sortedResults = filteredResults.sortedWith(compareByDescending<WyzieSubtitle> { sub ->
+            val sortedResults = results.sortedWith(compareByDescending<WyzieSubtitle> { sub ->
                 val name = sub.displayName.lowercase()
                 val q = query.lowercase()
                 var score = 0
@@ -304,32 +309,30 @@ class WyzieSearchRepository(
         source: String = "all",
         hi: Boolean? = null
     ): List<WyzieSubtitle> {
-        fun encode(s: String) = URLEncoder.encode(s, "UTF-8")
         
-        val url = StringBuilder("$baseUrl/search?id=${encode(id)}")
-            .apply {
-                if (season != null && episode != null) {
-                    append("&season=$season")
-                    append("&episode=$episode")
-                }
-                
-                // Wyzie API language format: single or multiple language codes are comma separated: `language=en,es`
-                language?.filter { !it.isWhitespace() }?.let { append("&language=${encode(it)}") }
-                
-                // Format and Encoding parameters
-                format?.split(",")?.filter { it.isNotBlank() }?.forEach { append("&${encode(it.trim())}=true") }
-                encoding?.split(",")?.filter { it.isNotBlank() }?.forEach { append("&${encode(it.trim())}=true") }
-                
-                // Source is a special case, "all" defaults to all sources implicitly, but adding specific sources works like `opensubtitles=true`
-                if (source != "all") {
-                   source.split(",").filter { it.isNotBlank() }.forEach { append("&${encode(it.trim())}=true") }
-                }
+        val finalUrl = "$baseUrl/search".toHttpUrlOrNull()?.newBuilder()?.apply {
+            addQueryParameter("id", id)
+            
+            if (season != null && episode != null) {
+                addQueryParameter("season", season.toString())
+                addQueryParameter("episode", episode.toString())
+            }
+            
+            language?.filter { !it.isWhitespace() }?.let { addQueryParameter("language", it) }
+            
+            format?.split(",")?.filter { it.isNotBlank() }?.forEach { addQueryParameter(it.trim(), "true") }
+            encoding?.split(",")?.filter { it.isNotBlank() }?.forEach { addQueryParameter(it.trim(), "true") }
+            
+            if (source != "all") {
+                source.split(",").filter { it.isNotBlank() }.forEach { addQueryParameter(it.trim(), "true") }
+            }
 
-                append("&unzip=true")
-                hi?.let { append("&hi=$it") }
-            }.toString()
+            addQueryParameter("unzip", "true")
+            hi?.let { addQueryParameter("hi", it.toString()) }
+        }?.build()?.toString() ?: throw IOException("Invalid Wyzie Base URL")
 
-        val request = Request.Builder().url(url).build()
+        val request = buildApiRequest(finalUrl)
+        
         client.newCall(request).execute().use { response ->
             val responseBodyString = response.body?.string() ?: ""
             if (!response.isSuccessful) {
@@ -341,7 +344,7 @@ class WyzieSearchRepository(
                 if (response.code == 400 && responseBodyString.contains("season and episode", ignoreCase = true)) {
                     throw IOException("Please select both a Season and an Episode.")
                 }
-                val errorMsg = "Search failed: HTTP ${response.code} for URL: $url | Body: $responseBodyString"
+                val errorMsg = "Search failed: HTTP ${response.code} for URL: $finalUrl | Body: $responseBodyString"
                 Log.e("WyzieSearchRepository", errorMsg)
                 throw IOException(errorMsg)
             }
@@ -408,7 +411,7 @@ class WyzieSearchRepository(
     suspend fun getTvShowDetails(id: Int): Result<WyzieTvShowDetails> = withContext(Dispatchers.IO) {
         try {
             val url = "$baseUrl/api/tmdb/tv/$id"
-            val request = Request.Builder().url(url).build()
+            val request = buildApiRequest(url)
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) throw IOException("Failed to get TV show details: ${response.code}")
                 val body = response.body?.string() ?: throw IOException("Empty body from $url")
@@ -423,7 +426,7 @@ class WyzieSearchRepository(
     suspend fun getSeasonEpisodes(id: Int, season: Int): Result<List<WyzieEpisode>> = withContext(Dispatchers.IO) {
         try {
             val url = "$baseUrl/api/tmdb/tv/$id/$season"
-            val request = Request.Builder().url(url).build()
+            val request = buildApiRequest(url)
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) throw IOException("Failed to get season episodes: ${response.code}")
                 val body = response.body?.string() ?: throw IOException("Empty body from $url")
@@ -437,7 +440,7 @@ class WyzieSearchRepository(
 
     private fun tmdbSearch(query: String): List<WyzieTmdbResult> {
         val url = "$baseUrl/api/tmdb/search?q=${URLEncoder.encode(query, "UTF-8")}"
-        val request = Request.Builder().url(url).build()
+        val request = buildApiRequest(url)
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw IOException("TMDb search failed: ${response.code}")
             val body = response.body?.string() ?: throw IOException("Empty body")

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -16,7 +16,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Clear
@@ -26,6 +29,8 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import app.marlboroadvance.mpvex.repository.wyzie.WyzieEncodings
 import app.marlboroadvance.mpvex.repository.wyzie.WyzieFormats
 import app.marlboroadvance.mpvex.repository.wyzie.WyzieSources
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -45,8 +50,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.preferences.SubtitlesPreferences
@@ -158,6 +168,7 @@ object SubtitlesPreferencesScreen : Screen {
         val wyzieSources by preferences.wyzieSources.collectAsState()
         val wyzieFormats by preferences.wyzieFormats.collectAsState()
         val wyzieEncodings by preferences.wyzieEncodings.collectAsState()
+        val wyzieApiKey by preferences.wyzieApiKey.collectAsState()
 
         val saveLocationPicker =
           rememberLauncherForActivityResult(
@@ -555,6 +566,77 @@ object SubtitlesPreferencesScreen : Screen {
               }
 
               PreferenceDivider()
+
+              TextFieldPreference(
+                value = wyzieApiKey,
+                onValueChange = preferences.wyzieApiKey::set,
+                textToValue = { it.trim() },
+                title = { Text(stringResource(R.string.pref_subtitles_wyzie_api_key_title)) },
+                summary = {
+                  val summaryText = if (wyzieApiKey.isNotBlank()) {
+                    stringResource(R.string.pref_subtitles_wyzie_api_key_masked)
+                  } else {
+                    stringResource(R.string.pref_subtitles_wyzie_api_key_not_set)
+                  }
+                  Text(summaryText, color = MaterialTheme.colorScheme.outline)
+                },
+                textField = { value, onValueChange, _ ->
+                  val uriHandler = LocalUriHandler.current
+                  val fullString = stringResource(R.string.pref_subtitles_wyzie_api_key_summary)
+                  val linkText = "sub.wyzie.io/redeem"
+                  
+                  val annotatedString = buildAnnotatedString {
+                      val startIndex = fullString.indexOf(linkText)
+                      if (startIndex >= 0) {
+                          append(fullString.substring(0, startIndex))
+                          pushStringAnnotation(tag = "URL", annotation = "https://$linkText")
+                          withStyle(style = SpanStyle(
+                              color = MaterialTheme.colorScheme.primary,
+                              textDecoration = TextDecoration.Underline,
+                              fontWeight = FontWeight.Bold
+                          )) {
+                              append(linkText)
+                          }
+                          pop()
+                          append(fullString.substring(startIndex + linkText.length))
+                      } else {
+                          append(fullString)
+                      }
+                  }
+
+                  Column(modifier = Modifier.padding(top = 8.dp)) {
+                    ClickableText(
+                        text = annotatedString,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurfaceVariant),
+                        onClick = { offset ->
+                            annotatedString.getStringAnnotations(tag = "URL", start = offset, end = offset)
+                                .firstOrNull()?.let { annotation ->
+                                    uriHandler.openUri(annotation.item)
+                                }
+                        }
+                    )
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    OutlinedTextField(
+                      value = value,
+                      onValueChange = onValueChange,
+                      modifier = Modifier.fillMaxWidth(),
+                      singleLine = true,
+                      placeholder = { Text(stringResource(R.string.pref_subtitles_wyzie_api_key_hint)) },
+                      shape = RoundedCornerShape(12.dp),
+                      colors = OutlinedTextFieldDefaults.colors(
+                          focusedBorderColor = MaterialTheme.colorScheme.primary,
+                          unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                          focusedContainerColor = MaterialTheme.colorScheme.surface,
+                          unfocusedContainerColor = MaterialTheme.colorScheme.surface
+                      )
+                    )
+                  }
+                },
+              )
+
+              PreferenceDivider()
               
               // Wyzie Tag
               Row(
@@ -570,12 +652,12 @@ object SubtitlesPreferencesScreen : Screen {
                   color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                  text = "sub.wyzie.ru",
+                  text = "sub.wyzie.io",
                   style = MaterialTheme.typography.bodySmall,
                   color = MaterialTheme.colorScheme.primary,
                   fontWeight = FontWeight.Bold,
                   modifier = Modifier.clickable {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://sub.wyzie.ru"))
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://sub.wyzie.io"))
                     context.startActivity(intent)
                   }
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,11 @@
     <string name="pref_subtitles_searching">Searching…</string>
     <string name="pref_subtitles_found">%d subtitles found</string>
     <string name="pref_subtitles_online_search_title">Online Subtitle Search</string>
+    <string name="pref_subtitles_wyzie_api_key_title">Wyzie API Key</string>
+    <string name="pref_subtitles_wyzie_api_key_summary">Required for subtitle searches. Get yours at sub.wyzie.io/redeem</string>
+    <string name="pref_subtitles_wyzie_api_key_hint">Enter API Key</string>
+    <string name="pref_subtitles_wyzie_api_key_not_set">Not set</string>
+    <string name="pref_subtitles_wyzie_api_key_masked">••••••••••••••••••••••</string>
 
     <string name="pref_audio">Audio</string>
     <string name="pref_audio_summary">Preferred languages, audio channels, pitch correction</string>


### PR DESCRIPTION
### Changes:
- Added UI in Subtitle Settings for user API key input and hyperlink
- Updated WyzieSearchRepository to enforce key requirement and fast-fail if missing
- Migrated base URL to official `sub.wyzie.io` endpoint
- Refactored fetch logic: removed obsolete local language filtering and redundant URL encoding

---
### Why there is no default API key:
Omitted a default API key to prevent security vulnerabilities. Though the Wyzie API does not currently enforce rate limits, requiring a user-provided key ensures the feature won't break if limits or other policy changes are introduced later.

Closes #54