### PR TITLE
feat(ui): modernize pull-to-refresh and toggle switches

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/pullrefresh/PullRefreshBox.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/presentation/components/pullrefresh/PullRefreshBox.kt
@@ -1,97 +1,176 @@
 package app.marlboroadvance.mpvex.presentation.components.pullrefresh
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * A reusable Box composable that wraps content with pull-to-refresh functionality.
+ * A reusable Box that wraps content with pull-to-refresh functionality.
  *
- * Automatically handles:
- * - Material Design theming for the refresh indicator
- * - Configurable refresh offset and threshold
- * - Delay after refresh for visual feedback
- * - Only activates when scrolled to top (when listState is provided)
- *
- * @param isRefreshing State that tracks whether refresh is in progress
- * @param onRefresh Lambda to invoke when refresh is triggered
- * @param modifier Modifier to apply to the Box
- * @param listState Optional LazyListState to check if at top (enables pull-to-refresh only at top)
- * @param refreshingOffset Distance that the indicator can be pulled beyond the trigger point
- * @param refreshThreshold Distance needed to pull to trigger the refresh
- * @param delayAfterRefresh Delay (in milliseconds) to show indicator after refresh completes
- * @param content Content to display inside the Box
+ * @param isRefreshing Tracks refresh state.
+ * @param onRefresh Invoked when refresh is triggered.
+ * @param modifier Box modifier.
+ * @param enabled Toggles pull-to-refresh.
+ * @param listState Unused. Reserved for top-scroll checks.
+ * @param refreshingOffset Unused. Reserved for offset customization.
+ * @param refreshThreshold Pull distance required to trigger refresh.
+ * @param delayAfterRefresh Delay (ms) to keep indicator visible after completion.
+ * @param content Content displayed inside the Box.
  */
-@OptIn(androidx.compose.material.ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PullRefreshBox(
   isRefreshing: MutableState<Boolean>,
   onRefresh: suspend () -> Unit,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
-  listState: LazyListState? = null,
-  refreshingOffset: Dp = 80.dp,
-  refreshThreshold: Dp = 72.dp,
+  @Suppress("UNUSED_PARAMETER") listState: LazyListState? = null,
+  @Suppress("UNUSED_PARAMETER") refreshingOffset: Dp = 80.dp,
+  refreshThreshold: Dp = 80.dp,
   delayAfterRefresh: Long = 800L,
   content: @Composable BoxScope.() -> Unit,
 ) {
   val coroutineScope = rememberCoroutineScope()
+  val state = rememberPullToRefreshState()
+  val density = LocalDensity.current
 
-  // Only enable pull-to-refresh when at the top of the list
-  val canRefresh by remember(listState) {
-    derivedStateOf {
-      listState?.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-    }
+  // Max pixel offset the content is pushed down.
+  val maxTranslationPx = with(density) { refreshThreshold.toPx() }
+
+  // Tracks active refresh to cancel previous jobs on rapid pulls.
+  val activeJob = remember { mutableStateOf<Job?>(null) }
+
+  // Target translation: hold at max if refreshing, otherwise track drag distance.
+  val targetTranslationY = if (isRefreshing.value) {
+    maxTranslationPx
+  } else {
+    (state.distanceFraction * maxTranslationPx).coerceAtLeast(0f)
   }
 
-  val pullRefreshState =
-    rememberPullRefreshState(
-      refreshing = isRefreshing.value,
+  // Spring animation for content snap/bounce.
+  val animatedTranslationY by animateFloatAsState(
+    targetValue = targetTranslationY,
+    animationSpec = spring(
+      dampingRatio = Spring.DampingRatioMediumBouncy,
+      stiffness = Spring.StiffnessMediumLow,
+    ),
+    label = "content_translationY",
+  )
+
+  // Indicator scale/alpha: 0 at rest, 1 at threshold/refreshing.
+  val indicatorScale by animateFloatAsState(
+    targetValue = if (isRefreshing.value) 1f else state.distanceFraction.coerceIn(0f, 1f),
+    animationSpec = spring(
+      dampingRatio = Spring.DampingRatioLowBouncy,
+      stiffness = Spring.StiffnessMedium,
+    ),
+    label = "indicator_scale",
+  )
+
+  // Morphing polygon sequence for indeterminate state.
+  val expressivePolygons = remember {
+    listOf(
+      MaterialShapes.Cookie4Sided,
+      MaterialShapes.SoftBurst,
+      MaterialShapes.Oval,
+    )
+  }
+
+  // Cached indicator size.
+  val indicatorSize = 56.dp
+  val indicatorSizePx = remember(density) { with(density) { indicatorSize.toPx() } }
+
+  Box(
+    modifier = modifier.pullToRefresh(
+      isRefreshing = isRefreshing.value,
+      state = state,
+      enabled = enabled,
       onRefresh = {
-        // Only trigger refresh if we're at the top or no listState provided
-        if (enabled && (listState == null || canRefresh)) {
-          isRefreshing.value = true
-          coroutineScope.launch {
+        activeJob.value?.cancel()
+        isRefreshing.value = true
+        activeJob.value = coroutineScope.launch {
+          try {
             onRefresh()
             delay(delayAfterRefresh)
+          } finally {
             isRefreshing.value = false
           }
         }
       },
-      refreshingOffset = refreshingOffset,
-      refreshThreshold = refreshThreshold,
-    )
-
-  Box(
-    modifier = modifier.pullRefresh(
-      state = pullRefreshState,
-      enabled = enabled && (listState == null || canRefresh),
     ),
   ) {
-    content()
+    // LAYER 1: Content (moves down during drag/refresh)
+    Box(
+      modifier = Modifier
+        .matchParentSize()
+        .graphicsLayer { translationY = animatedTranslationY },
+    ) {
+      content()
+    }
 
-    PullRefreshIndicator(
-      refreshing = isRefreshing.value,
-      state = pullRefreshState,
-      modifier = Modifier.align(Alignment.TopCenter),
-      backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
-      contentColor = MaterialTheme.colorScheme.primary,
-    )
+    // LAYER 2: Floating indicator (centered in the gap above content)
+    Box(
+      modifier = Modifier
+        .align(Alignment.TopCenter)
+        .graphicsLayer {
+          translationY = (animatedTranslationY / 2f) - (indicatorSizePx / 2f)
+          scaleX = indicatorScale
+          scaleY = indicatorScale
+          alpha = indicatorScale
+        }
+        .shadow(elevation = 4.dp, shape = CircleShape, clip = false)
+        .size(indicatorSize)
+        .clip(CircleShape)
+        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+        .padding(6.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      if (isRefreshing.value) {
+        // Indeterminate
+        LoadingIndicator(
+          polygons = expressivePolygons,
+          modifier = Modifier.fillMaxSize(),
+        )
+      } else {
+        // Determinate
+        LoadingIndicator(
+          progress = { state.distanceFraction.coerceIn(0f, 1f) },
+          polygons = expressivePolygons,
+          modifier = Modifier.fillMaxSize(),
+        )
+      }
+    }
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/dialogs/SortDialog.kt
@@ -36,6 +36,11 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.ripple
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.draw.scale
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -570,6 +575,30 @@ private fun ContentTogglesSection(
         Switch(
           checked = toggle.checked,
           onCheckedChange = toggle.onCheckedChange,
+          modifier = Modifier.scale(0.8f),
+          thumbContent = {
+            Crossfade(
+              targetState = toggle.checked,
+              animationSpec = tween(durationMillis = 200),
+              label = "SwitchIconAnimation"
+            ) { isChecked ->
+              if (isChecked) {
+                Icon(
+                  imageVector = Icons.Filled.Check,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+              } else {
+                Icon(
+                  imageVector = Icons.Filled.Close,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+              }
+            }
+          }
         )
       }
     }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/shorts/ShortsScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/shorts/ShortsScreen.kt
@@ -37,6 +37,10 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.draw.scale
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -728,7 +732,31 @@ private fun MoreActionsSheet(
                 trailingContent = {
                     Switch(
                         checked = isAutoSwipeEnabled,
-                        onCheckedChange = { onToggleAutoSwipe() }
+                        onCheckedChange = { onToggleAutoSwipe() },
+                        modifier = Modifier.scale(0.8f),
+                        thumbContent = {
+                            Crossfade(
+                                targetState = isAutoSwipeEnabled,
+                                animationSpec = tween(durationMillis = 200),
+                                label = "SwitchIconAnimation"
+                            ) { isChecked ->
+                                if (isChecked) {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = Icons.Filled.Close,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
                     )
                 },
                 modifier = Modifier.clickable { onToggleAutoSwipe() },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
@@ -35,6 +35,7 @@ import app.marlboroadvance.mpvex.ui.theme.spacing
 import `is`.xyz.mpv.MPVLib
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 
 @Composable
@@ -58,7 +59,7 @@ fun SubtitlesMiscellaneousCard(modifier: Modifier = Modifier) {
         var overrideAssSubs by remember {
           mutableStateOf(MPVLib.getPropertyString("sub-ass-override") == "force")
         }
-        SwitchPreference(
+        AnimatedIconSwitchPreference(
           overrideAssSubs,
           onValueChange = {
             overrideAssSubs = it
@@ -71,7 +72,7 @@ fun SubtitlesMiscellaneousCard(modifier: Modifier = Modifier) {
         var scaleByWindow by remember {
           mutableStateOf(MPVLib.getPropertyString("sub-scale-by-window") == "yes")
         }
-        SwitchPreference(
+        AnimatedIconSwitchPreference(
           scaleByWindow,
           onValueChange = {
             scaleByWindow = it

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
@@ -34,8 +34,7 @@ import app.marlboroadvance.mpvex.ui.player.controls.panelCardsColors
 import app.marlboroadvance.mpvex.ui.theme.spacing
 import `is`.xyz.mpv.MPVLib
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 
 @Composable
@@ -59,7 +58,7 @@ fun SubtitlesMiscellaneousCard(modifier: Modifier = Modifier) {
         var overrideAssSubs by remember {
           mutableStateOf(MPVLib.getPropertyString("sub-ass-override") == "force")
         }
-        AnimatedIconSwitchPreference(
+        SwitchPreference(
           overrideAssSubs,
           onValueChange = {
             overrideAssSubs = it
@@ -72,7 +71,7 @@ fun SubtitlesMiscellaneousCard(modifier: Modifier = Modifier) {
         var scaleByWindow by remember {
           mutableStateOf(MPVLib.getPropertyString("sub-scale-by-window") == "yes")
         }
-        AnimatedIconSwitchPreference(
+        SwitchPreference(
           scaleByWindow,
           onValueChange = {
             scaleByWindow = it

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/FrameNavigationSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/FrameNavigationSheet.kt
@@ -33,6 +33,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.draw.scale
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -563,6 +568,30 @@ private fun IncludeSubsToggle(
     Switch(
       checked = includeSubs,
       onCheckedChange = setIncludeSubs,
+      modifier = Modifier.scale(0.8f),
+      thumbContent = {
+        Crossfade(
+          targetState = includeSubs,
+          animationSpec = tween(durationMillis = 200),
+          label = "SwitchIconAnimation"
+        ) { isChecked ->
+          if (isChecked) {
+            Icon(
+              imageVector = Icons.Filled.Check,
+              contentDescription = null,
+              modifier = Modifier.size(SwitchDefaults.IconSize),
+              tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+          } else {
+            Icon(
+              imageVector = Icons.Filled.Close,
+              contentDescription = null,
+              modifier = Modifier.size(SwitchDefaults.IconSize),
+              tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+          }
+        }
+      }
     )
     Text(
       text = stringResource(R.string.player_sheets_frame_navigation_include_subtitles),

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
@@ -82,6 +82,7 @@ import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.getPlayerButtonLabel
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.components.PlayerSheet
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import app.marlboroadvance.mpvex.ui.player.Panels
 import app.marlboroadvance.mpvex.ui.player.PlayerActivity
 import app.marlboroadvance.mpvex.ui.player.PlayerViewModel
@@ -687,23 +688,21 @@ private fun InteractionSwitch(
   onCheckedChange: (Boolean) -> Unit,
 ) {
   Surface(
-    onClick = { onCheckedChange(!checked) },
     shape = MaterialTheme.shapes.medium,
     color = MaterialTheme.colorScheme.surfaceContainerLow,
     modifier = Modifier.fillMaxWidth()
   ) {
-    ListItem(
-      headlineContent = { Text(label, style = MaterialTheme.typography.bodyLarge) },
-      supportingContent = { Text(description, style = MaterialTheme.typography.bodySmall) },
-      trailingContent = {
-        Switch(
-          checked = checked,
-          onCheckedChange = onCheckedChange
-        )
-      },
-      colors = androidx.compose.material3.ListItemDefaults.colors(
-        containerColor = Color.Transparent
-      )
+    SwitchPreference(
+      value = checked,
+      onValueChange = onCheckedChange,
+      title = { Text(label, style = MaterialTheme.typography.bodyLarge) },
+      summary = { 
+        Text(
+          text = description, 
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.outline
+        ) 
+      }
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
@@ -58,8 +58,7 @@ import app.marlboroadvance.mpvex.presentation.components.SliderItem
 import app.marlboroadvance.mpvex.ui.theme.spacing
 import `is`.xyz.mpv.MPVLib
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 import app.marlboroadvance.mpvex.presentation.components.RepeatingIconButton
 import kotlin.math.pow
@@ -245,7 +244,7 @@ fun PlaybackSpeedSheet(
         // Audio Pitch Correction
         val pitchCorrection by audioPreferences.audioPitchCorrection.collectAsState()
         
-        AnimatedIconSwitchPreference(
+        SwitchPreference(
             value = pitchCorrection,
             onValueChange = { newValue ->
                 audioPreferences.audioPitchCorrection.set(newValue)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/PlaybackSpeedSheet.kt
@@ -59,6 +59,7 @@ import app.marlboroadvance.mpvex.ui.theme.spacing
 import `is`.xyz.mpv.MPVLib
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 import app.marlboroadvance.mpvex.presentation.components.RepeatingIconButton
 import kotlin.math.pow
@@ -244,41 +245,28 @@ fun PlaybackSpeedSheet(
         // Audio Pitch Correction
         val pitchCorrection by audioPreferences.audioPitchCorrection.collectAsState()
         
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { 
-                    val newValue = !pitchCorrection
-                    audioPreferences.audioPitchCorrection.set(newValue)
-                    MPVLib.setPropertyBoolean("audio-pitch-correction", newValue)
-                }
-                .padding(horizontal = MaterialTheme.spacing.medium, vertical = 2.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(modifier = Modifier.weight(1f).padding(end = 16.dp)) {
+        AnimatedIconSwitchPreference(
+            value = pitchCorrection,
+            onValueChange = { newValue ->
+                audioPreferences.audioPitchCorrection.set(newValue)
+                MPVLib.setPropertyBoolean("audio-pitch-correction", newValue)
+            },
+            title = {
                 Text(
                     text = stringResource(id = R.string.pref_audio_pitch_correction_title),
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold
                 )
+            },
+            summary = {
                 Text(
                     text = stringResource(id = R.string.pref_audio_pitch_correction_summary),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            }
-            androidx.compose.material3.Switch(
-                checked = pitchCorrection,
-                onCheckedChange = { 
-                    audioPreferences.audioPitchCorrection.set(it)
-                    MPVLib.setPropertyBoolean("audio-pitch-correction", it)
-                },
-                modifier = Modifier.scale(0.8f) // Make switch slightly smaller
-            )
-        }
-
-
+            },
+            switchModifier = Modifier.scale(0.8f)
+        )
       }
 
       Row(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/VideoZoomSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/VideoZoomSheet.kt
@@ -37,6 +37,12 @@ import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.components.PlayerSheet
 import app.marlboroadvance.mpvex.presentation.components.SliderItem
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.draw.scale
 import app.marlboroadvance.mpvex.ui.theme.spacing
 import `is`.xyz.mpv.MPVLib
 import org.koin.compose.koinInject
@@ -172,6 +178,30 @@ private fun ZoomVideoSheet(
         Switch(
           checked = panAndZoomEnabled,
           onCheckedChange = onPanAndZoomToggle,
+          modifier = Modifier.scale(0.8f),
+          thumbContent = {
+            Crossfade(
+              targetState = panAndZoomEnabled,
+              animationSpec = tween(durationMillis = 200),
+              label = "SwitchIconAnimation"
+            ) { isChecked ->
+              if (isChecked) {
+                Icon(
+                  imageVector = Icons.Filled.Check,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+              } else {
+                Icon(
+                  imageVector = Icons.Filled.Close,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+              }
+            }
+          }
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AboutScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AboutScreen.kt
@@ -60,6 +60,7 @@ import app.marlboroadvance.mpvex.presentation.crash.CrashActivity.Companion.coll
 import app.marlboroadvance.mpvex.ui.utils.LocalBackStack
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.Serializable
@@ -312,7 +313,7 @@ object AboutScreen : Screen {
         if (BuildConfig.ENABLE_UPDATE_FEATURE) {
           PreferenceSectionHeader(title = "Updates")
           PreferenceCard {
-            SwitchPreference(
+            AnimatedIconSwitchPreference(
               value = isAutoUpdateEnabled,
               onValueChange = { updateViewModel?.toggleAutoUpdate(it) },
               title = { Text("Auto Check for Updates") },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AboutScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AboutScreen.kt
@@ -59,8 +59,7 @@ import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.presentation.crash.CrashActivity.Companion.collectDeviceInfo
 import app.marlboroadvance.mpvex.ui.utils.LocalBackStack
 import me.zhanghai.compose.preference.Preference
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.Serializable
@@ -313,7 +312,7 @@ object AboutScreen : Screen {
         if (BuildConfig.ENABLE_UPDATE_FEATURE) {
           PreferenceSectionHeader(title = "Updates")
           PreferenceCard {
-            AnimatedIconSwitchPreference(
+            SwitchPreference(
               value = isAutoUpdateEnabled,
               onValueChange = { updateViewModel?.toggleAutoUpdate(it) },
               title = { Text("Auto Check for Updates") },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AdvancedPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AdvancedPreferencesScreen.kt
@@ -62,8 +62,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import me.zhanghai.compose.preference.TwoTargetIconButtonPreference
 import org.koin.compose.koinInject
 import java.io.File
@@ -450,7 +449,7 @@ object AdvancedPreferencesScreen : Screen {
               val selectedScripts by preferences.selectedLuaScripts.collectAsState()
               val enableLuaScripts by preferences.enableLuaScripts.collectAsState()
               
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = enableLuaScripts,
                 onValueChange = preferences.enableLuaScripts::set,
                 title = { Text("Enable Lua Scripts") },
@@ -521,7 +520,7 @@ object AdvancedPreferencesScreen : Screen {
               val mpvexDatabase = koinInject<MpvExDatabase>()
               val enableRecentlyPlayed by preferences.enableRecentlyPlayed.collectAsState()
               
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = enableRecentlyPlayed,
                 onValueChange = preferences.enableRecentlyPlayed::set,
                 title = { Text(stringResource(R.string.pref_advanced_enable_recently_played_title)) },
@@ -702,7 +701,7 @@ object AdvancedPreferencesScreen : Screen {
             PreferenceCard {
               val enableMediaInfoActivity by preferences.enableMediaInfoActivity.collectAsState()
 
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = enableMediaInfoActivity,
                 onValueChange = {
                   preferences.enableMediaInfoActivity.set(it)
@@ -730,7 +729,7 @@ object AdvancedPreferencesScreen : Screen {
               val clipboard = androidx.compose.ui.platform.LocalClipboardManager.current
               val verboseLogging by preferences.verboseLogging.collectAsState()
               
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = verboseLogging,
                 onValueChange = preferences.verboseLogging::set,
                 title = { Text(stringResource(R.string.pref_advanced_verbose_logging_title)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AdvancedPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AdvancedPreferencesScreen.kt
@@ -63,6 +63,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import me.zhanghai.compose.preference.TwoTargetIconButtonPreference
 import org.koin.compose.koinInject
 import java.io.File
@@ -449,7 +450,7 @@ object AdvancedPreferencesScreen : Screen {
               val selectedScripts by preferences.selectedLuaScripts.collectAsState()
               val enableLuaScripts by preferences.enableLuaScripts.collectAsState()
               
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = enableLuaScripts,
                 onValueChange = preferences.enableLuaScripts::set,
                 title = { Text("Enable Lua Scripts") },
@@ -520,7 +521,7 @@ object AdvancedPreferencesScreen : Screen {
               val mpvexDatabase = koinInject<MpvExDatabase>()
               val enableRecentlyPlayed by preferences.enableRecentlyPlayed.collectAsState()
               
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = enableRecentlyPlayed,
                 onValueChange = preferences.enableRecentlyPlayed::set,
                 title = { Text(stringResource(R.string.pref_advanced_enable_recently_played_title)) },
@@ -701,7 +702,7 @@ object AdvancedPreferencesScreen : Screen {
             PreferenceCard {
               val enableMediaInfoActivity by preferences.enableMediaInfoActivity.collectAsState()
 
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = enableMediaInfoActivity,
                 onValueChange = {
                   preferences.enableMediaInfoActivity.set(it)
@@ -729,7 +730,7 @@ object AdvancedPreferencesScreen : Screen {
               val clipboard = androidx.compose.ui.platform.LocalClipboardManager.current
               val verboseLogging by preferences.verboseLogging.collectAsState()
               
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = verboseLogging,
                 onValueChange = preferences.verboseLogging::set,
                 title = { Text(stringResource(R.string.pref_advanced_verbose_logging_title)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
@@ -37,6 +37,7 @@ import app.marlboroadvance.mpvex.preferences.BrowserPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.MultiChoiceSegmentedButton
 import app.marlboroadvance.mpvex.ui.preferences.components.ThemePicker
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.ui.theme.DarkMode
@@ -168,7 +169,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             // AMOLED mode toggle
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = amoledMode,
                                 onValueChange = { newValue ->
                                     preferences.amoledMode.set(newValue)
@@ -188,7 +189,7 @@ object AppearancePreferencesScreen : Screen {
                             // System font toggle
                             val useSystemFont by preferences.useSystemFont.collectAsState()
 
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = useSystemFont,
                                 onValueChange = { newValue ->
                                     preferences.useSystemFont.set(newValue)
@@ -205,7 +206,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val matchPlayerControlsToTheme by preferences.matchPlayerControlsToTheme.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = matchPlayerControlsToTheme,
                                 onValueChange = { preferences.matchPlayerControlsToTheme.set(it) },
                                 title = {
@@ -223,7 +224,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val hidePlayerButtonsBackground by preferences.hidePlayerButtonsBackground.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = hidePlayerButtonsBackground,
                                 onValueChange = { preferences.hidePlayerButtonsBackground.set(it) },
                                 title = {
@@ -241,7 +242,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val playerAlwaysDarkMode by preferences.playerAlwaysDarkMode.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = playerAlwaysDarkMode,
                                 onValueChange = { preferences.playerAlwaysDarkMode.set(it) },
                                 title = {
@@ -264,7 +265,7 @@ object AppearancePreferencesScreen : Screen {
                     item {
                         PreferenceCard {
                             val unlimitedNameLines by preferences.unlimitedNameLines.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = unlimitedNameLines,
                                 onValueChange = { preferences.unlimitedNameLines.set(it) },
                                 title = {
@@ -283,7 +284,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showUnplayedOldVideoLabel by preferences.showUnplayedOldVideoLabel.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = showUnplayedOldVideoLabel,
                                 onValueChange = { preferences.showUnplayedOldVideoLabel.set(it) },
                                 title = {
@@ -324,7 +325,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val autoScrollToLastPlayed by browserPreferences.autoScrollToLastPlayed.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = autoScrollToLastPlayed,
                                 onValueChange = { browserPreferences.autoScrollToLastPlayed.set(it) },
                                 title = {
@@ -363,7 +364,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showAudioFiles by browserPreferences.showAudioFiles.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = showAudioFiles,
                                 onValueChange = { browserPreferences.showAudioFiles.set(it) },
                                 title = {
@@ -388,7 +389,7 @@ object AppearancePreferencesScreen : Screen {
                     item {
                         PreferenceCard {
                             val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = tapThumbnailToSelect,
                                 onValueChange = { gesturePreferences.tapThumbnailToSelect.set(it) },
                                 title = {
@@ -407,7 +408,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showNetworkThumbnails by preferences.showNetworkThumbnails.collectAsState()
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = showNetworkThumbnails,
                                 onValueChange = { newValue ->
                                     if (newValue) {
@@ -469,7 +470,7 @@ object AppearancePreferencesScreen : Screen {
                                     text = stringResource(id = R.string.pref_appearance_thumbnail_strategy_summary),
                                     modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp, bottom = 12.dp),
                                     style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    color = MaterialTheme.colorScheme.outline,
                                 )
                                 MultiChoiceSegmentedButton(
                                     choices = persistentListOf(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AppearancePreferencesScreen.kt
@@ -37,7 +37,7 @@ import app.marlboroadvance.mpvex.preferences.BrowserPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.MultiChoiceSegmentedButton
 import app.marlboroadvance.mpvex.ui.preferences.components.ThemePicker
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.ui.theme.DarkMode
@@ -47,7 +47,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
-import me.zhanghai.compose.preference.SwitchPreference
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 import androidx.compose.runtime.remember
@@ -169,7 +168,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             // AMOLED mode toggle
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = amoledMode,
                                 onValueChange = { newValue ->
                                     preferences.amoledMode.set(newValue)
@@ -189,7 +188,7 @@ object AppearancePreferencesScreen : Screen {
                             // System font toggle
                             val useSystemFont by preferences.useSystemFont.collectAsState()
 
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = useSystemFont,
                                 onValueChange = { newValue ->
                                     preferences.useSystemFont.set(newValue)
@@ -206,7 +205,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val matchPlayerControlsToTheme by preferences.matchPlayerControlsToTheme.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = matchPlayerControlsToTheme,
                                 onValueChange = { preferences.matchPlayerControlsToTheme.set(it) },
                                 title = {
@@ -224,7 +223,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val hidePlayerButtonsBackground by preferences.hidePlayerButtonsBackground.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = hidePlayerButtonsBackground,
                                 onValueChange = { preferences.hidePlayerButtonsBackground.set(it) },
                                 title = {
@@ -242,7 +241,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val playerAlwaysDarkMode by preferences.playerAlwaysDarkMode.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = playerAlwaysDarkMode,
                                 onValueChange = { preferences.playerAlwaysDarkMode.set(it) },
                                 title = {
@@ -265,7 +264,7 @@ object AppearancePreferencesScreen : Screen {
                     item {
                         PreferenceCard {
                             val unlimitedNameLines by preferences.unlimitedNameLines.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = unlimitedNameLines,
                                 onValueChange = { preferences.unlimitedNameLines.set(it) },
                                 title = {
@@ -284,7 +283,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showUnplayedOldVideoLabel by preferences.showUnplayedOldVideoLabel.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = showUnplayedOldVideoLabel,
                                 onValueChange = { preferences.showUnplayedOldVideoLabel.set(it) },
                                 title = {
@@ -325,7 +324,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val autoScrollToLastPlayed by browserPreferences.autoScrollToLastPlayed.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = autoScrollToLastPlayed,
                                 onValueChange = { browserPreferences.autoScrollToLastPlayed.set(it) },
                                 title = {
@@ -364,7 +363,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showAudioFiles by browserPreferences.showAudioFiles.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = showAudioFiles,
                                 onValueChange = { browserPreferences.showAudioFiles.set(it) },
                                 title = {
@@ -389,7 +388,7 @@ object AppearancePreferencesScreen : Screen {
                     item {
                         PreferenceCard {
                             val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = tapThumbnailToSelect,
                                 onValueChange = { gesturePreferences.tapThumbnailToSelect.set(it) },
                                 title = {
@@ -408,7 +407,7 @@ object AppearancePreferencesScreen : Screen {
                             PreferenceDivider()
 
                             val showNetworkThumbnails by preferences.showNetworkThumbnails.collectAsState()
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = showNetworkThumbnails,
                                 onValueChange = { newValue ->
                                     if (newValue) {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AudioPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AudioPreferencesScreen.kt
@@ -33,6 +33,7 @@ import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import me.zhanghai.compose.preference.TextFieldPreference
 import org.koin.compose.koinInject
 
@@ -114,7 +115,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val audioPitchCorrection by preferences.audioPitchCorrection.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = audioPitchCorrection,
             onValueChange = { preferences.audioPitchCorrection.set(it) },
             title = { Text(stringResource(R.string.pref_audio_pitch_correction_title)) },
@@ -128,7 +129,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val volumeNormalization by preferences.volumeNormalization.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = volumeNormalization,
             onValueChange = { preferences.volumeNormalization.set(it) },
             title = { Text(stringResource(R.string.pref_audio_volume_normalization_title)) },
@@ -142,7 +143,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val automaticBackgroundPlayback by preferences.automaticBackgroundPlayback.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = automaticBackgroundPlayback,
             onValueChange = { preferences.automaticBackgroundPlayback.set(it) },
             title = { Text(stringResource(R.string.background_playback_title)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AudioPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/AudioPreferencesScreen.kt
@@ -32,8 +32,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import me.zhanghai.compose.preference.TextFieldPreference
 import org.koin.compose.koinInject
 
@@ -115,7 +114,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val audioPitchCorrection by preferences.audioPitchCorrection.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = audioPitchCorrection,
             onValueChange = { preferences.audioPitchCorrection.set(it) },
             title = { Text(stringResource(R.string.pref_audio_pitch_correction_title)) },
@@ -129,7 +128,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val volumeNormalization by preferences.volumeNormalization.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = volumeNormalization,
             onValueChange = { preferences.volumeNormalization.set(it) },
             title = { Text(stringResource(R.string.pref_audio_volume_normalization_title)) },
@@ -143,7 +142,7 @@ object AudioPreferencesScreen : Screen {
           
           PreferenceDivider()
           val automaticBackgroundPlayback by preferences.automaticBackgroundPlayback.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = automaticBackgroundPlayback,
             onValueChange = { preferences.automaticBackgroundPlayback.set(it) },
             title = { Text(stringResource(R.string.background_playback_title)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/DecoderPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/DecoderPreferencesScreen.kt
@@ -48,6 +48,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 
 @Serializable
@@ -114,7 +115,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               val tryHWDecoding by preferences.tryHWDecoding.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = tryHWDecoding,
                 onValueChange = {
                   preferences.tryHWDecoding.set(it)
@@ -126,7 +127,7 @@ object DecoderPreferencesScreen : Screen {
 
               val gpuNext by preferences.gpuNext.collectAsState()
               val useVulkan by preferences.useVulkan.collectAsState() // Added to check Vulkan state
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = gpuNext,
                 onValueChange = { enabled ->
                     if (enabled && !gpuNext && !useVulkan) { // Only show warning if Vulkan is disabled
@@ -195,7 +196,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               // val useVulkan by preferences.useVulkan.collectAsState() // Moved up for gpuNext logic
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = useVulkan,
                 onValueChange = { enabled ->
                   preferences.useVulkan.set(enabled)
@@ -242,7 +243,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               val useYUV420p by preferences.useYUV420P.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = useYUV420p,
                 onValueChange = {
                   preferences.useYUV420P.set(it)
@@ -259,7 +260,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
               
               val enableAnime4K by preferences.enableAnime4K.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = enableAnime4K,
                 onValueChange = { enabled ->
                     preferences.enableAnime4K.set(enabled)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/DecoderPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/DecoderPreferencesScreen.kt
@@ -47,8 +47,7 @@ import app.marlboroadvance.mpvex.ui.preferences.VulkanUtils
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 
 @Serializable
@@ -115,7 +114,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               val tryHWDecoding by preferences.tryHWDecoding.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = tryHWDecoding,
                 onValueChange = {
                   preferences.tryHWDecoding.set(it)
@@ -127,7 +126,7 @@ object DecoderPreferencesScreen : Screen {
 
               val gpuNext by preferences.gpuNext.collectAsState()
               val useVulkan by preferences.useVulkan.collectAsState() // Added to check Vulkan state
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = gpuNext,
                 onValueChange = { enabled ->
                     if (enabled && !gpuNext && !useVulkan) { // Only show warning if Vulkan is disabled
@@ -196,7 +195,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               // val useVulkan by preferences.useVulkan.collectAsState() // Moved up for gpuNext logic
-              AnimatedIconSwitchPreference(
+             SwitchPreference(
                 value = useVulkan,
                 onValueChange = { enabled ->
                   preferences.useVulkan.set(enabled)
@@ -243,7 +242,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
 
               val useYUV420p by preferences.useYUV420P.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = useYUV420p,
                 onValueChange = {
                   preferences.useYUV420P.set(it)
@@ -260,7 +259,7 @@ object DecoderPreferencesScreen : Screen {
               PreferenceDivider()
               
               val enableAnime4K by preferences.enableAnime4K.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = enableAnime4K,
                 onValueChange = { enabled ->
                     preferences.enableAnime4K.set(enabled)

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/GesturePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/GesturePreferencesScreen.kt
@@ -44,8 +44,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.FooterPreference
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 
 @Serializable
@@ -196,7 +195,7 @@ object GesturePreferencesScreen : Screen {
           PreferenceDivider()
 
           val reverseDoubleTap by preferences.reverseDoubleTap.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = reverseDoubleTap,
             onValueChange = { preferences.reverseDoubleTap.set(it) },
             title = { Text(text = stringResource(id = R.string.pref_gesture_reverse_double_tap_title)) },
@@ -275,7 +274,7 @@ object GesturePreferencesScreen : Screen {
           PreferenceDivider()
 
           val useSingleTapForCenter by preferences.useSingleTapForCenter.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = useSingleTapForCenter,
             onValueChange = { preferences.useSingleTapForCenter.set(it) },
             title = {
@@ -291,7 +290,7 @@ object GesturePreferencesScreen : Screen {
             },
           )
 
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = useSingleTapForLeftRight,
             onValueChange = { preferences.useSingleTapForLeftRight.set(it) },
             title = {
@@ -308,7 +307,7 @@ object GesturePreferencesScreen : Screen {
           )
 
           val preventSeekbarTap by preferences.preventSeekbarTap.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = preventSeekbarTap,
             onValueChange = { preferences.preventSeekbarTap.set(it) },
             title = {
@@ -324,7 +323,7 @@ object GesturePreferencesScreen : Screen {
           )
 
           val useRelativeSeeking by preferences.useRelativeSeeking.collectAsState()
-          AnimatedIconSwitchPreference(
+          SwitchPreference(
             value = useRelativeSeeking,
             onValueChange = { preferences.useRelativeSeeking.set(it) },
             title = {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/GesturePreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/GesturePreferencesScreen.kt
@@ -45,6 +45,7 @@ import me.zhanghai.compose.preference.FooterPreference
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 
 @Serializable
@@ -195,7 +196,7 @@ object GesturePreferencesScreen : Screen {
           PreferenceDivider()
 
           val reverseDoubleTap by preferences.reverseDoubleTap.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = reverseDoubleTap,
             onValueChange = { preferences.reverseDoubleTap.set(it) },
             title = { Text(text = stringResource(id = R.string.pref_gesture_reverse_double_tap_title)) },
@@ -274,7 +275,7 @@ object GesturePreferencesScreen : Screen {
           PreferenceDivider()
 
           val useSingleTapForCenter by preferences.useSingleTapForCenter.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = useSingleTapForCenter,
             onValueChange = { preferences.useSingleTapForCenter.set(it) },
             title = {
@@ -290,7 +291,7 @@ object GesturePreferencesScreen : Screen {
             },
           )
 
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = useSingleTapForLeftRight,
             onValueChange = { preferences.useSingleTapForLeftRight.set(it) },
             title = {
@@ -307,7 +308,7 @@ object GesturePreferencesScreen : Screen {
           )
 
           val preventSeekbarTap by preferences.preventSeekbarTap.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = preventSeekbarTap,
             onValueChange = { preferences.preventSeekbarTap.set(it) },
             title = {
@@ -323,7 +324,7 @@ object GesturePreferencesScreen : Screen {
           )
 
           val useRelativeSeeking by preferences.useRelativeSeeking.collectAsState()
-          SwitchPreference(
+          AnimatedIconSwitchPreference(
             value = useRelativeSeeking,
             onValueChange = { preferences.useRelativeSeeking.set(it) },
             title = {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
@@ -49,6 +49,7 @@ import app.marlboroadvance.mpvex.preferences.PlayerButton
 import app.marlboroadvance.mpvex.preferences.allPlayerButtons
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.SeekbarStyle
+import app.marlboroadvance.mpvex.ui.player.controls.components.SeekbarPreview
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.ui.utils.LocalBackStack
@@ -56,6 +57,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import me.zhanghai.compose.preference.SliderPreference
 import app.marlboroadvance.mpvex.ui.player.controls.components.sheets.toFixed
 import app.marlboroadvance.mpvex.ui.preferences.components.PlayerButtonChip
@@ -270,7 +272,7 @@ object PlayerControlsPreferencesScreen : Screen {
             val bottomControlsBelowSeekbar by playerPrefs.bottomControlsBelowSeekbar.collectAsState()
             
             PreferenceCard {
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = bottomControlsBelowSeekbar,
                 onValueChange = { playerPrefs.bottomControlsBelowSeekbar.set(it) },
                 title = {
@@ -305,7 +307,7 @@ object PlayerControlsPreferencesScreen : Screen {
             var customTimeValue by remember { mutableStateOf("") }
             
             PreferenceCard {
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = enableBounceAnimation,
                 onValueChange = { appearancePrefs.enableBounceAnimation.set(it) },
                 title = {
@@ -322,7 +324,7 @@ object PlayerControlsPreferencesScreen : Screen {
               
               PreferenceDivider()
 
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = hidePlayerButtonsBackground,
                 onValueChange = { appearancePrefs.hidePlayerButtonsBackground.set(it) },
                 title = {
@@ -339,7 +341,7 @@ object PlayerControlsPreferencesScreen : Screen {
               
               PreferenceDivider()
 
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = playerAlwaysDarkMode,
                 onValueChange = { appearancePrefs.playerAlwaysDarkMode.set(it) },
                 title = {
@@ -397,6 +399,7 @@ object PlayerControlsPreferencesScreen : Screen {
                     } else {
                       "$playerTimeToDisappear ms"
                     },
+                      color = MaterialTheme.colorScheme.outline,
                   )
                 },
               )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerControlsPreferencesScreen.kt
@@ -49,15 +49,13 @@ import app.marlboroadvance.mpvex.preferences.PlayerButton
 import app.marlboroadvance.mpvex.preferences.allPlayerButtons
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
 import app.marlboroadvance.mpvex.preferences.SeekbarStyle
-import app.marlboroadvance.mpvex.ui.player.controls.components.SeekbarPreview
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.ui.utils.LocalBackStack
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import me.zhanghai.compose.preference.SliderPreference
 import app.marlboroadvance.mpvex.ui.player.controls.components.sheets.toFixed
 import app.marlboroadvance.mpvex.ui.preferences.components.PlayerButtonChip
@@ -272,7 +270,7 @@ object PlayerControlsPreferencesScreen : Screen {
             val bottomControlsBelowSeekbar by playerPrefs.bottomControlsBelowSeekbar.collectAsState()
             
             PreferenceCard {
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = bottomControlsBelowSeekbar,
                 onValueChange = { playerPrefs.bottomControlsBelowSeekbar.set(it) },
                 title = {
@@ -307,7 +305,7 @@ object PlayerControlsPreferencesScreen : Screen {
             var customTimeValue by remember { mutableStateOf("") }
             
             PreferenceCard {
-              AnimatedIconSwitchPreference(
+            SwitchPreference(
                 value = enableBounceAnimation,
                 onValueChange = { appearancePrefs.enableBounceAnimation.set(it) },
                 title = {
@@ -324,7 +322,7 @@ object PlayerControlsPreferencesScreen : Screen {
               
               PreferenceDivider()
 
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = hidePlayerButtonsBackground,
                 onValueChange = { appearancePrefs.hidePlayerButtonsBackground.set(it) },
                 title = {
@@ -341,7 +339,7 @@ object PlayerControlsPreferencesScreen : Screen {
               
               PreferenceDivider()
 
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = playerAlwaysDarkMode,
                 onValueChange = { appearancePrefs.playerAlwaysDarkMode.set(it) },
                 title = {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -30,8 +30,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
@@ -98,7 +97,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = savePositionOnQuit,
                 onValueChange = preferences.savePositionOnQuit::set,
                 title = { Text(stringResource(R.string.pref_player_save_position_on_quit)) },
@@ -107,7 +106,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val closeAfterEndOfVideo by preferences.closeAfterReachingEndOfVideo.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = closeAfterEndOfVideo,
                 onValueChange = preferences.closeAfterReachingEndOfVideo::set,
                 title = { Text(stringResource(id = R.string.pref_player_close_after_eof)) },
@@ -116,7 +115,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val autoplayNextVideo by preferences.autoplayNextVideo.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = autoplayNextVideo,
                 onValueChange = preferences.autoplayNextVideo::set,
                 title = { Text(text = "Autoplay next video") },
@@ -134,7 +133,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val playlistMode by preferences.playlistMode.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = playlistMode,
                 onValueChange = preferences.playlistMode::set,
                 title = { Text(text = "Enable next/previous navigation") },
@@ -152,7 +151,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val rememberBrightness by preferences.rememberBrightness.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = rememberBrightness,
                 onValueChange = preferences.rememberBrightness::set,
                 title = { Text(text = stringResource(R.string.pref_player_remember_brightness)) },
@@ -161,7 +160,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val autoPiPOnNavigation by preferences.autoPiPOnNavigation.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = autoPiPOnNavigation,
                 onValueChange = preferences.autoPiPOnNavigation::set,
                 title = { Text("Auto Picture-in-Picture") },
@@ -176,7 +175,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val keepScreenOnWhenPaused by preferences.keepScreenOnWhenPaused.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = keepScreenOnWhenPaused,
                 onValueChange = preferences.keepScreenOnWhenPaused::set,
                 title = { Text("Keep screen on when paused") },
@@ -194,7 +193,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val resumeOnUnlock by preferences.resumeOnUnlock.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = resumeOnUnlock,
                 onValueChange = preferences.resumeOnUnlock::set,
                 title = { Text(stringResource(R.string.pref_player_resume_on_unlock_title)) },
@@ -218,7 +217,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val showDoubleTapOvals by preferences.showDoubleTapOvals.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showDoubleTapOvals,
                 onValueChange = preferences.showDoubleTapOvals::set,
                 title = { Text(stringResource(R.string.show_splash_ovals_on_double_tap_to_seek)) },
@@ -227,7 +226,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showSeekTimeWhileSeeking by preferences.showSeekTimeWhileSeeking.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showSeekTimeWhileSeeking,
                 onValueChange = preferences.showSeekTimeWhileSeeking::set,
                 title = { Text(stringResource(R.string.show_time_on_double_tap_to_seek)) },
@@ -236,7 +235,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val usePreciseSeeking by preferences.usePreciseSeeking.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = usePreciseSeeking,
                 onValueChange = preferences.usePreciseSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_use_precise_seeking)) },
@@ -245,7 +244,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val showSeekBarWhenSeeking by preferences.showSeekBarWhenSeeking.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showSeekBarWhenSeeking,
                 onValueChange = preferences.showSeekBarWhenSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_show_seekbar_when_seeking_title)) },
@@ -280,7 +279,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val brightnessGesture by preferences.brightnessGesture.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = brightnessGesture,
                 onValueChange = preferences.brightnessGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_brightness)) },
@@ -289,7 +288,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val volumeGesture by preferences.volumeGesture.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = volumeGesture,
                 onValueChange = preferences.volumeGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_volume)) },
@@ -298,7 +297,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val pinchToZoomGesture by preferences.pinchToZoomGesture.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = pinchToZoomGesture,
                 onValueChange = preferences.pinchToZoomGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_pinch_to_zoom)) },
@@ -307,7 +306,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val horizontalSwipeToSeek by preferences.horizontalSwipeToSeek.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = horizontalSwipeToSeek,
                 onValueChange = preferences.horizontalSwipeToSeek::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_horizontal_swipe_to_seek)) },
@@ -316,7 +315,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val swipeToSubtitleSeek by preferences.swipeToSubtitleSeek.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = swipeToSubtitleSeek,
                 onValueChange = preferences.swipeToSubtitleSeek::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_swipe_to_subtitle_seek_title)) },
@@ -367,15 +366,15 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showDynamicSpeedOverlay by preferences.showDynamicSpeedOverlay.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showDynamicSpeedOverlay,
                 onValueChange = preferences.showDynamicSpeedOverlay::set,
                 title = { Text("Dynamic Speed Overlay") },
-                summary = { 
+                summary = {
                   Text(
                     "Show advance overlay for speed control during long press and swipe",
                     color = MaterialTheme.colorScheme.outline,
-                  ) 
+                  )
                 }
               )
             }
@@ -388,7 +387,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val disableMediaButtons by preferences.disableMediaButtons.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = disableMediaButtons,
                 onValueChange = preferences.disableMediaButtons::set,
                 title = { Text(stringResource(id = R.string.pref_player_controls_disable_media_buttons_title)) },
@@ -403,7 +402,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val allowGesturesInPanels by preferences.allowGesturesInPanels.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = allowGesturesInPanels,
                 onValueChange = preferences.allowGesturesInPanels::set,
                 title = {
@@ -416,7 +415,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val swapVolumeAndBrightness by preferences.swapVolumeAndBrightness.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = swapVolumeAndBrightness,
                 onValueChange = preferences.swapVolumeAndBrightness::set,
                 title = { Text(stringResource(R.string.swap_the_volume_and_brightness_slider)) },
@@ -425,7 +424,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showLoadingCircle by preferences.showLoadingCircle.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showLoadingCircle,
                 onValueChange = preferences.showLoadingCircle::set,
                 title = { Text(stringResource(R.string.pref_player_controls_show_loading_circle)) },
@@ -440,7 +439,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val showSystemStatusBar by preferences.showSystemStatusBar.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showSystemStatusBar,
                 onValueChange = preferences.showSystemStatusBar::set,
                 title = { Text(stringResource(R.string.pref_player_display_show_status_bar)) },
@@ -449,7 +448,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val showSystemNavigationBar by preferences.showSystemNavigationBar.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = showSystemNavigationBar,
                 onValueChange = preferences.showSystemNavigationBar::set,
                 title = { Text("Show navigation bar with controls") },
@@ -458,7 +457,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val reduceMotion by preferences.reduceMotion.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = reduceMotion,
                 onValueChange = preferences.reduceMotion::set,
                 title = { Text(stringResource(R.string.pref_player_display_reduce_player_animation)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -31,6 +31,7 @@ import me.zhanghai.compose.preference.ListPreference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
@@ -97,7 +98,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = savePositionOnQuit,
                 onValueChange = preferences.savePositionOnQuit::set,
                 title = { Text(stringResource(R.string.pref_player_save_position_on_quit)) },
@@ -106,7 +107,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val closeAfterEndOfVideo by preferences.closeAfterReachingEndOfVideo.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = closeAfterEndOfVideo,
                 onValueChange = preferences.closeAfterReachingEndOfVideo::set,
                 title = { Text(stringResource(id = R.string.pref_player_close_after_eof)) },
@@ -115,7 +116,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val autoplayNextVideo by preferences.autoplayNextVideo.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = autoplayNextVideo,
                 onValueChange = preferences.autoplayNextVideo::set,
                 title = { Text(text = "Autoplay next video") },
@@ -133,7 +134,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val playlistMode by preferences.playlistMode.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = playlistMode,
                 onValueChange = preferences.playlistMode::set,
                 title = { Text(text = "Enable next/previous navigation") },
@@ -151,7 +152,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val rememberBrightness by preferences.rememberBrightness.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = rememberBrightness,
                 onValueChange = preferences.rememberBrightness::set,
                 title = { Text(text = stringResource(R.string.pref_player_remember_brightness)) },
@@ -160,7 +161,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val autoPiPOnNavigation by preferences.autoPiPOnNavigation.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = autoPiPOnNavigation,
                 onValueChange = preferences.autoPiPOnNavigation::set,
                 title = { Text("Auto Picture-in-Picture") },
@@ -175,7 +176,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val keepScreenOnWhenPaused by preferences.keepScreenOnWhenPaused.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = keepScreenOnWhenPaused,
                 onValueChange = preferences.keepScreenOnWhenPaused::set,
                 title = { Text("Keep screen on when paused") },
@@ -193,7 +194,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val resumeOnUnlock by preferences.resumeOnUnlock.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = resumeOnUnlock,
                 onValueChange = preferences.resumeOnUnlock::set,
                 title = { Text(stringResource(R.string.pref_player_resume_on_unlock_title)) },
@@ -217,7 +218,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val showDoubleTapOvals by preferences.showDoubleTapOvals.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showDoubleTapOvals,
                 onValueChange = preferences.showDoubleTapOvals::set,
                 title = { Text(stringResource(R.string.show_splash_ovals_on_double_tap_to_seek)) },
@@ -226,7 +227,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showSeekTimeWhileSeeking by preferences.showSeekTimeWhileSeeking.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showSeekTimeWhileSeeking,
                 onValueChange = preferences.showSeekTimeWhileSeeking::set,
                 title = { Text(stringResource(R.string.show_time_on_double_tap_to_seek)) },
@@ -235,7 +236,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val usePreciseSeeking by preferences.usePreciseSeeking.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = usePreciseSeeking,
                 onValueChange = preferences.usePreciseSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_use_precise_seeking)) },
@@ -244,7 +245,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val showSeekBarWhenSeeking by preferences.showSeekBarWhenSeeking.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showSeekBarWhenSeeking,
                 onValueChange = preferences.showSeekBarWhenSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_show_seekbar_when_seeking_title)) },
@@ -279,7 +280,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val brightnessGesture by preferences.brightnessGesture.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = brightnessGesture,
                 onValueChange = preferences.brightnessGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_brightness)) },
@@ -288,7 +289,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val volumeGesture by preferences.volumeGesture.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = volumeGesture,
                 onValueChange = preferences.volumeGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_volume)) },
@@ -297,7 +298,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val pinchToZoomGesture by preferences.pinchToZoomGesture.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = pinchToZoomGesture,
                 onValueChange = preferences.pinchToZoomGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_pinch_to_zoom)) },
@@ -306,7 +307,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val horizontalSwipeToSeek by preferences.horizontalSwipeToSeek.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = horizontalSwipeToSeek,
                 onValueChange = preferences.horizontalSwipeToSeek::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_horizontal_swipe_to_seek)) },
@@ -315,7 +316,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val swipeToSubtitleSeek by preferences.swipeToSubtitleSeek.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = swipeToSubtitleSeek,
                 onValueChange = preferences.swipeToSubtitleSeek::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_swipe_to_subtitle_seek_title)) },
@@ -366,7 +367,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showDynamicSpeedOverlay by preferences.showDynamicSpeedOverlay.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showDynamicSpeedOverlay,
                 onValueChange = preferences.showDynamicSpeedOverlay::set,
                 title = { Text("Dynamic Speed Overlay") },
@@ -387,7 +388,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val disableMediaButtons by preferences.disableMediaButtons.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = disableMediaButtons,
                 onValueChange = preferences.disableMediaButtons::set,
                 title = { Text(stringResource(id = R.string.pref_player_controls_disable_media_buttons_title)) },
@@ -402,7 +403,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val allowGesturesInPanels by preferences.allowGesturesInPanels.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = allowGesturesInPanels,
                 onValueChange = preferences.allowGesturesInPanels::set,
                 title = {
@@ -415,7 +416,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val swapVolumeAndBrightness by preferences.swapVolumeAndBrightness.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = swapVolumeAndBrightness,
                 onValueChange = preferences.swapVolumeAndBrightness::set,
                 title = { Text(stringResource(R.string.swap_the_volume_and_brightness_slider)) },
@@ -424,7 +425,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val showLoadingCircle by preferences.showLoadingCircle.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showLoadingCircle,
                 onValueChange = preferences.showLoadingCircle::set,
                 title = { Text(stringResource(R.string.pref_player_controls_show_loading_circle)) },
@@ -439,7 +440,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceCard {
               val showSystemStatusBar by preferences.showSystemStatusBar.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showSystemStatusBar,
                 onValueChange = preferences.showSystemStatusBar::set,
                 title = { Text(stringResource(R.string.pref_player_display_show_status_bar)) },
@@ -448,7 +449,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
 
               val showSystemNavigationBar by preferences.showSystemNavigationBar.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = showSystemNavigationBar,
                 onValueChange = preferences.showSystemNavigationBar::set,
                 title = { Text("Show navigation bar with controls") },
@@ -457,7 +458,7 @@ object PlayerPreferencesScreen : Screen {
               PreferenceDivider()
               
               val reduceMotion by preferences.reduceMotion.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = reduceMotion,
                 onValueChange = preferences.reduceMotion::set,
                 title = { Text(stringResource(R.string.pref_player_display_reduce_player_animation)) },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ShortsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ShortsPreferencesScreen.kt
@@ -32,6 +32,7 @@ import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
@@ -82,7 +83,7 @@ object ShortsPreferencesScreen : Screen {
 
                     item {
                         PreferenceCard {
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = enableShorts,
                                 onValueChange = { browserPreferences.enableShorts.set(it) },
                                 title = { Text("Enable RexShorts") },
@@ -98,7 +99,7 @@ object ShortsPreferencesScreen : Screen {
 
                             PreferenceDivider()
 
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = autoSwipeShorts,
                                 onValueChange = { browserPreferences.autoSwipeShorts.set(it) },
                                 title = { Text("Auto Swipe to Next Short") },
@@ -120,7 +121,7 @@ object ShortsPreferencesScreen : Screen {
 
                     item {
                         PreferenceCard {
-                            SwitchPreference(
+                            AnimatedIconSwitchPreference(
                                 value = includeHorizontal,
                                 onValueChange = { browserPreferences.includeShortHorizontalVideos.set(it) },
                                 title = { Text("Include Short Normal Videos") },
@@ -142,7 +143,12 @@ object ShortsPreferencesScreen : Screen {
                                 sliderValue = maxDuration.toFloat(),
                                 onSliderValueChange = { browserPreferences.maxHorizontalVideoDurationMinutes.set(it.roundToInt()) },
                                 title = { Text("Max Horizontal Duration") },
-                                summary = { Text("Limit horizontal videos to $maxDuration minute${if (maxDuration > 1) "s" else ""}") },
+                                summary = { 
+                                    Text(
+                                        text = "Limit horizontal videos to $maxDuration minute${if (maxDuration > 1) "s" else ""}",
+                                        color = MaterialTheme.colorScheme.outline
+                                    ) 
+                                },
                                 valueRange = 1f..10f,
                                 valueSteps = 9,
                                 enabled = includeHorizontal,
@@ -161,7 +167,12 @@ object ShortsPreferencesScreen : Screen {
                         PreferenceCard {
                             Preference(
                                 title = { Text("Blocked Videos") },
-                                summary = { Text("View and manage blocked shorts") },
+                                summary = { 
+                                    Text(
+                                        text = "View and manage blocked shorts",
+                                        color = MaterialTheme.colorScheme.outline
+                                    ) 
+                                },
                                 icon = {
                                     Icon(
                                         Icons.Outlined.Block,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ShortsPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/ShortsPreferencesScreen.kt
@@ -31,8 +31,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SliderPreference
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
@@ -83,7 +82,7 @@ object ShortsPreferencesScreen : Screen {
 
                     item {
                         PreferenceCard {
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = enableShorts,
                                 onValueChange = { browserPreferences.enableShorts.set(it) },
                                 title = { Text("Enable RexShorts") },
@@ -99,7 +98,7 @@ object ShortsPreferencesScreen : Screen {
 
                             PreferenceDivider()
 
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = autoSwipeShorts,
                                 onValueChange = { browserPreferences.autoSwipeShorts.set(it) },
                                 title = { Text("Auto Swipe to Next Short") },
@@ -121,7 +120,7 @@ object ShortsPreferencesScreen : Screen {
 
                     item {
                         PreferenceCard {
-                            AnimatedIconSwitchPreference(
+                            SwitchPreference(
                                 value = includeHorizontal,
                                 onValueChange = { browserPreferences.includeShortHorizontalVideos.set(it) },
                                 title = { Text("Include Short Normal Videos") },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -74,6 +74,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import me.zhanghai.compose.preference.SwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
 import me.zhanghai.compose.preference.TextFieldPreference
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -230,7 +231,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val autoload by preferences.autoloadMatchingSubtitles.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = autoload,
                 onValueChange = { preferences.autoloadMatchingSubtitles.set(it) },
                 title = { Text(stringResource(R.string.pref_subtitles_autoload_title)) },
@@ -245,7 +246,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val overrideAss by preferences.overrideAssSubs.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = overrideAss,
                 onValueChange = { preferences.overrideAssSubs.set(it) },
                 title = { Text(stringResource(R.string.player_sheets_sub_override_ass)) },
@@ -260,7 +261,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val scaleByWindow by preferences.scaleByWindow.collectAsState()
-              SwitchPreference(
+              AnimatedIconSwitchPreference(
                 value = scaleByWindow,
                 onValueChange = { preferences.scaleByWindow.set(it) },
                 title = { Text(stringResource(R.string.player_sheets_sub_scale_by_window)) },
@@ -395,7 +396,7 @@ object SubtitlesPreferencesScreen : Screen {
                   Text(
                     text = folderPath,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.outline,
                   )
                 }
               }
@@ -472,7 +473,7 @@ object SubtitlesPreferencesScreen : Screen {
                 
                 if (showAdvanced) {
                   Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                    SwitchPreference(
+                    AnimatedIconSwitchPreference(
                       value = wyzieHearingImpaired,
                       onValueChange = { preferences.wyzieHearingImpaired.set(it) },
                       title = { Text("Hearing-impaired friendly") },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -73,8 +73,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.Preference
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
-import me.zhanghai.compose.preference.SwitchPreference
-import app.marlboroadvance.mpvex.ui.preferences.components.AnimatedIconSwitchPreference
+import app.marlboroadvance.mpvex.ui.preferences.components.SwitchPreference
 import me.zhanghai.compose.preference.TextFieldPreference
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -231,7 +230,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val autoload by preferences.autoloadMatchingSubtitles.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = autoload,
                 onValueChange = { preferences.autoloadMatchingSubtitles.set(it) },
                 title = { Text(stringResource(R.string.pref_subtitles_autoload_title)) },
@@ -246,7 +245,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val overrideAss by preferences.overrideAssSubs.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = overrideAss,
                 onValueChange = { preferences.overrideAssSubs.set(it) },
                 title = { Text(stringResource(R.string.player_sheets_sub_override_ass)) },
@@ -261,7 +260,7 @@ object SubtitlesPreferencesScreen : Screen {
               PreferenceDivider()
 
               val scaleByWindow by preferences.scaleByWindow.collectAsState()
-              AnimatedIconSwitchPreference(
+              SwitchPreference(
                 value = scaleByWindow,
                 onValueChange = { preferences.scaleByWindow.set(it) },
                 title = { Text(stringResource(R.string.player_sheets_sub_scale_by_window)) },
@@ -473,7 +472,7 @@ object SubtitlesPreferencesScreen : Screen {
                 
                 if (showAdvanced) {
                   Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                    AnimatedIconSwitchPreference(
+                    SwitchPreference(
                       value = wyzieHearingImpaired,
                       onValueChange = { preferences.wyzieHearingImpaired.set(it) },
                       title = { Text("Hearing-impaired friendly") },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/components/AnimatedIconSwitchPreference.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/components/AnimatedIconSwitchPreference.kt
@@ -1,0 +1,99 @@
+package app.marlboroadvance.mpvex.ui.preferences.components
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AnimatedIconSwitchPreference(
+    value: Boolean,
+    onValueChange: (Boolean) -> Unit,
+    title: @Composable () -> Unit,
+    summary: @Composable (() -> Unit)? = null,
+    icon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    titleStyle: TextStyle = MaterialTheme.typography.bodyLarge,
+    summaryStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    switchModifier: Modifier = Modifier
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled) { onValueChange(!value) }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (icon != null) {
+            Box(
+                modifier = Modifier.padding(end = 16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                icon()
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 16.dp)
+        ) {
+            ProvideTextStyle(value = titleStyle) {
+                title()
+            }
+            if (summary != null) {
+                ProvideTextStyle(value = summaryStyle.copy(color = MaterialTheme.colorScheme.outline)) {
+                    summary()
+                }
+            }
+        }
+
+        Switch(
+            checked = value,
+            onCheckedChange = onValueChange,
+            enabled = enabled,
+            modifier = switchModifier,
+            thumbContent = {
+                Crossfade(
+                    targetState = value,
+                    animationSpec = tween(durationMillis = 200),
+                    label = "SwitchIconAnimation"
+                ) { isChecked ->
+                    if (isChecked) {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = null,
+                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/components/SwitchPreference.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/components/SwitchPreference.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun AnimatedIconSwitchPreference(
+fun SwitchPreference(
     value: Boolean,
     onValueChange: (Boolean) -> Unit,
     title: @Composable () -> Unit,


### PR DESCRIPTION
This PR updates key UI components to provide better state visibility and align the app with a more modern design language.

### Changes Included

- **Pull-to-refresh**: Replaced the standard animation with a new shape-based loading indicator.
- **Toggle Switches**: Replaced standard Material switches with expressive toggles (`AnimatedIconSwitchPreference`) that feature dynamic check/close icons for immediate state feedback.

wanted to add other UI redesign changes to this PR. To keep this review scope manageable, I think it is better to make separate PR for them. 
- volume and brightness slider
- sort and view option ( more like nextplayer )

 what do you think?
 
 ---
 # Screenshots

<table>
  <tr>
    <th align="center">Pull to refresh</th>
    <th align="center">Expressive Toggle</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f27be1cf-85f1-4719-862b-be74df98b89b" width="300" alt="Screenshot 1"></td>
    <td><img src="https://github.com/user-attachments/assets/22672f2a-a8d1-46c1-8d39-e2e914c0448a" width="300" alt="Screenshot 2"></td>
  </tr>
</table>

