### PR TITLE
Fix SMB socket exhaustion, background timeouts, and path encoding

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
@@ -39,7 +39,7 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
     }
 
     /**
-     * Recursively digs through the exception chain to identify transport, socket, or timeout failures.
+     * Recursively traverses the exception chain to detect underlying network transport or timeout failures.
      */
     private fun isNetworkError(e: Throwable?): Boolean {
         var current = e
@@ -48,7 +48,8 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
                 current is com.hierynomus.protocol.transport.TransportException ||
                 current is com.hierynomus.smbj.common.SMBRuntimeException ||
                 current is java.net.SocketException ||
-                current is java.net.SocketTimeoutException) {
+                current is java.net.SocketTimeoutException ||
+                current is java.io.EOFException) {
                 return true
             }
             current = current.cause
@@ -61,14 +62,17 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
      * Prevents race conditions during concurrent reconnects via strict session reference tracking.
      */
     private suspend fun <T> executeWithRetry(block: suspend () -> T): T {
-        // Capture the exact session reference used when we started
         val sessionAtStart = session
         
         return try {
+            // Pre-flight check: Force a reconnect immediately if the session is inherently dead
+            if (session == null) {
+                throw java.net.SocketException("Session is null on execute")
+            }
             block()
         } catch (e: Exception) {
             if (isNetworkError(e)) {
-                Log.w(TAG, "SMB socket dead (likely backgrounded). Reconnecting...", e)
+                Log.w(TAG, "SMB socket dead. Reconnecting...", e)
                 
                 connectionMutex.withLock {
                     // Reconnect only if another coroutine hasn't already rebuilt this specific session
@@ -137,7 +141,7 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
 
     override suspend fun performListFiles(path: String): List<NetworkFile> {
         return executeWithRetry {
-            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw java.net.SocketException("Session is null or share failed")
             
             try {
                 val smbPath = path.trim('/').replace('/', '\\')
@@ -166,7 +170,7 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
 
     override suspend fun performGetFileStream(path: String): InputStream {
         return executeWithRetry {
-            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw java.net.SocketException("Session is null or share failed")
             val smbPath = path.trim('/').replace('/', '\\')
             
             val file = diskShare.openFile(
@@ -194,7 +198,7 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
 
     override suspend fun performGetFileSize(path: String): Long {
         return executeWithRetry {
-            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw java.net.SocketException("Session is null or share failed")
             try {
                 val smbPath = path.trim('/').replace('/', '\\')
                 diskShare.getFileInformation(smbPath).standardInformation.endOfFile

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
@@ -14,6 +14,8 @@ import com.hierynomus.smbj.auth.AuthenticationContext
 import com.hierynomus.smbj.connection.Connection
 import com.hierynomus.smbj.session.Session
 import com.hierynomus.smbj.share.DiskShare
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -30,9 +32,57 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
     private var session: Session? = null
     private var shareName: String = ""
     private var resolvedHostIp: String = ""
+    private val connectionMutex = Mutex()
 
     companion object {
         private const val TAG = "SmbClient"
+    }
+
+    /**
+     * Recursively digs through the exception chain to identify transport, socket, or timeout failures.
+     */
+    private fun isNetworkError(e: Throwable?): Boolean {
+        var current = e
+        while (current != null) {
+            if (current is java.util.concurrent.TimeoutException ||
+                current is com.hierynomus.protocol.transport.TransportException ||
+                current is com.hierynomus.smbj.common.SMBRuntimeException ||
+                current is java.net.SocketException ||
+                current is java.net.SocketTimeoutException) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
+    /**
+     * Executes a network operation with a single-retry mechanism.
+     * Prevents race conditions during concurrent reconnects via strict session reference tracking.
+     */
+    private suspend fun <T> executeWithRetry(block: suspend () -> T): T {
+        // Capture the exact session reference used when we started
+        val sessionAtStart = session
+        
+        return try {
+            block()
+        } catch (e: Exception) {
+            if (isNetworkError(e)) {
+                Log.w(TAG, "SMB socket dead (likely backgrounded). Reconnecting...", e)
+                
+                connectionMutex.withLock {
+                    // Reconnect only if another coroutine hasn't already rebuilt this specific session
+                    if (session === sessionAtStart) {
+                        performDisconnect()
+                        performConnect()
+                    }
+                }
+                
+                block()
+            } else {
+                throw e
+            }
+        }
     }
 
     override suspend fun performConnect() {
@@ -86,46 +136,50 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
     override fun checkIsConnected(): Boolean = session != null
 
     override suspend fun performListFiles(path: String): List<NetworkFile> {
-        val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
-        
-        return try {
-            val smbPath = path.trim('/').replace('/', '\\')
-            val fileList = diskShare.list(smbPath)
+        return executeWithRetry {
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
             
-            fileList.filter { it.fileName != "." && it.fileName != ".." }
-                .map { info ->
-                    val fileName = info.fileName
-                    val filePath = if (path.isEmpty() || path == "/") fileName 
-                    else "${path.trimEnd('/')}/$fileName"
+            try {
+                val smbPath = path.trim('/').replace('/', '\\')
+                val fileList = diskShare.list(smbPath)
+                
+                fileList.filter { it.fileName != "." && it.fileName != ".." }
+                    .map { info ->
+                        val fileName = info.fileName
+                        val filePath = if (path.isEmpty() || path == "/") fileName 
+                        else "${path.trimEnd('/')}/$fileName"
 
-                    NetworkFile(
-                        name = fileName,
-                        path = filePath,
-                        isDirectory = info.fileAttributes and 0x10L != 0L,
-                        size = info.endOfFile,
-                        lastModified = info.changeTime.toEpoch(TimeUnit.MILLISECONDS),
-                        mimeType = if (info.fileAttributes and 0x10L != 0L) null else getMimeType(fileName)
-                    )
-                }
-        } finally {
-            diskShare.close()
+                        NetworkFile(
+                            name = fileName,
+                            path = filePath,
+                            isDirectory = info.fileAttributes and 0x10L != 0L,
+                            size = info.endOfFile,
+                            lastModified = info.changeTime.toEpoch(TimeUnit.MILLISECONDS),
+                            mimeType = if (info.fileAttributes and 0x10L != 0L) null else getMimeType(fileName)
+                        )
+                    }
+            } finally {
+                diskShare.close()
+            }
         }
     }
 
     override suspend fun performGetFileStream(path: String): InputStream {
-        val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
-        val smbPath = path.trim('/').replace('/', '\\')
-        
-        val file = diskShare.openFile(
-            smbPath,
-            EnumSet.of(AccessMask.GENERIC_READ),
-            null,
-            EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
-            SMB2CreateDisposition.FILE_OPEN,
-            null
-        )
-        
-        return file.inputStream
+        return executeWithRetry {
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
+            val smbPath = path.trim('/').replace('/', '\\')
+            
+            val file = diskShare.openFile(
+                smbPath,
+                EnumSet.of(AccessMask.GENERIC_READ),
+                null,
+                EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
+                SMB2CreateDisposition.FILE_OPEN,
+                null
+            )
+            
+            file.inputStream
+        }
     }
 
     override suspend fun performGetFileUri(path: String): Uri {
@@ -139,12 +193,14 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
     }
 
     override suspend fun performGetFileSize(path: String): Long {
-        val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
-        return try {
-            val smbPath = path.trim('/').replace('/', '\\')
-            diskShare.getFileInformation(smbPath).standardInformation.endOfFile
-        } finally {
-            diskShare.close()
+        return executeWithRetry {
+            val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw Exception("Failed to connect to share")
+            try {
+                val smbPath = path.trim('/').replace('/', '\\')
+                diskShare.getFileInformation(smbPath).standardInformation.endOfFile
+            } finally {
+                diskShare.close()
+            }
         }
     }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
@@ -272,15 +272,22 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
   }
 
   /**
-   * Get file size using SMB
+   * Get the file size using SMB.
+   * Opens a discrete connection, queries the file, and tears the socket down immediately.
    */
   private suspend fun getFileSizeSMB(streamInfo: StreamInfo): Long {
+    var smbClient: SMBClient? = null
+    var connection: Connection? = null
+    var session: Session? = null
+    var diskShare: DiskShare? = null
+    var file: com.hierynomus.smbj.share.File? = null
+
     try {
       Log.d(TAG, "SMB getFileSize called")
       Log.d(TAG, "  Connection path: ${streamInfo.connection.path}")
       Log.d(TAG, "  File path: ${streamInfo.filePath}")
 
-      // Extract share name from connection path (just the share name, no subfolders)
+      // Extract the base share name, explicitly rejecting nested paths
       val shareName = streamInfo.connection.path.trim('/')
 
       if (shareName.isEmpty() || shareName.contains('/')) {
@@ -288,48 +295,35 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         return -1L
       }
 
-      // Parse filePath to extract the relative path within the share
-      // filePath format: smb://host/shareName/folder/file.mkv
+      // Isolate the relative file path within the share.
+      // Expected input format: smb://host/shareName/path/to/file.mkv
       val relativePath = when {
         streamInfo.filePath.startsWith("smb://", ignoreCase = true) -> {
-          // Don't use URI parsing - just use string manipulation to avoid encoding issues
-          // Format: smb://host/shareName/path/to/file.mkv
-          val pathAfterProtocol = streamInfo.filePath.substring(6) // Remove "smb://"
+          // Bypassing standard URI parsing to avoid premature encoding shifts
+          val pathAfterProtocol = streamInfo.filePath.substring(6) 
           val firstSlash = pathAfterProtocol.indexOf('/')
           if (firstSlash == -1) {
             Log.e(TAG, "Invalid SMB path format")
             return -1L
           }
 
-          // Skip past "host/shareName/" to get the file path
-          val pathAfterHost = pathAfterProtocol.substring(firstSlash + 1) // Remove "host/"
+          val pathAfterHost = pathAfterProtocol.substring(firstSlash + 1)
           val secondSlash = pathAfterHost.indexOf('/')
-          if (secondSlash == -1) {
-            // Just "smb://host/shareName" with no file
-            ""
-          } else {
-            // Get everything after "shareName/"
-            val extracted = pathAfterHost.substring(secondSlash + 1)
-            Log.d(TAG, "  Extracted from SMB URL: $extracted")
-            extracted
-          }
+          if (secondSlash == -1) "" else pathAfterHost.substring(secondSlash + 1)
         }
-        else -> {
-          // Fallback: assume it's already a relative path
-          val extracted = streamInfo.filePath.trim('/')
-          Log.d(TAG, "  Using as relative path: $extracted")
-          extracted
-        }
+        else -> streamInfo.filePath.trim('/')
       }
 
-      Log.d(TAG, "  Final: share=$shareName, relativePath=$relativePath")
+      // Decode URL-encoded characters (e.g., %20 to space) so SMBJ can resolve the literal disk path
+      val decodedRelativePath = java.net.URLDecoder.decode(relativePath, "UTF-8")
+      Log.d(TAG, "  Final: share=$shareName, relativePath=$decodedRelativePath")
 
       val smbConfig = SmbConfig.builder()
         .withTimeout(30000, TimeUnit.MILLISECONDS)
         .withSoTimeout(35000, TimeUnit.MILLISECONDS)
         .build()
-      val smbClient = SMBClient(smbConfig)
-      val connection = smbClient.connect(streamInfo.connection.host, streamInfo.connection.port)
+        
+      smbClient = SMBClient(smbConfig)
 
       val authContext = if (streamInfo.connection.isAnonymous) {
         AuthenticationContext.anonymous()
@@ -341,30 +335,30 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         )
       }
 
-      val session = connection.authenticate(authContext)
-      val diskShare = session.connectShare(shareName) as DiskShare
-
-      val file = diskShare.openFile(
-        relativePath,
+      connection = smbClient.connect(streamInfo.connection.host, streamInfo.connection.port)
+      session = connection.authenticate(authContext)
+      diskShare = session.connectShare(shareName) as DiskShare
+      
+      file = diskShare.openFile(
+        decodedRelativePath,
         EnumSet.of(AccessMask.GENERIC_READ),
         null,
         EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
         SMB2CreateDisposition.FILE_OPEN,
         null,
       )
+      
+      return file.fileInformation.standardInformation.endOfFile
 
-      val fileSize = file.fileInformation.standardInformation.endOfFile
-      Log.d(TAG, "  File size: $fileSize")
-
-      file.close()
-      diskShare.close()
-      session.close()
-      connection.close()
-      smbClient.close()
-      return fileSize
     } catch (e: Exception) {
       Log.e(TAG, "SMB getFileSize error: ${e.message}", e)
       return -1L
+    } finally {
+      runCatching { file?.close() }
+      runCatching { diskShare?.close() }
+      runCatching { session?.close() }
+      runCatching { connection?.close() }
+      runCatching { smbClient?.close() }
     }
   }
 
@@ -697,15 +691,23 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
   }
 
   /**
-   * Get SMB stream with offset using SMBJ (efficient seeking)
+   * Generates a seekable InputStream for SMB files.
+   * Maintains an open network socket for the duration of the stream.
+   * Teardown is delegated to the InputStream's close() method.
    */
   private suspend fun getStreamWithOffsetSMB(streamInfo: StreamInfo, offset: Long): InputStream? {
+    var smbClient: SMBClient? = null
+    var connection: Connection? = null
+    var session: Session? = null
+    var diskShare: DiskShare? = null
+    var file: com.hierynomus.smbj.share.File? = null
+
     try {
       Log.d(TAG, "SMB getStreamWithOffset called, offset=$offset")
       Log.d(TAG, "  Connection path: ${streamInfo.connection.path}")
       Log.d(TAG, "  File path: ${streamInfo.filePath}")
 
-      // Extract share name from connection path (just the share name, no subfolders)
+      // Extract the base share name, explicitly rejecting nested paths
       val shareName = streamInfo.connection.path.trim('/')
 
       if (shareName.isEmpty() || shareName.contains('/')) {
@@ -713,49 +715,35 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         return null
       }
 
-      // Parse filePath to extract the relative path within the share
-      // filePath format: smb://host/shareName/folder/file.mkv
+      // Isolate the relative file path within the share
       val relativePath = when {
         streamInfo.filePath.startsWith("smb://", ignoreCase = true) -> {
-          // Don't use URI parsing - just use string manipulation to avoid encoding issues
-          // Format: smb://host/shareName/path/to/file.mkv
-          val pathAfterProtocol = streamInfo.filePath.substring(6) // Remove "smb://"
+          val pathAfterProtocol = streamInfo.filePath.substring(6)
           val firstSlash = pathAfterProtocol.indexOf('/')
           if (firstSlash == -1) {
             Log.e(TAG, "Invalid SMB path format")
             return null
           }
 
-          // Skip past "host/shareName/" to get the file path
-          val pathAfterHost = pathAfterProtocol.substring(firstSlash + 1) // Remove "host/"
+          val pathAfterHost = pathAfterProtocol.substring(firstSlash + 1)
           val secondSlash = pathAfterHost.indexOf('/')
-          if (secondSlash == -1) {
-            // Just "smb://host/shareName" with no file
-            ""
-          } else {
-            // Get everything after "shareName/"
-            val extracted = pathAfterHost.substring(secondSlash + 1)
-            Log.d(TAG, "  Extracted from SMB URL: '$extracted'")
-            extracted
-          }
+          if (secondSlash == -1) "" else pathAfterHost.substring(secondSlash + 1)
         }
-        else -> {
-          // Fallback: assume it's already a relative path
-          val extracted = streamInfo.filePath.trim('/')
-          Log.d(TAG, "  Using as relative path: '$extracted'")
-          extracted
-        }
+        else -> streamInfo.filePath.trim('/')
       }
 
-      Log.d(TAG, "  Final: share=$shareName, relativePath=$relativePath")
+      // Decode URL-encoded characters so SMBJ can resolve the literal disk path
+      val decodedRelativePath = java.net.URLDecoder.decode(relativePath, "UTF-8")
+      Log.d(TAG, "  Final: share=$shareName, relativePath=$decodedRelativePath")
 
       val smbConfig = SmbConfig.builder()
-        .withTimeout(120000, TimeUnit.MILLISECONDS) // Increase timeout for large seeks
+        .withTimeout(120000, TimeUnit.MILLISECONDS) 
         .withSoTimeout(120000, TimeUnit.MILLISECONDS)
         .withReadTimeout(120000, TimeUnit.MILLISECONDS)
         .build()
-      val smbClient = SMBClient(smbConfig)
-      val connection = smbClient.connect(streamInfo.connection.host, streamInfo.connection.port)
+        
+      smbClient = SMBClient(smbConfig)
+      connection = smbClient.connect(streamInfo.connection.host, streamInfo.connection.port)
 
       val authContext = if (streamInfo.connection.isAnonymous) {
         AuthenticationContext.anonymous()
@@ -767,12 +755,11 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         )
       }
 
-      val session = connection.authenticate(authContext)
-      val diskShare = session.connectShare(shareName) as DiskShare
+      session = connection.authenticate(authContext)
+      diskShare = session.connectShare(shareName) as DiskShare
 
-      // Open file with read access
-      val file = diskShare.openFile(
-        relativePath,
+      file = diskShare.openFile(
+        decodedRelativePath,
         EnumSet.of(AccessMask.GENERIC_READ),
         null,
         EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
@@ -780,10 +767,9 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         null,
       )
 
-      // Create a seekable stream that reads from file at specific offsets
       val seekableStream = object : InputStream() {
         private var currentPosition = offset
-        private val fileHandle = file
+        private val fileHandle = file!!
         private var closed = false
 
         override fun read(): Int {
@@ -832,34 +818,27 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         override fun close() {
           if (!closed) {
             closed = true
-            try {
-              fileHandle.close()
-            } catch (_: Exception) {
-            }
-            try {
-              diskShare.close()
-            } catch (_: Exception) {
-            }
-            try {
-              session.close()
-            } catch (_: Exception) {
-            }
-            try {
-              connection.close()
-            } catch (_: Exception) {
-            }
-            try {
-              smbClient.close()
-            } catch (_: Exception) {
-            }
+            // Complete network stack teardown initiated by the media player
+            runCatching { fileHandle.close() }
+            runCatching { diskShare.close() }
+            runCatching { session.close() }
+            runCatching { connection.close() }
+            runCatching { smbClient.close() }
           }
         }
       }
 
       Log.d(TAG, "  Stream created successfully starting at offset $offset")
       return seekableStream
+      
     } catch (e: Exception) {
       Log.e(TAG, "SMB getStreamWithOffset error: ${e.message}", e)
+      // Cleanup partial connections if setup failed before the stream was created
+      runCatching { file?.close() }
+      runCatching { diskShare?.close() }
+      runCatching { session?.close() }
+      runCatching { connection?.close() }
+      runCatching { smbClient?.close() }
       return null
     }
   }


### PR DESCRIPTION
### Overview
The old SMB code was leaking TCP sockets, crashing when resuming from the background due to dead sessions, and failing on files with spaces in their names. This PR rewrites the connection lifecycle and error handling to make the network stable.

### Key Changes
- **Stop socket leaks:** Added try-finally blocks in NetworkStreamingProxy (e.g., getFileSizeSMB) to guarantee teardown. This stops the app from maxing out the host server's connection limit.
- **Auto-reconnect dead sessions**: Added executeWithRetry in SmbClient to silently rebuild dropped connections. It digs through the exception chain to catch hidden timeouts and EOFExceptions, allowing smooth recovery after the app sits in the background or finishes a long video.
- **Fix race conditions**: Wrapped the reconnect logic in a Mutex using strict reference checks (===). This stops multiple coroutines from firing at once and spawning duplicate sockets.
- **Fix spaces in filenames**: Added URLDecoder.decode to SMB paths. Files with spaces or special characters will no longer crash with FileNotFoundException.
- **Clean up streams properly**: Moved the proxy stream teardown directly into InputStream.close(). Sockets now stay alive exactly as long as the media player needs them, and close cleanly when playback stops.

Fixes #88 