### PR TITLE
feat(player): touch the subtitle and drag it up/down to reposition

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/preferences/PlayerPreferences.kt
@@ -23,6 +23,7 @@ class PlayerPreferences(
   val pinchToZoomGesture = preferenceStore.getBoolean("pinch_to_zoom_gesture", true)
   val horizontalSwipeToSeek = preferenceStore.getBoolean("horizontal_swipe_to_seek", true)
   val swipeToSubtitleSeek = preferenceStore.getBoolean("swipe_to_subtitle_seek", false)
+  val moveSubtitleByDragging = preferenceStore.getBoolean("move_subtitle_by_dragging", true)
   val horizontalSwipeSensitivity = preferenceStore.getFloat("horizontal_swipe_sensitivity", 0.05f)
 
   val customAspectRatios = preferenceStore.getStringSet("custom_aspect_ratios", emptySet())

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/GestureHandler.kt
@@ -56,6 +56,7 @@ import `is`.xyz.mpv.MPVLib
 import app.marlboroadvance.mpvex.preferences.AudioPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
+import app.marlboroadvance.mpvex.preferences.SubtitlesPreferences
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.components.LeftSideOvalShape
 import app.marlboroadvance.mpvex.presentation.components.RightSideOvalShape
@@ -83,6 +84,7 @@ fun GestureHandler(
   val playerPreferences = koinInject<PlayerPreferences>()
   val audioPreferences = koinInject<AudioPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
+  val subtitlesPreferences = koinInject<SubtitlesPreferences>()
   val panelShown by viewModel.panelShown.collectAsState()
   val allowGesturesInPanels by playerPreferences.allowGesturesInPanels.collectAsState()
   val paused by MPVLib.propBoolean["pause"].collectAsState()
@@ -116,6 +118,7 @@ fun GestureHandler(
   val panAndZoomEnabled by playerPreferences.panAndZoomEnabled.collectAsState()
   val horizontalSwipeToSeek by playerPreferences.horizontalSwipeToSeek.collectAsState()
   val swipeToSubtitleSeek by playerPreferences.swipeToSubtitleSeek.collectAsState()
+  val moveSubtitleByDragging by playerPreferences.moveSubtitleByDragging.collectAsState()
   val horizontalSwipeSensitivity by playerPreferences.horizontalSwipeSensitivity.collectAsState()
   var isLongPressing by remember { mutableStateOf(false) }
   var isDynamicSpeedControlActive by remember { mutableStateOf(false) }
@@ -375,8 +378,8 @@ fun GestureHandler(
           } while (event.changes.any { it.pressed })
         }
       }
-      .pointerInput(areControlsLocked, multipleSpeedGesture, brightnessGesture, volumeGesture) {
-        if ((!brightnessGesture && !volumeGesture && multipleSpeedGesture <= 0f) || areControlsLocked) return@pointerInput
+      .pointerInput(areControlsLocked, multipleSpeedGesture, brightnessGesture, volumeGesture, moveSubtitleByDragging) {
+        if ((!brightnessGesture && !volumeGesture && multipleSpeedGesture <= 0f && !moveSubtitleByDragging) || areControlsLocked) return@pointerInput
 
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)
@@ -397,6 +400,11 @@ fun GestureHandler(
           val brightnessGestureSens = 0.001f
           val volumeGestureSens = 0.017f
           val mpvVolumeGestureSens = 0.017f
+
+          // State for subtitle-position drag (touch on the subtitle, drag up/down)
+          var subPosOriginal = 0
+          var subPosDragStartY = 0f
+          var lastSubPosValue = 0
 
           // Original speed for long press
           var originalSpeed = playbackSpeed ?: 1f
@@ -483,7 +491,32 @@ fun GestureHandler(
                         dynamicSpeedStartValue = MPVLib.getPropertyFloat("speed") ?: multipleSpeedGesture
                       }
                       "vertical" -> {
-                        if ((brightnessGesture || volumeGesture) && !isLongPressing) {
+                        // If the drag started on the subtitle, reposition it instead of
+                        // adjusting brightness/volume (XPlayer-style "grab the subtitle").
+                        val subtitleActive = (MPVLib.getPropertyInt("sid") ?: 0) > 0
+                        val curSubPos = (MPVLib.getPropertyInt("sub-pos") ?: subtitlesPreferences.subPos.get())
+                          .coerceIn(0, 150)
+                        // sub-pos is the subtitle's vertical anchor as a % of height (100 = bottom).
+                        // The text sits above that line, so bias the hit-band upward.
+                        val subAnchorY = (curSubPos.coerceIn(0, 100) / 100f) * size.height
+                        // Subtitles are horizontally centered, so only grab them in the centre
+                        // band. This keeps brightness (far left) / volume (far right) swipes free
+                        // even when they start low on the screen.
+                        val startedOnSubtitle = moveSubtitleByDragging && subtitleActive && !isLongPressing &&
+                          startPosition.y >= subAnchorY - size.height * 0.22f &&
+                          startPosition.y <= subAnchorY + size.height * 0.06f &&
+                          startPosition.x >= size.width * 0.2f &&
+                          startPosition.x <= size.width * 0.8f
+
+                        if (startedOnSubtitle) {
+                          gestureType = "subtitle_pos"
+                          subPosOriginal = curSubPos
+                          lastSubPosValue = curSubPos
+                          subPosDragStartY = startPosition.y
+                          isVerticalGestureActive = true
+                          viewModel.isVerticalGestureActive.value = true
+                          haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                        } else if ((brightnessGesture || volumeGesture) && !isLongPressing) {
                           isVerticalGestureActive = true
                           viewModel.isVerticalGestureActive.value = true
                           startingY = 0f
@@ -565,6 +598,20 @@ fun GestureHandler(
                             }
                         }
                       }
+                    }
+                    "subtitle_pos" -> {
+                      // Move the subtitle 1:1 with the finger. Dragging up lowers sub-pos
+                      // (subtitle moves up); dragging down raises it (subtitle moves down).
+                      val deltaY = currentPosition.y - subPosDragStartY
+                      val newSubPos = (subPosOriginal + (deltaY / size.height * 100f))
+                        .toInt()
+                        .coerceIn(0, 150)
+                      if (newSubPos != lastSubPosValue) {
+                        MPVLib.setPropertyInt("sub-pos", newSubPos)
+                        lastSubPosValue = newSubPos
+                        viewModel.playerUpdate.update { PlayerUpdates.ShowText("Sub position: $newSubPos") }
+                      }
+                      change.consume()
                     }
                     "vertical" -> {
                       if ((brightnessGesture || volumeGesture) && !isLongPressing) {
@@ -669,6 +716,12 @@ fun GestureHandler(
                       lastBrightnessValue = currentBrightness
                     }
                   }
+                  "subtitle_pos" -> {
+                    isVerticalGestureActive = false
+                    viewModel.isVerticalGestureActive.value = false
+                    subtitlesPreferences.subPos.set(lastSubPosValue)
+                    viewModel.playerUpdate.update { PlayerUpdates.None }
+                  }
                 }
                 gestureType = null
               }
@@ -716,6 +769,13 @@ fun GestureHandler(
                 lastMPVVolumeValue = currentMPVVolume ?: 100
                 lastBrightnessValue = currentBrightness
               }
+            }
+            "subtitle_pos" -> {
+              isVerticalGestureActive = false
+              viewModel.isVerticalGestureActive.value = false
+              // Persist the final position so it carries across videos.
+              subtitlesPreferences.subPos.set(lastSubPosValue)
+              viewModel.playerUpdate.update { PlayerUpdates.None }
             }
           }
         }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/preferences/PlayerPreferencesScreen.kt
@@ -321,7 +321,17 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_gestures_swipe_to_subtitle_seek_title)) },
                 summary = { Text(stringResource(R.string.pref_player_gestures_swipe_to_subtitle_seek_summary)) },
               )
-              
+
+              PreferenceDivider()
+
+              val moveSubtitleByDragging by preferences.moveSubtitleByDragging.collectAsState()
+              SwitchPreference(
+                value = moveSubtitleByDragging,
+                onValueChange = preferences.moveSubtitleByDragging::set,
+                title = { Text(stringResource(R.string.pref_player_gestures_move_subtitle_by_dragging_title)) },
+                summary = { Text(stringResource(R.string.pref_player_gestures_move_subtitle_by_dragging_summary)) },
+              )
+
               PreferenceDivider()
               
               val horizontalSwipeSensitivity by preferences.horizontalSwipeSensitivity.collectAsState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
     <string name="pref_player_gestures_horizontal_swipe_to_seek_summary">Swipe left or right on screen to seek forward or backward</string>
     <string name="pref_player_gestures_swipe_to_subtitle_seek_title">Swipe to subtitle seek</string>
     <string name="pref_player_gestures_swipe_to_subtitle_seek_summary">Swipe left or right on the top or bottom of the screen to seek subtitles</string>
+    <string name="pref_player_gestures_move_subtitle_by_dragging_title">Drag subtitle to reposition</string>
+    <string name="pref_player_gestures_move_subtitle_by_dragging_summary">Touch the subtitle and drag up or down to move it. Brightness and volume swipes still work elsewhere</string>
     <string name="pref_player_gestures_horizontal_swipe_sensitivity">Horizontal swipe sensitivity</string>
     <string name="pref_player_gestures_horizontal_swipe_sensitivity_summary">Adjust how much distance is covered per swipe</string>
     <string name="pref_player_gestures_hold_for_multiple_speed">Hold for multi - x speed</string>


### PR DESCRIPTION
## What

Adds an XPlayer-style gesture: **touch directly on the subtitle, then drag it up or down** to reposition it. The drag maps 1:1 to mpv's `sub-pos`.

## Why

Today the only way to move subtitles vertically is the **Sub position** slider buried in Subtitle Settings → Miscellaneous. Touching the subtitle and dragging it is far more intuitive and is a common feature in popular players.

## How it works

- A vertical drag is treated as a subtitle move **only when it starts on the subtitle's centre-bottom band** *and* a subtitle is currently shown (`sid > 0`).
- Subtitles are horizontally centred, so the grab-zone is limited to the centre ~60% width — **brightness (far left) and volume (far right) swipes are unaffected**, even when they start low on the screen.
- Drag up → subtitle up, drag down → subtitle down (1:1 with the finger), with a light haptic on grab and a live "Sub position: NN" overlay.
- The final value is persisted via the existing `sub_pos` preference, so it carries across videos (same store the slider uses).
- New toggle **"Drag subtitle to reposition"** (default on) under **Player → Gestures**; the feature can be disabled there.

## Files

- `PlayerPreferences.kt` — new `moveSubtitleByDragging` preference
- `GestureHandler.kt` — hit-test + `sub-pos` drag handling, cleanup/persist on release
- `PlayerPreferencesScreen.kt` + `strings.xml` — settings toggle

## Testing

Built and verified on a physical device (Android 16):
- Touching the subtitle and dragging moves it live (`sub-pos` updates) and the text visibly repositions.
- Far-left swipe drives brightness, far-right drives volume — **0** `sub-pos` changes in both.
- Position persists and re-applies on the next video.
