### PR TITLE
perf: uncap SMB bandwidth and overhaul thumbnail extraction pipeline

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailBitmapUtils.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailBitmapUtils.kt
@@ -1,0 +1,88 @@
+package app.marlboroadvance.mpvex.domain.thumbnail
+
+import android.graphics.Bitmap
+import kotlin.math.abs
+
+internal const val MAX_THUMBNAIL_SIZE = 512
+
+internal fun calculateThumbnailSampleSize(
+  width: Int,
+  height: Int,
+  maxSize: Int = MAX_THUMBNAIL_SIZE,
+): Int {
+  if (width <= maxSize && height <= maxSize) return 1
+  var inSampleSize = 1
+  val maxDimension = maxOf(width, height)
+  while (maxDimension / (inSampleSize * 2) >= maxSize) {
+    inSampleSize *= 2
+  }
+  return inSampleSize
+}
+
+internal fun Bitmap.scaleToThumbnailMax(maxSize: Int = MAX_THUMBNAIL_SIZE): Bitmap {
+  if (width <= maxSize && height <= maxSize) return this
+  val scale = maxSize.toFloat() / maxOf(width, height)
+  val scaledWidth = (width * scale).toInt().coerceAtLeast(1)
+  val scaledHeight = (height * scale).toInt().coerceAtLeast(1)
+  val scaled = Bitmap.createScaledBitmap(this, scaledWidth, scaledHeight, true)
+  if (scaled !== this && !isRecycled) recycle()
+  return scaled
+}
+
+internal fun isMostlySolidThumbnail(
+  bitmap: Bitmap,
+  threshold: Float = 0.7f,
+): Boolean {
+  val width = bitmap.width
+  val height = bitmap.height
+  if (width <= 0 || height <= 0) return false
+
+  val marginX = width / 10
+  val marginY = height / 10
+  val sampleAreaRight = width - marginX
+  val sampleAreaBottom = height - marginY
+  val gridSize = 10
+  val stepX = (sampleAreaRight - marginX) / gridSize
+  val stepY = (sampleAreaBottom - marginY) / gridSize
+
+  if (stepX <= 0 || stepY <= 0) return false
+
+  val sampledColors = IntArray(gridSize * gridSize)
+  var validSampleCount = 0
+
+  for (x in 0 until gridSize) {
+    for (y in 0 until gridSize) {
+      val pixelX = marginX + x * stepX
+      val pixelY = marginY + y * stepY
+      if (pixelX in 0 until width && pixelY in 0 until height) {
+        sampledColors[validSampleCount++] = bitmap.getPixel(pixelX, pixelY)
+      }
+    }
+  }
+
+  if (validSampleCount == 0) return false
+
+  val referenceColor = sampledColors[0]
+  val referenceR = (referenceColor shr 16) and 0xFF
+  val referenceG = (referenceColor shr 8) and 0xFF
+  val referenceB = referenceColor and 0xFF
+  val tolerance = 30
+
+  // Iterate only up to validSampleCount to avoid trailing zeroes
+  var similarCount = 0
+  for (i in 0 until validSampleCount) {
+    val color = sampledColors[i]
+    val r = (color shr 16) and 0xFF
+    val g = (color shr 8) and 0xFF
+    val b = color and 0xFF
+
+    if (kotlin.math.abs(r - referenceR) <= tolerance &&
+        kotlin.math.abs(g - referenceG) <= tolerance &&
+        kotlin.math.abs(b - referenceB) <= tolerance) {
+        similarCount++
+    }
+  }
+
+  // Calculate threshold based strictly on valid samples
+  return similarCount.toFloat() / validSampleCount >= threshold
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailRepository.kt
@@ -6,6 +6,8 @@ import android.graphics.BitmapFactory
 import android.util.LruCache
 import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.utils.media.MediaInfoOps
+import app.marlboroadvance.mpvex.ui.browser.networkstreaming.proxy.NetworkStreamingProxy
+import app.marlboroadvance.mpvex.domain.network.NetworkConnection
 import `is`.xyz.mpv.FastThumbnails
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -710,5 +712,100 @@ class ThumbnailRepository(
       md.update(";".toByteArray())
     }
     return md.digest().joinToString("") { b -> "%02x".format(b) }
+  }
+  
+  
+/**
+ * Resolves network video thumbnails via a localized proxy stream.
+ * 
+ * Strategy: MemCache -> DiskCache -> Proxy Extraction -> Cache/Fail.
+ * Bypasses network extraction limits by registering a temporary [NetworkStreamingProxy] 
+ * stream and feeding a mocked localhost URI to standard extractors. Guarantees proxy cleanup.
+ */
+  suspend fun getThumbnailViaProxy(
+    path: String,
+    name: String,
+    size: Long,
+    connection: NetworkConnection,
+    dimension: Int
+  ): Bitmap? = withContext(Dispatchers.IO) {
+    if (!appearancePreferences.showNetworkThumbnails.get()) return@withContext null
+
+    val videoKey = "$path|networkProxy|$dimension"
+    
+    if (networkThumbnailFailed.containsKey(path)) return@withContext null
+
+    // Check Memory Cache
+    memoryCache.get(videoKey)?.let { return@withContext it }
+
+    // Check Disk Cache
+    val diskFile = File(networkDiskDir, keyToFileName(videoKey))
+    if (diskFile.exists()) {
+      runCatching {
+        BitmapFactory.decodeFile(diskFile.absolutePath)
+      }.getOrNull()?.let {
+        memoryCache.put(videoKey, it)
+        return@withContext it
+      }
+    }
+
+    // Spin up Proxy
+    val proxy = NetworkStreamingProxy.getInstance()
+    val streamId = "thumb_${path.hashCode()}_${System.nanoTime()}"
+
+    val localUrl = proxy.registerStream(
+      streamId = streamId,
+      connection = connection,
+      filePath = path,
+      fileSize = size
+    )
+
+    var bitmap: Bitmap? = null
+    try {
+      // Create a dummy Video object with the LOCALHOST URL to trick the extractors
+      val tempVideo = Video(
+        id = path.hashCode().toLong(),
+        title = name,
+        displayName = name,
+        path = localUrl,
+        uri = android.net.Uri.parse(localUrl),
+        duration = 0,
+        durationFormatted = "",
+        size = size,
+        sizeFormatted = "",
+        dateModified = 0,
+        dateAdded = 0,
+        mimeType = "video/*",
+        bucketId = "",
+        bucketDisplayName = "",
+        width = 0,
+        height = 0,
+        fps = 0f,
+        resolution = ""
+      )
+
+      // Extract using existing logic
+      bitmap = generateWithFastThumbnails(tempVideo, dimension)
+      if (bitmap == null) {
+        bitmap = generateWithMediaMetadataRetriever(tempVideo, dimension)
+      }
+    } finally {
+      // kill the proxy stream to prevent memory/connection leaks
+      proxy.unregisterStream(streamId)
+    }
+
+    // Cache or mark as failed
+    if (bitmap != null) {
+      memoryCache.put(videoKey, bitmap)
+      runCatching {
+        FileOutputStream(diskFile).use { out ->
+          bitmap.compress(Bitmap.CompressFormat.JPEG, diskJpegQuality, out)
+        }
+      }
+    } else {
+      networkThumbnailFailed[path] = true
+    }
+
+    return@withContext bitmap
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/domain/thumbnail/ThumbnailRepository.kt
@@ -8,6 +8,8 @@ import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.utils.media.MediaInfoOps
 import app.marlboroadvance.mpvex.ui.browser.networkstreaming.proxy.NetworkStreamingProxy
 import app.marlboroadvance.mpvex.domain.network.NetworkConnection
+import app.marlboroadvance.mpvex.domain.thumbnail.isMostlySolidThumbnail
+import app.marlboroadvance.mpvex.domain.thumbnail.scaleToThumbnailMax
 import `is`.xyz.mpv.FastThumbnails
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -125,40 +127,73 @@ class ThumbnailRepository(
 
             val videoKey = videoBaseKey(video)
             val thumbnail = if (isNetworkUrl(video.path)) {
+              
               // ---- Network path ------------------------------------------------
               // Android's native MediaStore cannot handle network URLs properly,
-              // FastThumbnails  ->  MediaMetadataRetriever
+              // MediaMetadataRetriever -> FastThumbnails
               // Once both fail record it to avoid re-trying on every scroll.
               if (networkThumbnailFailed.containsKey(videoKey)) {
                 android.util.Log.d("ThumbnailRepository", "Skipping network thumbnail (previously failed): ${video.displayName}")
                 null
               } else {
+                // Priority 1: MediaMetadataRetriever (10s, 15s with solid check)
+                val retrieverResult = generateWithMediaMetadataRetriever(video, diskCacheDimension)
+                if (retrieverResult != null) {
+                  retrieverResult
+                } else {
+                  // Fallback: FastThumbnails (10s only, no solid check)
+                  android.util.Log.w("ThumbnailRepository", "Retriever failed for network stream ${video.displayName}, trying FastThumbnails")
+                  val fastResult = generateWithFastThumbnails(video, diskCacheDimension)
+                  if (fastResult == null) {
+                    android.util.Log.w("ThumbnailRepository", "All strategies failed for network stream ${video.displayName}")
+                    networkThumbnailFailed[videoKey] = true
+                  }
+                  fastResult
+                }
+              }
+            } else {
+              
+              // ---- Local-file path ---------------------------------------------
+              // For local videos, we can be more aggressive about trying to find a good thumbnail:
+              // Short videos: (<2 min) get priority for MediaStore 
+              // Longer videos: FastThumbnails -> MediaMetadataRetriever -> MediaStore
+              val isShortVideo = video.duration in 1L..120_000L
+
+              // If it's a short video, or we already know heavy extractors fail on this file, go straight to MediaStore
+              if (useMediaStoreForVideo.containsKey(videoKey) || isShortVideo) {
+                val storeResult = generateWithMediaStore(video, diskCacheDimension)
+                
+                if (storeResult != null) {
+                  storeResult
+                } else if (isShortVideo) {
+                  // If MediaStore inexplicably fails on a short video, run through the standard heavy fallback
+                  android.util.Log.w("ThumbnailRepository", "MediaStore failed for short video ${video.displayName}, falling back to FastThumbnails")
+                  val fastResult = generateWithFastThumbnails(video, diskCacheDimension)
+                  if (fastResult != null) {
+                    fastResult
+                  } else {
+                    generateWithMediaMetadataRetriever(video, diskCacheDimension)
+                  }
+                } else {
+                  null
+                }
+              } else {
+                // For videos > 120s: Priority 1 - FastThumbnails (10s, 20s, 30s)
                 val fastResult = generateWithFastThumbnails(video, diskCacheDimension)
                 if (fastResult != null) {
                   fastResult
                 } else {
-                  android.util.Log.w("ThumbnailRepository", "FastThumbnails failed for network stream ${video.displayName}, trying MediaMetadataRetriever")
+                  // Fallback 1: MediaMetadataRetriever (10s, 15s)
+                  android.util.Log.w("ThumbnailRepository", "FastThumbnails failed for local ${video.displayName}, trying Retriever")
                   val retrieverResult = generateWithMediaMetadataRetriever(video, diskCacheDimension)
-                  if (retrieverResult == null) {
-                    android.util.Log.w("ThumbnailRepository", "All strategies failed for network stream ${video.displayName}")
-                    networkThumbnailFailed[videoKey] = true
+                  if (retrieverResult != null) {
+                    retrieverResult
+                  } else {
+                    // Fallback 2: MediaStore & ThumbnailUtils
+                    android.util.Log.w("ThumbnailRepository", "Retriever failed for local ${video.displayName}, falling back to MediaStore")
+                    useMediaStoreForVideo[videoKey] = true
+                    generateWithMediaStore(video, diskCacheDimension)
                   }
-                  retrieverResult
-                }
-              }
-            } else {
-              // ---- Local-file path ---------------------------------------------
-              if (useMediaStoreForVideo.containsKey(videoKey)) {
-                android.util.Log.d("ThumbnailRepository", "Using MediaStore for ${video.displayName}")
-                generateWithMediaStore(video, diskCacheDimension)
-              } else {
-                val fastResult = generateWithFastThumbnails(video, diskCacheDimension)
-                if (fastResult == null) {
-                  android.util.Log.w("ThumbnailRepository", "FastThumbnails failed for ${video.displayName}, falling back to MediaStore")
-                  useMediaStoreForVideo[videoKey] = true
-                  generateWithMediaStore(video, diskCacheDimension)
-                } else {
-                  fastResult
                 }
               }
             }
@@ -350,21 +385,14 @@ class ThumbnailRepository(
     }
   }
 
-  private fun loadFromDisk(video: Video): Bitmap? {
+  private fun loadFromDisk(video: Video, targetDimension: Int = diskCacheDimension): Bitmap? {
     val diskFile = File(diskDirFor(video), keyToFileName(diskKey(video)))
     if (!diskFile.exists()) {
       android.util.Log.d("ThumbnailRepository", "Disk cache MISS: ${diskFile.name} for ${video.displayName}")
       return null
     }
     android.util.Log.d("ThumbnailRepository", "Disk cache HIT: ${diskFile.name} for ${video.displayName}")
-    return runCatching {
-      val options = BitmapFactory.Options().apply {
-          inPreferredConfig = Bitmap.Config.ARGB_8888
-        }
-      BitmapFactory.decodeFile(diskFile.absolutePath, options)
-    }.onFailure { e ->
-      android.util.Log.e("ThumbnailRepository", "loadFromDisk decode FAILED for ${video.displayName}", e)
-    }.getOrNull()
+    return decodeFileSafely(diskFile.absolutePath, targetDimension)
   }
 
   private fun writeToDisk(video: Video, bitmap: Bitmap) {
@@ -379,6 +407,21 @@ class ThumbnailRepository(
       android.util.Log.e("ThumbnailRepository", "writeToDisk FAILED for ${video.displayName}", e)
     }
   }
+  
+  private fun decodeFileSafely(filePath: String, targetDimension: Int): Bitmap? {
+    return runCatching {
+      val options = BitmapFactory.Options().apply {
+        inJustDecodeBounds = true
+        BitmapFactory.decodeFile(filePath, this)
+        inSampleSize = calculateThumbnailSampleSize(outWidth, outHeight, targetDimension)
+        inJustDecodeBounds = false
+        inPreferredConfig = Bitmap.Config.ARGB_8888
+      }
+      BitmapFactory.decodeFile(filePath, options)
+    }.onFailure { e ->
+      android.util.Log.e("ThumbnailRepository", "Safe decode FAILED for $filePath", e)
+    }.getOrNull()
+  }
 
   private suspend fun rotateIfNeeded(
     video: Video,
@@ -391,6 +434,11 @@ class ThumbnailRepository(
     return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
   }
 
+  /**
+   * Software Decoder. Highly CPU-intensive fallback for unsupported codecs.
+   * - Network: Single attempt (10s), no solid-frame evasion (saves bandwidth).
+   * - Local: Multi-pass (10s, 20s, 30s) with solid-frame evasion.
+   */
   private suspend fun generateWithFastThumbnails(
     video: Video,
     dimension: Int,
@@ -400,30 +448,55 @@ class ThumbnailRepository(
     // Additional extension-based safety check
     val extension = video.path.substringAfterLast(".", "").lowercase()
     val audioExtensions = setOf("mp3", "wav", "flac", "ogg", "m4a", "aac", "wma", "opus", "m4p", "amr")
-    if (extension in audioExtensions) {
-      android.util.Log.d("ThumbnailRepository", "Skipping FastThumbnails for suspected audio extension: $extension")
-      return null
-    }
-
-    // MIME type check
-    if (video.mimeType.startsWith("audio/", ignoreCase = true)) {
-      android.util.Log.d("ThumbnailRepository", "Skipping FastThumbnails for audio MIME type: ${video.mimeType}")
-      return null
-    }
+    if (extension in audioExtensions || video.mimeType.startsWith("audio/", ignoreCase = true)) return null
     
+    val isNetwork = isNetworkUrl(video.path)
+    val durationSec = video.duration / 1000.0
+
     return try {
-      val positionSec = preferredPositionSeconds(video)
-      
-      val bmp = FastThumbnails.generateAsync(
-          video.path.ifBlank { video.uri.toString() },
-          positionSec,
-          dimension,
-          useHwDec = false
-      ) ?: return null
-      rotateIfNeeded(video, bmp)
+      if (isNetwork) {
+        // Network: Try 10s mark only. No solid check.
+        val targetPosition = if (durationSec > 0) minOf(10.0, max(0.0, durationSec - 1.0)) else 10.0
+        val bmp = FastThumbnails.generateAsync(
+            video.path.ifBlank { video.uri.toString() },
+            targetPosition,
+            dimension,
+            useHwDec = false
+        ) ?: return null
+        return rotateIfNeeded(video, bmp)
+      } else {
+        // Local: Check 10s, 20s, 30s. Skip solid frames.
+        val attemptOffsets = listOf(10.0, 20.0, 30.0)
+        var lastSolidBitmap: Bitmap? = null
+
+        for (offset in attemptOffsets) {
+          val targetPosition = if (durationSec > 0) minOf(offset, max(0.0, durationSec - 1.0)) else offset
+
+          val bmp = FastThumbnails.generateAsync(
+              video.path.ifBlank { video.uri.toString() },
+              targetPosition,
+              dimension,
+              useHwDec = false
+          ) ?: continue
+
+          if (isMostlySolidThumbnail(bmp)) {
+            lastSolidBitmap?.recycle()
+            lastSolidBitmap = bmp
+            continue
+          }
+          
+          lastSolidBitmap?.recycle()
+          return rotateIfNeeded(video, bmp)
+        }
+        
+        if (lastSolidBitmap != null) {
+          return rotateIfNeeded(video, lastSolidBitmap)
+        }
+
+        return null
+      }
     } catch (e: Throwable) {
-      android.util.Log.e("ThumbnailRepository", "FastThumbnails crashed for ${video.displayName}", e)
-      null
+      return null
     }
   }
 
@@ -580,80 +653,59 @@ class ThumbnailRepository(
   }
 
   /**
-   * Extracts a thumbnail from a network stream (HLS, HTTP MP4, RTSP, etc.) using
-   * [android.media.MediaMetadataRetriever].  Seeks to 10s of the duration when the
-   * server reports it; falls back to 2 s for live / unknown-duration streams.
+   * Hardware Decoder. Battery-efficient primary extractor for network 
+   * streams, and low-cost fallback for local files.
+   * - Evaluates 10s and 15s offsets with solid-frame evasion.
    */
   private suspend fun generateWithMediaMetadataRetriever(
     video: Video,
     dimension: Int,
   ): Bitmap? = withContext(Dispatchers.IO) {
     val url = video.path.ifBlank { video.uri.toString() }
-    android.util.Log.d("ThumbnailRepository", "MediaMetadataRetriever: extracting frame from $url")
-
     val retriever = android.media.MediaMetadataRetriever()
+    var lastSolidBitmap: Bitmap? = null
+
     try {
-      // Empty-headers map is required for the network overload on all API levels
       retriever.setDataSource(url, emptyMap<String, String>())
-
-      // Prefer the duration reported by the stream; fall back to what the Video model says
-      val streamDurationMs = retriever
-        .extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION)
-        ?.toLongOrNull()
-        ?.takeIf { it > 0L }
+      val streamDurationMs = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull()?.takeIf { it > 0L }
       val durationMs = streamDurationMs ?: video.duration.takeIf { it > 0L }
+      
+      val attemptOffsetsUs = listOf(10_000_000L, 15_000_000L)
 
-      // Position in microseconds (MediaMetadataRetriever uses microsecond units)
-      val positionUs: Long = if (durationMs != null && durationMs > 0L) {
-        val maxSafePositionUs = (durationMs - 100L).coerceAtLeast(0L) * 1000L
-          minOf(10_000_000L, maxSafePositionUs)
-      } else {
-          10_000_000L
+      for (offsetUs in attemptOffsetsUs) {
+        val positionUs: Long = if (durationMs != null && durationMs > 0L) {
+          minOf(offsetUs, (durationMs - 100L).coerceAtLeast(0L) * 1000L)
+        } else {
+          offsetUs
+        }
+
+        val frame: Bitmap? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1) {
+          runCatching { retriever.getScaledFrameAtTime(positionUs, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC, dimension, dimension) }.getOrNull()
+            ?: retriever.getFrameAtTime(positionUs, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC)?.scaleToThumbnailMax(dimension)
+        } else {
+          retriever.getFrameAtTime(positionUs, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC)?.scaleToThumbnailMax(dimension)
+        }
+
+        if (frame == null) continue 
+
+        if (isMostlySolidThumbnail(frame)) {
+          lastSolidBitmap?.recycle()
+          lastSolidBitmap = frame
+          continue
+        }
+
+        lastSolidBitmap?.recycle()
+        return@withContext rotateIfNeeded(video, frame)
       }
 
-      android.util.Log.d(
-        "ThumbnailRepository",
-        "MediaMetadataRetriever: seeking to ${positionUs / 1_000_000.0}s (duration=${durationMs}ms) for ${video.displayName}"
-      )
-
-      val frame: Bitmap? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O_MR1) {
-        // API 27+ – returns already-scaled bitmap, avoids an extra allocation
-        retriever.getScaledFrameAtTime(
-          positionUs,
-          android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
-          dimension,
-          dimension,
-        )
-      } else {
-        // Older APIs – get raw frame then scale down
-        retriever.getFrameAtTime(positionUs, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
-          ?.let { raw ->
-            val scale = dimension.toFloat() / maxOf(raw.width, raw.height).toFloat()
-            if (scale >= 1f) {
-              raw
-            } else {
-              val scaled = Bitmap.createScaledBitmap(
-                raw,
-                (raw.width * scale).toInt().coerceAtLeast(1),
-                (raw.height * scale).toInt().coerceAtLeast(1),
-                true,
-              )
-              if (scaled !== raw) raw.recycle()
-              scaled
-            }
-          }
+      if (lastSolidBitmap != null) {
+        return@withContext rotateIfNeeded(video, lastSolidBitmap)
       }
 
-      if (frame == null) {
-        android.util.Log.w("ThumbnailRepository", "MediaMetadataRetriever returned null frame for ${video.displayName}")
-        return@withContext null
-      }
-
-      android.util.Log.d("ThumbnailRepository", "MediaMetadataRetriever: frame extracted (${frame.width}x${frame.height}) for ${video.displayName}")
-      rotateIfNeeded(video, frame)
+      return@withContext null
     } catch (e: Throwable) {
-      android.util.Log.e("ThumbnailRepository", "MediaMetadataRetriever failed for ${video.displayName}", e)
-      null
+      lastSolidBitmap?.recycle()
+      return@withContext null
     } finally {
       runCatching { retriever.release() }
     }
@@ -741,9 +793,7 @@ class ThumbnailRepository(
     // Check Disk Cache
     val diskFile = File(networkDiskDir, keyToFileName(videoKey))
     if (diskFile.exists()) {
-      runCatching {
-        BitmapFactory.decodeFile(diskFile.absolutePath)
-      }.getOrNull()?.let {
+      decodeFileSafely(diskFile.absolutePath, dimension)?.let {
         memoryCache.put(videoKey, it)
         return@withContext it
       }
@@ -785,9 +835,9 @@ class ThumbnailRepository(
       )
 
       // Extract using existing logic
-      bitmap = generateWithFastThumbnails(tempVideo, dimension)
+      bitmap = generateWithMediaMetadataRetriever(tempVideo, dimension)
       if (bitmap == null) {
-        bitmap = generateWithMediaMetadataRetriever(tempVideo, dimension)
+        bitmap = generateWithFastThumbnails(tempVideo, dimension)
       }
     } finally {
       // kill the proxy stream to prevent memory/connection leaks

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/NetworkVideoCard.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/cards/NetworkVideoCard.kt
@@ -1,43 +1,27 @@
 package app.marlboroadvance.mpvex.ui.browser.cards
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import app.marlboroadvance.mpvex.preferences.AppearancePreferences
-import app.marlboroadvance.mpvex.preferences.BrowserPreferences
-import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.domain.network.NetworkConnection
 import app.marlboroadvance.mpvex.domain.network.NetworkFile
-import androidx.compose.foundation.combinedClickable
+import app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository
+import app.marlboroadvance.mpvex.preferences.UiSettings
 import app.marlboroadvance.mpvex.utils.media.MediaFormatter
 import org.koin.compose.koinInject
-import java.util.Locale
-
-import app.marlboroadvance.mpvex.preferences.UiSettings
+import kotlin.math.roundToInt
 
 @Composable
 fun NetworkVideoCard(
@@ -49,12 +33,45 @@ fun NetworkVideoCard(
   onLongClick: (() -> Unit)? = null,
   isSelected: Boolean = false,
 ) {
+  val thumbnailRepository = koinInject<ThumbnailRepository>()
+  var thumbnail by remember(file.path) { mutableStateOf<android.graphics.Bitmap?>(null) }
+
+  if (uiSettings.showNetworkThumbnails) {
+    val density = LocalDensity.current
+    val targetThumbnailSize = 128.dp
+    val thumbWidthPx = with(density) { targetThumbnailSize.toPx().roundToInt() }
+
+    LaunchedEffect(file.path) {
+      if (thumbnail == null) {
+        thumbnail = thumbnailRepository.getThumbnailViaProxy(
+          path = file.path,
+          name = file.name,
+          size = file.size,
+          connection = connection,
+          dimension = thumbWidthPx
+        )
+      }
+    }
+  }
+
   val maxLines = if (uiSettings.unlimitedNameLines) Int.MAX_VALUE else 2
 
   BaseMediaCard(
     title = file.name,
     modifier = modifier,
+    thumbnailSize = 128.dp,
+    thumbnail = thumbnail?.asImageBitmap(),
     thumbnailAspectRatio = 16f / 9f,
+    thumbnailIcon = if (thumbnail == null) {
+      {
+        Icon(
+          Icons.Filled.PlayArrow,
+          contentDescription = null,
+          modifier = Modifier.size(48.dp),
+          tint = MaterialTheme.colorScheme.secondary,
+        )
+      }
+    } else null,
     onClick = onClick,
     onLongClick = onLongClick,
     isSelected = isSelected,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/clients/SmbClient.kt
@@ -101,6 +101,8 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
                 com.hierynomus.mssmb2.SMB2Dialect.SMB_2_0_2,
             )
             .withDfsEnabled(false)
+            .withSigningRequired(false)
+            .withEncryptData(false)
             .build()
 
         smbClient = SMBClient(config)
@@ -143,7 +145,7 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
         return executeWithRetry {
             val diskShare = session?.connectShare(shareName) as? DiskShare ?: throw java.net.SocketException("Session is null or share failed")
             
-            try {
+            diskShare.use { diskShare ->
                 val smbPath = path.trim('/').replace('/', '\\')
                 val fileList = diskShare.list(smbPath)
                 
@@ -162,8 +164,6 @@ class SmbClient(connection: NetworkConnection) : BaseNetworkClient(connection) {
                             mimeType = if (info.fileAttributes and 0x10L != 0L) null else getMimeType(fileName)
                         )
                     }
-            } finally {
-                diskShare.close()
             }
         }
     }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
@@ -740,6 +740,8 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         .withTimeout(120000, TimeUnit.MILLISECONDS) 
         .withSoTimeout(120000, TimeUnit.MILLISECONDS)
         .withReadTimeout(120000, TimeUnit.MILLISECONDS)
+        .withSigningRequired(false)
+        .withEncryptData(false)
         .build()
         
       smbClient = SMBClient(smbConfig)
@@ -771,7 +773,8 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         private var currentPosition = offset
         private val fileHandle = file!!
         private var closed = false
-
+        private var scratch = ByteArray(0)
+        
         override fun read(): Int {
           if (closed) return -1
           val buf = ByteArray(1)
@@ -788,15 +791,28 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
           if (len == 0) return 0
 
           try {
-            // SMBJ's file.read() signature: read(ByteArray, Long) -> Int
-            // We need to read into a temp buffer then copy to the output buffer
-            val readBuffer = ByteArray(len)
+            // ZERO-COPY OPTIMIZATION: 
+            // If NanoHTTPD asks for a full buffer array, we inject that exact 
+            // array directly into the SMB client. No copying needed.
+            val readBuffer = if (off == 0 && len == b.size) {
+              b
+            } else {
+              // If an offset is requested, we reuse our scratch array to prevent GC thrashing.
+              // We ONLY allocate memory if the requested length is bigger than our current scratch pad.
+              if (scratch.size < len) {
+                scratch = ByteArray(len)
+              }
+              scratch
+            }
+
             val bytesRead = fileHandle.read(readBuffer, currentPosition)
 
             if (bytesRead <= 0) return -1
 
-            // Copy the data to the output buffer
-            System.arraycopy(readBuffer, 0, b, off, bytesRead)
+            // If we had to use the scratch array, we copy the bytes over to the final destination.
+            if (readBuffer !== b) {
+              System.arraycopy(readBuffer, 0, b, off, bytesRead)
+            }
             currentPosition += bytesRead
             return bytesRead
           } catch (e: Exception) {


### PR DESCRIPTION
### Description
This PR delivers a major performance and stability overhaul to the network streaming and thumbnail generation systems. It resolves SMB bandwidth bottlenecks by stripping out software cryptography overhead, introduces a localized proxy tunnel for network thumbnails, and completely rebuilds the extraction hierarchy to prevent memory leaks, evade blank frames, and prioritize hardware/OS-level caches.

### Key Changes

**1. Networking & SMB Optimization**

- **Uncapped Throughput:** Disabled SMB packet signing and data encryption globally in `SmbClient `to bypass CPU-bound Java bottlenecks.
- **Stream Efficiency:** Implemented zero-copy buffer injection and reusable scratch arrays in `NetworkStreamingProxy `to eliminate GC thrashing during high-speed transfers.
- **Proxy Routing:** Added `getThumbnailViaProxy `to `ThumbnailRepository `(authenticated via NetworkVideoCard) to trick standard extractors into safely processing remote files via a mocked local HTTP URL.

**2. Thumbnail Pipeline & Quality**

- Solid Frame Evasion: Introduced `ThumbnailBitmapUtils` to scan multiple timestamp offsets (Local: 10s/20s/30s, Network: 10s/15s) to automatically detect and skip black/blank frames.
- Smart Local Fallbacks: Bypasses heavy software/hardware decoders for short local videos (<120s), routing them directly to the zero-cost MediaStore cache.

**3. Stability & Memory Management**

- OOM Prevention: Applied strict `inSampleSize` bounds checking (`decodeFileSafely`) to all disk-to-memory decodes, including proxy streams.
- Network Throttling: Restricted `FastThumbnails `network fallbacks to a strict single 10-second attempt (without solid-frame scanning) to prevent CPU lockups and bandwidth drain on dead streams.

Fixes #48