### PR TITLE
refactor(ui): unify all media and file browsers under strategy-driven UnifiedExplorerContent

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/MainScreen.kt
@@ -372,8 +372,12 @@ object MainScreen : Screen {
           },
           label = "tab_animation"
         ) { targetTab ->
+          val shortsIdx = visibleTabs.indexOfFirst { it.id == "shorts" }
+          val isShortsTabActive = isShortsEnabled && shortsIdx != -1 && selectedTab == shortsIdx
+          val isNavBarVisible = !hideNavigationBar.value && !isShortsTabActive && visibleTabs.size > 1
+          
           CompositionLocalProvider(
-            LocalNavigationBarHeight provides if (visibleTabs.size == 1) 0.dp else fabBottomPadding
+            LocalNavigationBarHeight provides if (isNavBarVisible) fabBottomPadding else 0.dp
           ) {
             if (targetTab in visibleTabs.indices) {
               visibleTabs[targetTab].content()

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -1,0 +1,321 @@
+package app.marlboroadvance.mpvex.ui.browser.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VideoLibrary
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import app.marlboroadvance.mpvex.domain.media.model.Video
+import app.marlboroadvance.mpvex.domain.media.model.VideoFolder
+import app.marlboroadvance.mpvex.ui.browser.playlist.PlaylistWithCount
+import app.marlboroadvance.mpvex.ui.browser.playlist.PlaylistVideoItem
+import app.marlboroadvance.mpvex.ui.browser.recentlyplayed.RecentlyPlayedItem
+import app.marlboroadvance.mpvex.domain.browser.FileSystemItem
+import app.marlboroadvance.mpvex.ui.browser.cards.FolderCard
+import app.marlboroadvance.mpvex.ui.browser.cards.PlaylistCard
+import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
+import app.marlboroadvance.mpvex.ui.browser.videolist.VideoWithPlaybackInfo
+import app.marlboroadvance.mpvex.preferences.UiSettings
+import org.koin.compose.koinInject
+import app.marlboroadvance.mpvex.preferences.BrowserPreferences
+import app.marlboroadvance.mpvex.preferences.GesturePreferences
+import app.marlboroadvance.mpvex.preferences.MediaLayoutMode
+import app.marlboroadvance.mpvex.ui.browser.states.EmptyState
+import app.marlboroadvance.mpvex.preferences.preference.collectAsState
+
+@Composable
+fun <T> UnifiedExplorerContent(
+  items: List<T>,
+  isLoading: Boolean,
+  uiSettings: UiSettings,
+  isSelected: (T) -> Boolean,
+  onClick: (T) -> Unit,
+  onLongClick: (T) -> Unit,
+  modifier: Modifier = Modifier,
+  emptyTitle: String = "No items",
+  emptyMessage: String = "This folder is empty",
+  onThumbClick: ((T) -> Unit)? = null,
+) {
+  val browserPreferences = koinInject<BrowserPreferences>()
+  val gesturePreferences = koinInject<GesturePreferences>()
+
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+  val configuration = LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val columns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
+  val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
+
+  if (isLoading && items.isEmpty()) {
+    Box(
+      modifier = modifier
+        .fillMaxSize()
+        .padding(bottom = 80.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      CircularProgressIndicator(
+        modifier = Modifier.size(48.dp),
+        color = MaterialTheme.colorScheme.primary,
+      )
+    }
+  } else if (items.isEmpty()) {
+    Box(
+      modifier = modifier.fillMaxSize(),
+      contentAlignment = Alignment.Center,
+    ) {
+      EmptyState(
+        icon = Icons.Filled.VideoLibrary,
+        title = emptyTitle,
+        message = emptyMessage,
+      )
+    }
+  } else {
+    val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
+
+    if (mediaLayoutMode == MediaLayoutMode.GRID) {
+      LazyVerticalGrid(
+        columns = GridCells.Fixed(columns),
+        state = gridState,
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+      ) {
+        items(
+          items = items,
+          key = { getItemId(it) }
+        ) { item ->
+          ExplorerItemCard(
+            item = item,
+            isSelected = isSelected(item),
+            showSubtitleIndicator = showSubtitleIndicator,
+            isGridMode = true,
+            columns = columns,
+            uiSettings = uiSettings,
+            onClick = { onClick(item) },
+            onLongClick = { onLongClick(item) },
+            onThumbClick = {
+              if (onThumbClick != null) {
+                onThumbClick(item)
+              } else if (tapThumbnailToSelect) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+          )
+        }
+      }
+    } else {
+      LazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+      ) {
+        items(
+          items = items,
+          key = { getItemId(it) }
+        ) { item ->
+          ExplorerItemCard(
+            item = item,
+            isSelected = isSelected(item),
+            showSubtitleIndicator = showSubtitleIndicator,
+            isGridMode = false,
+            columns = 1,
+            uiSettings = uiSettings,
+            onClick = { onClick(item) },
+            onLongClick = { onLongClick(item) },
+            onThumbClick = {
+              if (onThumbClick != null) {
+                onThumbClick(item)
+              } else if (tapThumbnailToSelect) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+          )
+        }
+      }
+    }
+  }
+}
+
+private fun <T> getItemId(item: T): String {
+  return when (item) {
+    is VideoFolder -> item.bucketId
+    is Video -> item.path
+    is VideoWithPlaybackInfo -> item.video.path
+    is PlaylistWithCount -> item.playlist.id.toString()
+    is RecentlyPlayedItem.VideoItem -> item.video.path
+    is RecentlyPlayedItem.PlaylistItem -> item.playlist.id.toString()
+    is FileSystemItem.Folder -> item.path
+    is FileSystemItem.VideoFile -> item.path
+    is PlaylistVideoItem -> item.playlistItem.id.toString()
+    else -> item.hashCode().toString()
+  }
+}
+
+@Composable
+private fun <T> ExplorerItemCard(
+  item: T,
+  isSelected: Boolean,
+  showSubtitleIndicator: Boolean,
+  isGridMode: Boolean,
+  columns: Int,
+  uiSettings: UiSettings,
+  onClick: () -> Unit,
+  onLongClick: () -> Unit,
+  onThumbClick: () -> Unit,
+) {
+  when (item) {
+    is VideoFolder -> {
+      FolderCard(
+        folder = item,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        isGridMode = isGridMode,
+        gridColumns = columns
+      )
+    }
+    is Video -> {
+      VideoCard(
+        video = item,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        gridColumns = columns,
+        showSubtitleIndicator = showSubtitleIndicator
+      )
+    }
+    is VideoWithPlaybackInfo -> {
+      VideoCard(
+        video = item.video,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        gridColumns = columns,
+        showSubtitleIndicator = showSubtitleIndicator,
+        progressPercentage = item.progressPercentage,
+        isWatched = item.isWatched
+      )
+    }
+    is PlaylistWithCount -> {
+      PlaylistCard(
+        playlist = item.playlist,
+        itemCount = item.itemCount,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        thumbnailSize = if (isGridMode) 160.dp else 128.dp,
+        thumbnailAspectRatio = 16f / 9f
+      )
+    }
+    is RecentlyPlayedItem.VideoItem -> {
+      VideoCard(
+        video = item.video,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        gridColumns = columns,
+        showSubtitleIndicator = showSubtitleIndicator,
+        progressPercentage = item.progress,
+        isWatched = item.isWatched
+      )
+    }
+    is RecentlyPlayedItem.PlaylistItem -> {
+      PlaylistCard(
+        playlist = item.playlist,
+        itemCount = item.videoCount,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        thumbnailSize = if (isGridMode) 160.dp else 128.dp,
+        thumbnailAspectRatio = 16f / 9f
+      )
+    }
+    is FileSystemItem.Folder -> {
+      val folderModel = VideoFolder(
+        bucketId = item.path,
+        name = item.name,
+        path = item.path,
+        videoCount = item.videoCount,
+        audioCount = item.audioCount,
+        totalSize = item.totalSize,
+        totalDuration = item.totalDuration,
+        lastModified = item.lastModified / 1000,
+        newCount = item.newCount,
+        unwatchedVideoCount = item.unwatchedVideoCount,
+      )
+      FolderCard(
+        folder = folderModel,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        isGridMode = isGridMode,
+        gridColumns = columns
+      )
+    }
+    is FileSystemItem.VideoFile -> {
+      VideoCard(
+        video = item.video,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        gridColumns = columns,
+        showSubtitleIndicator = showSubtitleIndicator
+      )
+    }
+    is PlaylistVideoItem -> {
+      VideoCard(
+        video = item.video,
+        uiSettings = uiSettings,
+        isSelected = isSelected,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
+        isGridMode = isGridMode,
+        gridColumns = columns,
+        showSubtitleIndicator = showSubtitleIndicator
+      )
+    }
+  }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -34,6 +34,7 @@ import app.marlboroadvance.mpvex.preferences.MediaLayoutMode
 import app.marlboroadvance.mpvex.ui.browser.states.EmptyState
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.components.pullrefresh.PullRefreshBox
+import app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight
 
 @Composable
 fun <T> UnifiedExplorerContent(
@@ -70,6 +71,7 @@ fun <T> UnifiedExplorerContent(
 
   val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
+  val navigationBarHeight = LocalNavigationBarHeight.current
 
   if (isLoading && items.isEmpty()) {
     Box(
@@ -127,7 +129,12 @@ fun <T> UnifiedExplorerContent(
           columns = GridCells.Fixed(columns),
           state = gridState,
           modifier = Modifier.fillMaxSize(),
-          contentPadding = PaddingValues(8.dp),
+          contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            top = 8.dp,
+            bottom = navigationBarHeight + 8.dp
+          ),
           horizontalArrangement = Arrangement.spacedBy(8.dp),
           verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
@@ -175,7 +182,12 @@ fun <T> UnifiedExplorerContent(
         LazyColumn(
           state = listState,
           modifier = Modifier.fillMaxSize(),
-          contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+          contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            top = 8.dp,
+            bottom = navigationBarHeight + 8.dp
+          ),
           verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
           items(
@@ -287,12 +299,14 @@ private fun <T> ExplorerItemCard(
         onLongClick = onLongClick,
         onThumbClick = onThumbClick,
         isGridMode = isGridMode,
-        gridColumns = columns
+        gridColumns = columns,
+        newVideoCount = item.newCount
       )
     }
     is Video -> {
       val isOldAndUnplayed = newVideoIds.contains(item.id)
       val isWatched = watchedVideoIds.contains(item.id)
+      val isRecentlyPlayed = recentlyPlayedFilePath == item.path
 
       VideoCard(
         video = item,
@@ -305,7 +319,8 @@ private fun <T> ExplorerItemCard(
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
         isOldAndUnplayed = isOldAndUnplayed,
-        isWatched = isWatched
+        isWatched = isWatched,
+        isRecentlyPlayed = isRecentlyPlayed
       )
     }
     is VideoWithPlaybackInfo -> {
@@ -398,12 +413,14 @@ private fun <T> ExplorerItemCard(
         onLongClick = onLongClick,
         onThumbClick = onThumbClick,
         isGridMode = isGridMode,
-        gridColumns = columns
+        gridColumns = columns,
+        newVideoCount = item.newCount
       )
     }
     is FileSystemItem.VideoFile -> {
       val isOldAndUnplayed = newVideoIds.contains(item.video.id)
       val isWatched = watchedVideoIds.contains(item.video.id)
+      val isRecentlyPlayed = recentlyPlayedFilePath == item.video.path
 
       VideoCard(
         video = item.video,
@@ -416,7 +433,8 @@ private fun <T> ExplorerItemCard(
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
         isOldAndUnplayed = isOldAndUnplayed,
-        isWatched = isWatched
+        isWatched = isWatched,
+        isRecentlyPlayed = isRecentlyPlayed
       )
     }
     is PlaylistVideoItem -> {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -51,6 +51,11 @@ fun <T> UnifiedExplorerContent(
   isRefreshing: MutableState<Boolean>? = null,
   onRefresh: (suspend () -> Unit)? = null,
   isInSelectionMode: Boolean = false,
+  recentlyPlayedFilePath: String? = null,
+  playedFolderPaths: Set<String> = emptySet(),
+  newVideoIds: Set<Long> = emptySet(),
+  watchedVideoIds: Set<Long> = emptySet(),
+  autoScrollToLastPlayed: Boolean = false,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -92,6 +97,29 @@ fun <T> UnifiedExplorerContent(
   } else {
     val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
+
+    if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && items.isNotEmpty()) {
+      val lastPlayedIndex = items.indexOfFirst { item ->
+        when (item) {
+          is Video -> item.path == recentlyPlayedFilePath
+          is VideoWithPlaybackInfo -> item.video.path == recentlyPlayedFilePath
+          is RecentlyPlayedItem.VideoItem -> item.video.path == recentlyPlayedFilePath
+          is FileSystemItem.VideoFile -> item.video.path == recentlyPlayedFilePath
+          is VideoFolder -> recentlyPlayedFilePath.let { java.io.File(it).parent == item.path }
+          is FileSystemItem.Folder -> recentlyPlayedFilePath.let { java.io.File(it).parent == item.path }
+          else -> false
+        }
+      }
+      if (lastPlayedIndex != -1) {
+        LaunchedEffect(recentlyPlayedFilePath) {
+          if (mediaLayoutMode == MediaLayoutMode.GRID) {
+            gridState.scrollToItem(lastPlayedIndex)
+          } else {
+            listState.scrollToItem(lastPlayedIndex)
+          }
+        }
+      }
+    }
 
     val contentBlock: @Composable BoxScope.() -> Unit = {
       if (mediaLayoutMode == MediaLayoutMode.GRID) {
@@ -135,7 +163,11 @@ fun <T> UnifiedExplorerContent(
               uiSettings = uiSettings,
               onClick = effectiveOnClick,
               onLongClick = { onLongClick(item) },
-              onThumbClick = effectiveOnThumbClick
+              onThumbClick = effectiveOnThumbClick,
+              recentlyPlayedFilePath = recentlyPlayedFilePath,
+              playedFolderPaths = playedFolderPaths,
+              newVideoIds = newVideoIds,
+              watchedVideoIds = watchedVideoIds
             )
           }
         }
@@ -178,7 +210,11 @@ fun <T> UnifiedExplorerContent(
               uiSettings = uiSettings,
               onClick = effectiveOnClick,
               onLongClick = { onLongClick(item) },
-              onThumbClick = effectiveOnThumbClick
+              onThumbClick = effectiveOnThumbClick,
+              recentlyPlayedFilePath = recentlyPlayedFilePath,
+              playedFolderPaths = playedFolderPaths,
+              newVideoIds = newVideoIds,
+              watchedVideoIds = watchedVideoIds
             )
           }
         }
@@ -227,13 +263,26 @@ private fun <T> ExplorerItemCard(
   onClick: () -> Unit,
   onLongClick: () -> Unit,
   onThumbClick: () -> Unit,
+  recentlyPlayedFilePath: String? = null,
+  playedFolderPaths: Set<String> = emptySet(),
+  newVideoIds: Set<Long> = emptySet(),
+  watchedVideoIds: Set<Long> = emptySet(),
 ) {
   when (item) {
     is VideoFolder -> {
+      val isRecentlyPlayed = recentlyPlayedFilePath?.let {
+        java.io.File(it).parent == item.path
+      } ?: false
+      val isNeverPlayed = item.path !in playedFolderPaths
+      val isWatched = (item.videoCount > 0 || item.audioCount > 0) && item.unwatchedVideoCount == 0
+
       FolderCard(
         folder = item,
         uiSettings = uiSettings,
         isSelected = isSelected,
+        isRecentlyPlayed = isRecentlyPlayed,
+        isNeverPlayed = isNeverPlayed,
+        isWatched = isWatched,
         onClick = onClick,
         onLongClick = onLongClick,
         onThumbClick = onThumbClick,
@@ -242,6 +291,9 @@ private fun <T> ExplorerItemCard(
       )
     }
     is Video -> {
+      val isOldAndUnplayed = newVideoIds.contains(item.id)
+      val isWatched = watchedVideoIds.contains(item.id)
+
       VideoCard(
         video = item,
         uiSettings = uiSettings,
@@ -251,7 +303,9 @@ private fun <T> ExplorerItemCard(
         onThumbClick = onThumbClick,
         isGridMode = isGridMode,
         gridColumns = columns,
-        showSubtitleIndicator = showSubtitleIndicator
+        showSubtitleIndicator = showSubtitleIndicator,
+        isOldAndUnplayed = isOldAndUnplayed,
+        isWatched = isWatched
       )
     }
     is VideoWithPlaybackInfo -> {
@@ -266,7 +320,9 @@ private fun <T> ExplorerItemCard(
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
         progressPercentage = item.progressPercentage,
-        isWatched = item.isWatched
+        isWatched = item.isWatched,
+        isOldAndUnplayed = item.isOldAndUnplayed,
+        isNeverPlayed = item.isNeverPlayed
       )
     }
     is PlaylistWithCount -> {
@@ -325,10 +381,19 @@ private fun <T> ExplorerItemCard(
         newCount = item.newCount,
         unwatchedVideoCount = item.unwatchedVideoCount,
       )
+      val isRecentlyPlayed = recentlyPlayedFilePath?.let {
+        java.io.File(it).parent == item.path
+      } ?: false
+      val isNeverPlayed = item.path !in playedFolderPaths
+      val isWatched = (item.videoCount > 0 || item.audioCount > 0) && item.unwatchedVideoCount == 0
+
       FolderCard(
         folder = folderModel,
         uiSettings = uiSettings,
         isSelected = isSelected,
+        isRecentlyPlayed = isRecentlyPlayed,
+        isNeverPlayed = isNeverPlayed,
+        isWatched = isWatched,
         onClick = onClick,
         onLongClick = onLongClick,
         onThumbClick = onThumbClick,
@@ -337,6 +402,9 @@ private fun <T> ExplorerItemCard(
       )
     }
     is FileSystemItem.VideoFile -> {
+      val isOldAndUnplayed = newVideoIds.contains(item.video.id)
+      val isWatched = watchedVideoIds.contains(item.video.id)
+
       VideoCard(
         video = item.video,
         uiSettings = uiSettings,
@@ -346,7 +414,9 @@ private fun <T> ExplorerItemCard(
         onThumbClick = onThumbClick,
         isGridMode = isGridMode,
         gridColumns = columns,
-        showSubtitleIndicator = showSubtitleIndicator
+        showSubtitleIndicator = showSubtitleIndicator,
+        isOldAndUnplayed = isOldAndUnplayed,
+        isWatched = isWatched
       )
     }
     is PlaylistVideoItem -> {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -43,6 +43,7 @@ fun <T> UnifiedExplorerContent(
   isSelected: (T) -> Boolean,
   onClick: (T) -> Unit,
   onLongClick: (T) -> Unit,
+  onToggleSelection: (T) -> Unit,
   modifier: Modifier = Modifier,
   emptyTitle: String = "No items",
   emptyMessage: String = "This folder is empty",
@@ -108,18 +109,18 @@ fun <T> UnifiedExplorerContent(
           ) { item ->
             val effectiveOnClick = {
               if (isInSelectionMode) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else {
                 onClick(item)
               }
             }
             val effectiveOnThumbClick = {
               if (isInSelectionMode) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else if (onThumbClick != null) {
                 onThumbClick(item)
               } else if (tapThumbnailToSelect) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else {
                 onClick(item)
               }
@@ -151,18 +152,18 @@ fun <T> UnifiedExplorerContent(
           ) { item ->
             val effectiveOnClick = {
               if (isInSelectionMode) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else {
                 onClick(item)
               }
             }
             val effectiveOnThumbClick = {
               if (isInSelectionMode) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else if (onThumbClick != null) {
                 onThumbClick(item)
               } else if (tapThumbnailToSelect) {
-                onLongClick(item)
+                onToggleSelection(item)
               } else {
                 onClick(item)
               }
@@ -235,6 +236,7 @@ private fun <T> ExplorerItemCard(
         isSelected = isSelected,
         onClick = onClick,
         onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
         isGridMode = isGridMode,
         gridColumns = columns
       )
@@ -329,6 +331,7 @@ private fun <T> ExplorerItemCard(
         isSelected = isSelected,
         onClick = onClick,
         onLongClick = onLongClick,
+        onThumbClick = onThumbClick,
         isGridMode = isGridMode,
         gridColumns = columns
       )

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -49,6 +49,7 @@ fun <T> UnifiedExplorerContent(
   onThumbClick: ((T) -> Unit)? = null,
   isRefreshing: MutableState<Boolean>? = null,
   onRefresh: (suspend () -> Unit)? = null,
+  isInSelectionMode: Boolean = false,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -105,6 +106,25 @@ fun <T> UnifiedExplorerContent(
             items = items,
             key = { getItemId(it) }
           ) { item ->
+            val effectiveOnClick = {
+              if (isInSelectionMode) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+            val effectiveOnThumbClick = {
+              if (isInSelectionMode) {
+                onLongClick(item)
+              } else if (onThumbClick != null) {
+                onThumbClick(item)
+              } else if (tapThumbnailToSelect) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+
             ExplorerItemCard(
               item = item,
               isSelected = isSelected(item),
@@ -112,17 +132,9 @@ fun <T> UnifiedExplorerContent(
               isGridMode = true,
               columns = columns,
               uiSettings = uiSettings,
-              onClick = { onClick(item) },
+              onClick = effectiveOnClick,
               onLongClick = { onLongClick(item) },
-              onThumbClick = {
-                if (onThumbClick != null) {
-                  onThumbClick(item)
-                } else if (tapThumbnailToSelect) {
-                  onLongClick(item)
-                } else {
-                  onClick(item)
-                }
-              }
+              onThumbClick = effectiveOnThumbClick
             )
           }
         }
@@ -137,6 +149,25 @@ fun <T> UnifiedExplorerContent(
             items = items,
             key = { getItemId(it) }
           ) { item ->
+            val effectiveOnClick = {
+              if (isInSelectionMode) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+            val effectiveOnThumbClick = {
+              if (isInSelectionMode) {
+                onLongClick(item)
+              } else if (onThumbClick != null) {
+                onThumbClick(item)
+              } else if (tapThumbnailToSelect) {
+                onLongClick(item)
+              } else {
+                onClick(item)
+              }
+            }
+
             ExplorerItemCard(
               item = item,
               isSelected = isSelected(item),
@@ -144,17 +175,9 @@ fun <T> UnifiedExplorerContent(
               isGridMode = false,
               columns = 1,
               uiSettings = uiSettings,
-              onClick = { onClick(item) },
+              onClick = effectiveOnClick,
               onLongClick = { onLongClick(item) },
-              onThumbClick = {
-                if (onThumbClick != null) {
-                  onThumbClick(item)
-                } else if (tapThumbnailToSelect) {
-                  onLongClick(item)
-                } else {
-                  onClick(item)
-                }
-              }
+              onThumbClick = effectiveOnThumbClick
             )
           }
         }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -59,6 +59,7 @@ fun <T> UnifiedExplorerContent(
   autoScrollToLastPlayed: Boolean = false,
   scrollTriggerKey: Any? = null,
   gridColumns: Int? = null,
+  showSections: Boolean = false,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -152,7 +153,240 @@ fun <T> UnifiedExplorerContent(
     }
 
     val contentBlock: @Composable BoxScope.() -> Unit = {
-      if (mediaLayoutMode == MediaLayoutMode.GRID) {
+      if (showSections) {
+        val folderItems = items.filter { it is VideoFolder || it is FileSystemItem.Folder }
+        val videoItems = items.filter { it is Video || it is VideoWithPlaybackInfo || it is FileSystemItem.VideoFile || it is RecentlyPlayedItem.VideoItem }
+
+        val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+        val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+        LazyColumn(
+          state = listState,
+          modifier = Modifier.fillMaxSize(),
+          contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            top = 8.dp,
+            bottom = navigationBarHeight + 8.dp
+          ),
+          verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          // --- FOLDERS SECTION ---
+          if (folderItems.isNotEmpty()) {
+            item(key = "folders_header") {
+              SectionHeader(title = "Folders (${folderItems.size})")
+            }
+
+            if (mediaLayoutMode == MediaLayoutMode.GRID) {
+              val chunkedFolders = folderItems.chunked(folderGridColumns)
+              items(
+                items = chunkedFolders,
+                key = { chunk -> "folder_row_${getItemId(chunk.first())}" }
+              ) { rowItems ->
+                Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                  for (item in rowItems) {
+                    Box(modifier = Modifier.weight(1f)) {
+                      val effectiveOnClick = {
+                        if (isInSelectionMode) {
+                          onToggleSelection(item)
+                        } else {
+                          onClick(item)
+                        }
+                      }
+                      val effectiveOnThumbClick = {
+                        if (isInSelectionMode) {
+                          onToggleSelection(item)
+                        } else if (onThumbClick != null) {
+                          onThumbClick(item)
+                        } else if (tapThumbnailToSelect) {
+                          onToggleSelection(item)
+                        } else {
+                          onClick(item)
+                        }
+                      }
+
+                      ExplorerItemCard(
+                        item = item,
+                        isSelected = isSelected(item),
+                        showSubtitleIndicator = showSubtitleIndicator,
+                        isGridMode = true,
+                        columns = folderGridColumns,
+                        uiSettings = uiSettings,
+                        onClick = effectiveOnClick,
+                        onLongClick = { onLongClick(item) },
+                        onThumbClick = effectiveOnThumbClick,
+                        recentlyPlayedFilePath = recentlyPlayedFilePath,
+                        playedFolderPaths = playedFolderPaths,
+                        newVideoIds = newVideoIds,
+                        watchedVideoIds = watchedVideoIds
+                      )
+                    }
+                  }
+                  val emptySlots = folderGridColumns - rowItems.size
+                  repeat(emptySlots) {
+                    Spacer(modifier = Modifier.weight(1f))
+                  }
+                }
+              }
+            } else {
+              // List Mode
+              items(
+                items = folderItems,
+                key = { getItemId(it) }
+              ) { item ->
+                val effectiveOnClick = {
+                  if (isInSelectionMode) {
+                    onToggleSelection(item)
+                  } else {
+                    onClick(item)
+                  }
+                }
+                val effectiveOnThumbClick = {
+                  if (isInSelectionMode) {
+                    onToggleSelection(item)
+                  } else if (onThumbClick != null) {
+                    onThumbClick(item)
+                  } else if (tapThumbnailToSelect) {
+                    onToggleSelection(item)
+                  } else {
+                    onClick(item)
+                  }
+                }
+
+                ExplorerItemCard(
+                  item = item,
+                  isSelected = isSelected(item),
+                  showSubtitleIndicator = showSubtitleIndicator,
+                  isGridMode = false,
+                  columns = 1,
+                  uiSettings = uiSettings,
+                  onClick = effectiveOnClick,
+                  onLongClick = { onLongClick(item) },
+                  onThumbClick = effectiveOnThumbClick,
+                  recentlyPlayedFilePath = recentlyPlayedFilePath,
+                  playedFolderPaths = playedFolderPaths,
+                  newVideoIds = newVideoIds,
+                  watchedVideoIds = watchedVideoIds
+                )
+              }
+            }
+          }
+
+          // Section Spacer
+          if (folderItems.isNotEmpty() && videoItems.isNotEmpty()) {
+            item(key = "section_divider") {
+              Spacer(modifier = Modifier.height(8.dp))
+            }
+          }
+
+          // --- MEDIA SECTION ---
+          if (videoItems.isNotEmpty()) {
+            item(key = "media_header") {
+              SectionHeader(title = "Media (${videoItems.size})")
+            }
+
+            if (mediaLayoutMode == MediaLayoutMode.GRID) {
+              val chunkedVideos = videoItems.chunked(videoGridColumns)
+              items(
+                items = chunkedVideos,
+                key = { chunk -> "video_row_${getItemId(chunk.first())}" }
+              ) { rowItems ->
+                Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                  for (item in rowItems) {
+                    Box(modifier = Modifier.weight(1f)) {
+                      val effectiveOnClick = {
+                        if (isInSelectionMode) {
+                          onToggleSelection(item)
+                        } else {
+                          onClick(item)
+                        }
+                      }
+                      val effectiveOnThumbClick = {
+                        if (isInSelectionMode) {
+                          onToggleSelection(item)
+                        } else if (onThumbClick != null) {
+                          onThumbClick(item)
+                        } else if (tapThumbnailToSelect) {
+                          onToggleSelection(item)
+                        } else {
+                          onClick(item)
+                        }
+                      }
+
+                      ExplorerItemCard(
+                        item = item,
+                        isSelected = isSelected(item),
+                        showSubtitleIndicator = showSubtitleIndicator,
+                        isGridMode = true,
+                        columns = videoGridColumns,
+                        uiSettings = uiSettings,
+                        onClick = effectiveOnClick,
+                        onLongClick = { onLongClick(item) },
+                        onThumbClick = effectiveOnThumbClick,
+                        recentlyPlayedFilePath = recentlyPlayedFilePath,
+                        playedFolderPaths = playedFolderPaths,
+                        newVideoIds = newVideoIds,
+                        watchedVideoIds = watchedVideoIds
+                      )
+                    }
+                  }
+                  val emptySlots = videoGridColumns - rowItems.size
+                  repeat(emptySlots) {
+                    Spacer(modifier = Modifier.weight(1f))
+                  }
+                }
+              }
+            } else {
+              // List Mode
+              items(
+                items = videoItems,
+                key = { getItemId(it) }
+              ) { item ->
+                val effectiveOnClick = {
+                  if (isInSelectionMode) {
+                    onToggleSelection(item)
+                  } else {
+                    onClick(item)
+                  }
+                }
+                val effectiveOnThumbClick = {
+                  if (isInSelectionMode) {
+                    onToggleSelection(item)
+                  } else if (onThumbClick != null) {
+                    onThumbClick(item)
+                  } else if (tapThumbnailToSelect) {
+                    onToggleSelection(item)
+                  } else {
+                    onClick(item)
+                  }
+                }
+
+                ExplorerItemCard(
+                  item = item,
+                  isSelected = isSelected(item),
+                  showSubtitleIndicator = showSubtitleIndicator,
+                  isGridMode = false,
+                  columns = 1,
+                  uiSettings = uiSettings,
+                  onClick = effectiveOnClick,
+                  onLongClick = { onLongClick(item) },
+                  onThumbClick = effectiveOnThumbClick,
+                  recentlyPlayedFilePath = recentlyPlayedFilePath,
+                  playedFolderPaths = playedFolderPaths,
+                  newVideoIds = newVideoIds,
+                  watchedVideoIds = watchedVideoIds
+                )
+              }
+            }
+          }
+        }
+      } else if (mediaLayoutMode == MediaLayoutMode.GRID) {
         LazyVerticalGrid(
           columns = GridCells.Fixed(columns),
           state = gridState,
@@ -485,4 +719,17 @@ private fun <T> ExplorerItemCard(
       )
     }
   }
+}
+
+@Composable
+private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
+  Text(
+    text = title,
+    style = MaterialTheme.typography.titleMedium,
+    color = MaterialTheme.colorScheme.primary,
+    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 8.dp, vertical = 12.dp)
+  )
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -33,6 +33,7 @@ import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.MediaLayoutMode
 import app.marlboroadvance.mpvex.ui.browser.states.EmptyState
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
+import app.marlboroadvance.mpvex.presentation.components.pullrefresh.PullRefreshBox
 
 @Composable
 fun <T> UnifiedExplorerContent(
@@ -46,6 +47,8 @@ fun <T> UnifiedExplorerContent(
   emptyTitle: String = "No items",
   emptyMessage: String = "This folder is empty",
   onThumbClick: ((T) -> Unit)? = null,
+  isRefreshing: MutableState<Boolean>? = null,
+  onRefresh: (suspend () -> Unit)? = null,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -88,71 +91,87 @@ fun <T> UnifiedExplorerContent(
     val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
 
-    if (mediaLayoutMode == MediaLayoutMode.GRID) {
-      LazyVerticalGrid(
-        columns = GridCells.Fixed(columns),
-        state = gridState,
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-      ) {
-        items(
-          items = items,
-          key = { getItemId(it) }
-        ) { item ->
-          ExplorerItemCard(
-            item = item,
-            isSelected = isSelected(item),
-            showSubtitleIndicator = showSubtitleIndicator,
-            isGridMode = true,
-            columns = columns,
-            uiSettings = uiSettings,
-            onClick = { onClick(item) },
-            onLongClick = { onLongClick(item) },
-            onThumbClick = {
-              if (onThumbClick != null) {
-                onThumbClick(item)
-              } else if (tapThumbnailToSelect) {
-                onLongClick(item)
-              } else {
-                onClick(item)
+    val contentBlock: @Composable BoxScope.() -> Unit = {
+      if (mediaLayoutMode == MediaLayoutMode.GRID) {
+        LazyVerticalGrid(
+          columns = GridCells.Fixed(columns),
+          state = gridState,
+          modifier = Modifier.fillMaxSize(),
+          contentPadding = PaddingValues(8.dp),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          items(
+            items = items,
+            key = { getItemId(it) }
+          ) { item ->
+            ExplorerItemCard(
+              item = item,
+              isSelected = isSelected(item),
+              showSubtitleIndicator = showSubtitleIndicator,
+              isGridMode = true,
+              columns = columns,
+              uiSettings = uiSettings,
+              onClick = { onClick(item) },
+              onLongClick = { onLongClick(item) },
+              onThumbClick = {
+                if (onThumbClick != null) {
+                  onThumbClick(item)
+                } else if (tapThumbnailToSelect) {
+                  onLongClick(item)
+                } else {
+                  onClick(item)
+                }
               }
-            }
-          )
+            )
+          }
+        }
+      } else {
+        LazyColumn(
+          state = listState,
+          modifier = Modifier.fillMaxSize(),
+          contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          items(
+            items = items,
+            key = { getItemId(it) }
+          ) { item ->
+            ExplorerItemCard(
+              item = item,
+              isSelected = isSelected(item),
+              showSubtitleIndicator = showSubtitleIndicator,
+              isGridMode = false,
+              columns = 1,
+              uiSettings = uiSettings,
+              onClick = { onClick(item) },
+              onLongClick = { onLongClick(item) },
+              onThumbClick = {
+                if (onThumbClick != null) {
+                  onThumbClick(item)
+                } else if (tapThumbnailToSelect) {
+                  onLongClick(item)
+                } else {
+                  onClick(item)
+                }
+              }
+            )
+          }
         }
       }
-    } else {
-      LazyColumn(
-        state = listState,
+    }
+
+    if (isRefreshing != null && onRefresh != null) {
+      PullRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-      ) {
-        items(
-          items = items,
-          key = { getItemId(it) }
-        ) { item ->
-          ExplorerItemCard(
-            item = item,
-            isSelected = isSelected(item),
-            showSubtitleIndicator = showSubtitleIndicator,
-            isGridMode = false,
-            columns = 1,
-            uiSettings = uiSettings,
-            onClick = { onClick(item) },
-            onLongClick = { onLongClick(item) },
-            onThumbClick = {
-              if (onThumbClick != null) {
-                onThumbClick(item)
-              } else if (tapThumbnailToSelect) {
-                onLongClick(item)
-              } else {
-                onClick(item)
-              }
-            }
-          )
-        }
+        listState = listState,
+        content = contentBlock
+      )
+    } else {
+      Box(modifier = modifier.fillMaxSize()) {
+        contentBlock()
       }
     }
   }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -58,17 +58,33 @@ fun <T> UnifiedExplorerContent(
   watchedVideoIds: Set<Long> = emptySet(),
   autoScrollToLastPlayed: Boolean = false,
   scrollTriggerKey: Any? = null,
+  gridColumns: Int? = null,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
 
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
   val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
   val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
 
   val configuration = LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val columns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+  
+  val columns = gridColumns ?: run {
+    val isFolder = remember(items) {
+      items.firstOrNull()?.let {
+        it is VideoFolder || 
+        it is FileSystemItem.Folder
+      } ?: false
+    }
+    if (isFolder) {
+      if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+    } else {
+      if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+    }
+  }
 
   val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -57,6 +57,7 @@ fun <T> UnifiedExplorerContent(
   newVideoIds: Set<Long> = emptySet(),
   watchedVideoIds: Set<Long> = emptySet(),
   autoScrollToLastPlayed: Boolean = false,
+  scrollTriggerKey: Any? = null,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -99,6 +100,17 @@ fun <T> UnifiedExplorerContent(
   } else {
     val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
+
+    // Scroll to top whenever the caller changes the sort key, skipping the initial composition
+    val isInitialTrigger = remember { mutableStateOf(true) }
+    LaunchedEffect(scrollTriggerKey) {
+      if (isInitialTrigger.value) {
+        isInitialTrigger.value = false
+        return@LaunchedEffect
+      }
+      listState.scrollToItem(0)
+      gridState.scrollToItem(0)
+    }
 
     if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && items.isNotEmpty()) {
       val lastPlayedIndex = items.indexOfFirst { item ->

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/components/UnifiedExplorerContent.kt
@@ -324,6 +324,8 @@ private fun <T> ExplorerItemCard(
       )
     }
     is VideoWithPlaybackInfo -> {
+      val isRecentlyPlayed = recentlyPlayedFilePath == item.video.path
+
       VideoCard(
         video = item.video,
         uiSettings = uiSettings,
@@ -337,7 +339,8 @@ private fun <T> ExplorerItemCard(
         progressPercentage = item.progressPercentage,
         isWatched = item.isWatched,
         isOldAndUnplayed = item.isOldAndUnplayed,
-        isNeverPlayed = item.isNeverPlayed
+        isNeverPlayed = item.isNeverPlayed,
+        isRecentlyPlayed = isRecentlyPlayed
       )
     }
     is PlaylistWithCount -> {
@@ -355,6 +358,8 @@ private fun <T> ExplorerItemCard(
       )
     }
     is RecentlyPlayedItem.VideoItem -> {
+      val isRecentlyPlayed = recentlyPlayedFilePath == item.video.path
+
       VideoCard(
         video = item.video,
         uiSettings = uiSettings,
@@ -366,7 +371,8 @@ private fun <T> ExplorerItemCard(
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
         progressPercentage = item.progress,
-        isWatched = item.isWatched
+        isWatched = item.isWatched,
+        isRecentlyPlayed = isRecentlyPlayed
       )
     }
     is RecentlyPlayedItem.PlaylistItem -> {

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -910,6 +910,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
                 videoSelectionManager = videoSelectionManager,
                 modifier = Modifier,
                 isInSelectionMode = isInSelectionMode,
+                scrollTriggerKey = "${sortType.name}:${sortOrder.name}",
               )
             }
           }
@@ -1320,6 +1321,7 @@ private fun FileSystemBrowserContent(
   videoSelectionManager: app.marlboroadvance.mpvex.ui.browser.selection.SelectionManager<app.marlboroadvance.mpvex.domain.media.model.Video, Long>,
   modifier: Modifier = Modifier,
   isInSelectionMode: Boolean = false,
+  scrollTriggerKey: Any? = null,
 ) {
   val thumbnailRepository = koinInject<app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository>()
   val browserPreferences = koinInject<BrowserPreferences>()
@@ -1401,7 +1403,8 @@ private fun FileSystemBrowserContent(
       isInSelectionMode = isInSelectionMode,
       recentlyPlayedFilePath = recentlyPlayedFilePath,
       newVideoIds = newVideoIds,
-      watchedVideoIds = watchedVideoIds
+      watchedVideoIds = watchedVideoIds,
+      scrollTriggerKey = scrollTriggerKey,
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -100,6 +100,7 @@ import app.marlboroadvance.mpvex.ui.browser.cards.FolderCard
 import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserBottomBar
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.components.SelectionOverflowAction
 import app.marlboroadvance.mpvex.ui.browser.dialogs.AddToPlaylistDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.DeleteConfirmationDialog
@@ -1320,13 +1321,11 @@ private fun FileSystemBrowserContent(
   modifier: Modifier = Modifier,
   isInSelectionMode: Boolean = false,
 ) {
-  val gesturePreferences = koinInject<GesturePreferences>()
-  val browserPreferences = koinInject<BrowserPreferences>()
   val thumbnailRepository = koinInject<app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository>()
-  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
+  val browserPreferences = koinInject<BrowserPreferences>()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
 
-  // Calculate thumbnail dimensions for list mode
+  // Calculate thumbnail dimensions
   val thumbWidthDp = 160.dp
   val density = androidx.compose.ui.platform.LocalDensity.current
   val aspect = 16f / 9f
@@ -1336,7 +1335,6 @@ private fun FileSystemBrowserContent(
   val folders = items.filterIsInstance<FileSystemItem.Folder>()
   val videos = items.filterIsInstance<FileSystemItem.VideoFile>().map { it.video }
 
-  // Create a unique folderId based on the current directories
   val folderId = remember(folders, isAtRoot, breadcrumbs) {
     if (isAtRoot && breadcrumbs.isEmpty()) {
       "filesystem_root"
@@ -1357,180 +1355,42 @@ private fun FileSystemBrowserContent(
     }
   }
 
-  when {
-    isLoading -> {
-      Box(
-        modifier = modifier
-          .fillMaxSize()
-          .padding(bottom = 80.dp), // Account for bottom navigation bar
-        contentAlignment = Alignment.Center,
-      ) {
-        CircularProgressIndicator(
-          modifier = Modifier.size(48.dp),
-          color = MaterialTheme.colorScheme.primary,
-        )
-      }
-    }
-
-    error != null -> {
-      Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        EmptyState(
-          icon = Icons.Filled.Folder,
-          title = "Error loading directory",
-          message = error,
-        )
-      }
-    }
-
-    items.isEmpty() && itemsWereDeletedOrMoved && !isAtRoot -> {
-      Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        EmptyState(
-          icon = Icons.Filled.FolderOpen,
-          title = "Empty folder",
-          message = "This folder contains no videos or subfolders",
-        )
-      }
-    }
-
-    else -> {
-      // Check if at top of list to hide scrollbar during pull-to-refresh
-      val isAtTop by remember {
-        derivedStateOf {
-          listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-        }
-      }
-
-      // Only show scrollbar if list has more than 20 items
-      val hasEnoughItems = items.size > 20
-
-      // Animate scrollbar alpha
-      val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-        targetValue = if (isAtTop || !hasEnoughItems) 0f else 1f,
-        animationSpec = tween(durationMillis = 200),
-        label = "scrollbarAlpha",
+  Column(modifier = modifier.fillMaxSize()) {
+    // Breadcrumb navigation (if not at root)
+    if (!isAtRoot && breadcrumbs.isNotEmpty()) {
+      app.marlboroadvance.mpvex.ui.browser.filesystem.BreadcrumbNavigation(
+        breadcrumbs = breadcrumbs,
+        onBreadcrumbClick = onBreadcrumbClick,
       )
-
-      PullRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        listState = listState,
-        modifier = modifier.fillMaxSize(),
-      ) {
-        Box(
-          modifier = Modifier.fillMaxSize()
-        ) {
-          LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = 8.dp,
-              end = 8.dp,
-              bottom = navigationBarHeight
-            ),
-          ) {
-            // Breadcrumb navigation (if not at root)
-            if (!isAtRoot && breadcrumbs.isNotEmpty()) {
-              item {
-                app.marlboroadvance.mpvex.ui.browser.filesystem.BreadcrumbNavigation(
-                  breadcrumbs = breadcrumbs,
-                  onBreadcrumbClick = onBreadcrumbClick,
-                )
-              }
-            }
-
-            // Folders first
-            items(
-              items = items.filterIsInstance<FileSystemItem.Folder>(),
-              key = { it.path },
-            ) { folder ->
-              val folderModel = app.marlboroadvance.mpvex.domain.media.model.VideoFolder(
-                bucketId = folder.path,
-                name = folder.name,
-                path = folder.path,
-                videoCount = folder.videoCount,
-                audioCount = folder.audioCount,
-                totalSize = folder.totalSize,
-                totalDuration = folder.totalDuration,
-                lastModified = folder.lastModified / 1000,
-                newCount = folder.newCount,
-                unwatchedVideoCount = folder.unwatchedVideoCount,
-              )
-
-              FolderCard(
-                folder = folderModel,
-                uiSettings = uiSettings,
-                isSelected = folderSelectionManager.isSelected(folder),
-                newVideoCount = folder.newCount,
-                isWatched = (folder.videoCount > 0 || folder.audioCount > 0) && folder.unwatchedVideoCount == 0,
-                isRecentlyPlayed = recentlyPlayedFilePath?.let { it.startsWith(folder.path + "/") && folder.path != "/" } ?: false,
-                onClick = { onFolderClick(folder) },
-                onLongClick = { onFolderLongClick(folder) },
-                onThumbClick = if (tapThumbnailToSelect) {
-                  { onFolderLongClick(folder) }
-                } else {
-                  { onFolderClick(folder) }
-                },
-                isGridMode = false,
-              )
-            }
-
-            // Videos second
-            items(
-              items = items.filterIsInstance<FileSystemItem.VideoFile>(),
-              key = { "${it.video.id}_${it.video.path}" },
-            ) { videoFile ->
-              val isRecentlyPlayed = recentlyPlayedFilePath?.let { 
-                videoFile.video.path == it || videoFile.video.uri.toString() == it 
-              } ?: false
-
-              VideoCard(
-                video = videoFile.video,
-                uiSettings = uiSettings,
-                progressPercentage = videoFilesWithPlayback[videoFile.video.id],
-                isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
-                isWatched = watchedVideoIds.contains(videoFile.video.id),
-                isRecentlyPlayed = isRecentlyPlayed,
-                isNeverPlayed = videoFilesWithPlayback[videoFile.video.id] == null,
-                isSelected = videoSelectionManager.isSelected(videoFile.video),
-                onClick = { onVideoClick(videoFile.video) },
-                onLongClick = { onVideoLongClick(videoFile.video) },
-                onThumbClick = if (tapThumbnailToSelect) {
-                  { onVideoLongClick(videoFile.video) }
-                } else {
-                  { onVideoClick(videoFile.video) }
-                },
-                isGridMode = false,
-                showSubtitleIndicator = showSubtitleIndicator,
-                useFolderNameStyle = false,
-              )
-            }
-          }
-          
-          // Scrollbar with bottom padding to avoid overlap with navigation
-          Box(
-            modifier = Modifier
-              .fillMaxSize()
-              .padding(bottom = navigationBarHeight)
-          ) {
-            LazyColumnScrollbar(
-              state = listState,
-              settings = ScrollbarSettings(
-                thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-                thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-              ),
-            ) {
-              // Empty content - scrollbar only
-            }
-          }
-        }
-      }
     }
+
+    UnifiedExplorerContent(
+      items = items,
+      isLoading = isLoading,
+      uiSettings = uiSettings,
+      isSelected = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> folderSelectionManager.isSelected(item)
+          is FileSystemItem.VideoFile -> videoSelectionManager.isSelected(item.video)
+          else -> false
+        }
+      },
+      onClick = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> onFolderClick(item)
+          is FileSystemItem.VideoFile -> onVideoClick(item.video)
+        }
+      },
+      onLongClick = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> onFolderLongClick(item)
+          is FileSystemItem.VideoFile -> onVideoLongClick(item.video)
+        }
+      },
+      modifier = Modifier.weight(1f),
+      emptyTitle = "Empty folder",
+      emptyMessage = "This folder contains no videos or subfolders"
+    )
   }
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -15,6 +15,10 @@ import androidx.compose.animation.slideOutVertically
 import app.marlboroadvance.mpvex.utils.media.OpenDocumentTreeContract
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -81,6 +85,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -90,6 +95,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.marlboroadvance.mpvex.BuildConfig
 import app.marlboroadvance.mpvex.domain.browser.FileSystemItem
+import app.marlboroadvance.mpvex.domain.media.model.VideoFolder
 import app.marlboroadvance.mpvex.preferences.BrowserPreferences
 import app.marlboroadvance.mpvex.preferences.GesturePreferences
 import app.marlboroadvance.mpvex.preferences.MediaLayoutMode
@@ -1288,10 +1294,24 @@ private fun playVideosAsPlaylist(
   if (videos.size == 1) {
     // Single video - play normally
     MediaUtils.playFile(videos.first(), context)
-  } else {
-    // Multiple videos - play as playlist
-    MediaUtils.playPlaylist(videos, 0, context)
-  }}
+    } else {
+      // Multiple videos - play as playlist
+      MediaUtils.playPlaylist(videos, 0, context)
+    }
+  }
+
+@Composable
+private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
+  Text(
+    text = title,
+    style = MaterialTheme.typography.titleMedium,
+    color = MaterialTheme.colorScheme.primary,
+    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 8.dp, vertical = 12.dp)
+  )
+}
 
 @Composable
 private fun FileSystemBrowserContent(
@@ -1325,6 +1345,7 @@ private fun FileSystemBrowserContent(
 ) {
   val thumbnailRepository = koinInject<app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository>()
   val browserPreferences = koinInject<BrowserPreferences>()
+  val gesturePreferences = koinInject<GesturePreferences>()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
 
   // Calculate thumbnail dimensions
@@ -1357,6 +1378,19 @@ private fun FileSystemBrowserContent(
     }
   }
 
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+  val configuration = LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
+
   Column(modifier = modifier.fillMaxSize()) {
     // Breadcrumb navigation (if not at root)
     if (!isAtRoot && breadcrumbs.isNotEmpty()) {
@@ -1366,46 +1400,294 @@ private fun FileSystemBrowserContent(
       )
     }
 
-    UnifiedExplorerContent(
-      items = items,
-      isLoading = isLoading,
-      uiSettings = uiSettings,
-      isSelected = { item ->
-        when (item) {
-          is FileSystemItem.Folder -> folderSelectionManager.isSelected(item)
-          is FileSystemItem.VideoFile -> videoSelectionManager.isSelected(item.video)
-          else -> false
+    val contentBlock: @Composable BoxScope.() -> Unit = {
+      if (isLoading && items.isEmpty()) {
+        Box(
+          modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = 80.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          CircularProgressIndicator(
+            modifier = Modifier.size(48.dp),
+            color = MaterialTheme.colorScheme.primary,
+          )
         }
-      },
-      onClick = { item ->
-        when (item) {
-          is FileSystemItem.Folder -> onFolderClick(item)
-          is FileSystemItem.VideoFile -> onVideoClick(item.video)
+      } else if (items.isEmpty()) {
+        Box(
+          modifier = Modifier.fillMaxSize(),
+          contentAlignment = Alignment.Center,
+        ) {
+          EmptyState(
+            icon = Icons.Filled.VideoLibrary,
+            title = "Empty folder",
+            message = "This folder contains no videos or subfolders",
+          )
         }
-      },
-      onLongClick = { item ->
-        when (item) {
-          is FileSystemItem.Folder -> onFolderLongClick(item)
-          is FileSystemItem.VideoFile -> onVideoLongClick(item.video)
+      } else {
+        val folderItems = items.filterIsInstance<FileSystemItem.Folder>()
+        val videoItems = items.filterIsInstance<FileSystemItem.VideoFile>()
+
+        LazyColumnScrollbar(
+          state = listState,
+          settings = ScrollbarSettings(
+            thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+            thumbSelectedColor = MaterialTheme.colorScheme.primary,
+          )
+        ) {
+          LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+              start = 8.dp,
+              end = 8.dp,
+              top = 8.dp,
+              bottom = navigationBarHeight + 8.dp
+            ),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+          ) {
+            // --- FOLDERS SECTION ---
+            if (folderItems.isNotEmpty()) {
+              item(key = "folders_header") {
+                SectionHeader(title = "Folders (${folderItems.size})")
+              }
+
+              if (mediaLayoutMode == MediaLayoutMode.GRID) {
+                val chunkedFolders = folderItems.chunked(folderGridColumns)
+                items(
+                  items = chunkedFolders,
+                  key = { chunk -> "folder_row_${chunk.first().path}" }
+                ) { rowItems ->
+                  Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                  ) {
+                    for (folderItem in rowItems) {
+                      Box(modifier = Modifier.weight(1f)) {
+                        val folderModel = app.marlboroadvance.mpvex.domain.media.model.VideoFolder(
+                          bucketId = folderItem.path,
+                          name = folderItem.name,
+                          path = folderItem.path,
+                          videoCount = folderItem.videoCount,
+                          audioCount = folderItem.audioCount,
+                          totalSize = folderItem.totalSize,
+                          totalDuration = folderItem.totalDuration,
+                          lastModified = folderItem.lastModified / 1000,
+                          newCount = folderItem.newCount,
+                          unwatchedVideoCount = folderItem.unwatchedVideoCount,
+                        )
+                        val isRecentlyPlayed = recentlyPlayedFilePath?.let {
+                          File(it).parent == folderItem.path
+                        } ?: false
+                        val isWatched = (folderItem.videoCount > 0 || folderItem.audioCount > 0) && folderItem.unwatchedVideoCount == 0
+
+                        FolderCard(
+                          folder = folderModel,
+                          uiSettings = uiSettings,
+                          isSelected = folderSelectionManager.isSelected(folderItem),
+                          isRecentlyPlayed = isRecentlyPlayed,
+                          isNeverPlayed = false,
+                          isWatched = isWatched,
+                          onClick = {
+                            if (isInSelectionMode) {
+                              folderSelectionManager.toggle(folderItem)
+                            } else {
+                              onFolderClick(folderItem)
+                            }
+                          },
+                          onLongClick = { onFolderLongClick(folderItem) },
+                          onThumbClick = {
+                            if (isInSelectionMode) {
+                              folderSelectionManager.toggle(folderItem)
+                            } else {
+                              onFolderClick(folderItem)
+                            }
+                          },
+                          isGridMode = true,
+                          gridColumns = folderGridColumns,
+                          newVideoCount = folderItem.newCount
+                        )
+                      }
+                    }
+                    val emptySlots = folderGridColumns - rowItems.size
+                    repeat(emptySlots) {
+                      Spacer(modifier = Modifier.weight(1f))
+                    }
+                  }
+                }
+              } else {
+                // List Mode
+                items(
+                  items = folderItems,
+                  key = { "folder_${it.path}" }
+                ) { folderItem ->
+                  val folderModel = app.marlboroadvance.mpvex.domain.media.model.VideoFolder(
+                    bucketId = folderItem.path,
+                    name = folderItem.name,
+                    path = folderItem.path,
+                    videoCount = folderItem.videoCount,
+                    audioCount = folderItem.audioCount,
+                    totalSize = folderItem.totalSize,
+                    totalDuration = folderItem.totalDuration,
+                    lastModified = folderItem.lastModified / 1000,
+                    newCount = folderItem.newCount,
+                    unwatchedVideoCount = folderItem.unwatchedVideoCount,
+                  )
+                  val isRecentlyPlayed = recentlyPlayedFilePath?.let {
+                    File(it).parent == folderItem.path
+                  } ?: false
+                  val isWatched = (folderItem.videoCount > 0 || folderItem.audioCount > 0) && folderItem.unwatchedVideoCount == 0
+
+                  FolderCard(
+                    folder = folderModel,
+                    uiSettings = uiSettings,
+                    isSelected = folderSelectionManager.isSelected(folderItem),
+                    isRecentlyPlayed = isRecentlyPlayed,
+                    isNeverPlayed = false,
+                    isWatched = isWatched,
+                    onClick = {
+                      if (isInSelectionMode) {
+                        folderSelectionManager.toggle(folderItem)
+                      } else {
+                        onFolderClick(folderItem)
+                      }
+                    },
+                    onLongClick = { onFolderLongClick(folderItem) },
+                    onThumbClick = {
+                      if (isInSelectionMode) {
+                        folderSelectionManager.toggle(folderItem)
+                      } else {
+                        onFolderClick(folderItem)
+                      }
+                    },
+                    isGridMode = false,
+                    gridColumns = 1,
+                    newVideoCount = folderItem.newCount
+                  )
+                }
+              }
+            }
+
+            // Divider spacer
+            if (folderItems.isNotEmpty() && videoItems.isNotEmpty()) {
+              item(key = "section_divider") {
+                Spacer(modifier = Modifier.height(8.dp))
+              }
+            }
+
+            // --- MEDIA SECTION ---
+            if (videoItems.isNotEmpty()) {
+              item(key = "media_header") {
+                SectionHeader(title = "Media (${videoItems.size})")
+              }
+
+              if (mediaLayoutMode == MediaLayoutMode.GRID) {
+                val chunkedVideos = videoItems.chunked(videoGridColumns)
+                items(
+                  items = chunkedVideos,
+                  key = { chunk -> "video_row_${chunk.first().video.id}" }
+                ) { rowItems ->
+                  Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                  ) {
+                    for (videoItem in rowItems) {
+                      Box(modifier = Modifier.weight(1f)) {
+                        val isOldAndUnplayed = newVideoIds.contains(videoItem.video.id)
+                        val isWatched = watchedVideoIds.contains(videoItem.video.id)
+                        val isRecentlyPlayed = recentlyPlayedFilePath == videoItem.video.path
+
+                        VideoCard(
+                          video = videoItem.video,
+                          uiSettings = uiSettings,
+                          isSelected = videoSelectionManager.isSelected(videoItem.video),
+                          onClick = {
+                            if (isInSelectionMode) {
+                              videoSelectionManager.toggle(videoItem.video)
+                            } else {
+                              onVideoClick(videoItem.video)
+                            }
+                          },
+                          onLongClick = { onVideoLongClick(videoItem.video) },
+                          onThumbClick = {
+                            if (isInSelectionMode) {
+                              videoSelectionManager.toggle(videoItem.video)
+                            } else if (tapThumbnailToSelect) {
+                              videoSelectionManager.toggle(videoItem.video)
+                            } else {
+                              onVideoClick(videoItem.video)
+                            }
+                          },
+                          isGridMode = true,
+                          gridColumns = videoGridColumns,
+                          showSubtitleIndicator = showSubtitleIndicator,
+                          isOldAndUnplayed = isOldAndUnplayed,
+                          isWatched = isWatched,
+                          isRecentlyPlayed = isRecentlyPlayed
+                        )
+                      }
+                    }
+                    val emptySlots = videoGridColumns - rowItems.size
+                    repeat(emptySlots) {
+                      Spacer(modifier = Modifier.weight(1f))
+                    }
+                  }
+                }
+              } else {
+                // List Mode
+                items(
+                  items = videoItems,
+                  key = { "video_${it.video.id}" }
+                ) { videoItem ->
+                  val isOldAndUnplayed = newVideoIds.contains(videoItem.video.id)
+                  val isWatched = watchedVideoIds.contains(videoItem.video.id)
+                  val isRecentlyPlayed = recentlyPlayedFilePath == videoItem.video.path
+
+                  VideoCard(
+                    video = videoItem.video,
+                    uiSettings = uiSettings,
+                    isSelected = videoSelectionManager.isSelected(videoItem.video),
+                    onClick = {
+                      if (isInSelectionMode) {
+                        videoSelectionManager.toggle(videoItem.video)
+                      } else {
+                        onVideoClick(videoItem.video)
+                      }
+                    },
+                    onLongClick = { onVideoLongClick(videoItem.video) },
+                    onThumbClick = {
+                      if (isInSelectionMode) {
+                        videoSelectionManager.toggle(videoItem.video)
+                      } else if (tapThumbnailToSelect) {
+                        videoSelectionManager.toggle(videoItem.video)
+                      } else {
+                        onVideoClick(videoItem.video)
+                      }
+                    },
+                    isGridMode = false,
+                    gridColumns = 1,
+                    showSubtitleIndicator = showSubtitleIndicator,
+                    isOldAndUnplayed = isOldAndUnplayed,
+                    isWatched = isWatched,
+                    isRecentlyPlayed = isRecentlyPlayed
+                  )
+                }
+              }
+            }
+          }
         }
-      },
-      onToggleSelection = { item ->
-        when (item) {
-          is FileSystemItem.Folder -> folderSelectionManager.toggle(item)
-          is FileSystemItem.VideoFile -> videoSelectionManager.toggle(item.video)
-        }
-      },
-      modifier = Modifier.weight(1f),
-      emptyTitle = "Empty folder",
-      emptyMessage = "This folder contains no videos or subfolders",
-      isRefreshing = isRefreshing,
-      onRefresh = onRefresh,
-      isInSelectionMode = isInSelectionMode,
-      recentlyPlayedFilePath = recentlyPlayedFilePath,
-      newVideoIds = newVideoIds,
-      watchedVideoIds = watchedVideoIds,
-      scrollTriggerKey = scrollTriggerKey,
-    )
+      }
+    }
+
+    Box(modifier = Modifier.weight(1f)) {
+      PullRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize(),
+        listState = listState,
+        content = contentBlock
+      )
+    }
   }
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1387,6 +1387,12 @@ private fun FileSystemBrowserContent(
           is FileSystemItem.VideoFile -> onVideoLongClick(item.video)
         }
       },
+      onToggleSelection = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> folderSelectionManager.toggle(item)
+          is FileSystemItem.VideoFile -> videoSelectionManager.toggle(item.video)
+        }
+      },
       modifier = Modifier.weight(1f),
       emptyTitle = "Empty folder",
       emptyMessage = "This folder contains no videos or subfolders",

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1398,7 +1398,10 @@ private fun FileSystemBrowserContent(
       emptyMessage = "This folder contains no videos or subfolders",
       isRefreshing = isRefreshing,
       onRefresh = onRefresh,
-      isInSelectionMode = isInSelectionMode
+      isInSelectionMode = isInSelectionMode,
+      recentlyPlayedFilePath = recentlyPlayedFilePath,
+      newVideoIds = newVideoIds,
+      watchedVideoIds = watchedVideoIds
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1391,7 +1391,8 @@ private fun FileSystemBrowserContent(
       emptyTitle = "Empty folder",
       emptyMessage = "This folder contains no videos or subfolders",
       isRefreshing = isRefreshing,
-      onRefresh = onRefresh
+      onRefresh = onRefresh,
+      isInSelectionMode = isInSelectionMode
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1301,19 +1301,6 @@ private fun playVideosAsPlaylist(
   }
 
 @Composable
-private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
-  Text(
-    text = title,
-    style = MaterialTheme.typography.titleMedium,
-    color = MaterialTheme.colorScheme.primary,
-    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-    modifier = modifier
-      .fillMaxWidth()
-      .padding(horizontal = 8.dp, vertical = 12.dp)
-  )
-}
-
-@Composable
 private fun FileSystemBrowserContent(
   listState: LazyListState,
   items: List<FileSystemItem>,
@@ -1345,7 +1332,6 @@ private fun FileSystemBrowserContent(
 ) {
   val thumbnailRepository = koinInject<app.marlboroadvance.mpvex.domain.thumbnail.ThumbnailRepository>()
   val browserPreferences = koinInject<BrowserPreferences>()
-  val gesturePreferences = koinInject<GesturePreferences>()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
 
   // Calculate thumbnail dimensions
@@ -1378,19 +1364,6 @@ private fun FileSystemBrowserContent(
     }
   }
 
-  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
-
-  val configuration = LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
-  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
-
-  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-
   Column(modifier = modifier.fillMaxSize()) {
     // Breadcrumb navigation (if not at root)
     if (!isAtRoot && breadcrumbs.isNotEmpty()) {
@@ -1400,294 +1373,47 @@ private fun FileSystemBrowserContent(
       )
     }
 
-    val contentBlock: @Composable BoxScope.() -> Unit = {
-      if (isLoading && items.isEmpty()) {
-        Box(
-          modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = 80.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          CircularProgressIndicator(
-            modifier = Modifier.size(48.dp),
-            color = MaterialTheme.colorScheme.primary,
-          )
+    UnifiedExplorerContent(
+      items = items,
+      isLoading = isLoading,
+      uiSettings = uiSettings,
+      isSelected = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> folderSelectionManager.isSelected(item)
+          is FileSystemItem.VideoFile -> videoSelectionManager.isSelected(item.video)
+          else -> false
         }
-      } else if (items.isEmpty()) {
-        Box(
-          modifier = Modifier.fillMaxSize(),
-          contentAlignment = Alignment.Center,
-        ) {
-          EmptyState(
-            icon = Icons.Filled.VideoLibrary,
-            title = "Empty folder",
-            message = "This folder contains no videos or subfolders",
-          )
+      },
+      onClick = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> onFolderClick(item)
+          is FileSystemItem.VideoFile -> onVideoClick(item.video)
         }
-      } else {
-        val folderItems = items.filterIsInstance<FileSystemItem.Folder>()
-        val videoItems = items.filterIsInstance<FileSystemItem.VideoFile>()
-
-        LazyColumnScrollbar(
-          state = listState,
-          settings = ScrollbarSettings(
-            thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-            thumbSelectedColor = MaterialTheme.colorScheme.primary,
-          )
-        ) {
-          LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = 8.dp,
-              end = 8.dp,
-              top = 8.dp,
-              bottom = navigationBarHeight + 8.dp
-            ),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-          ) {
-            // --- FOLDERS SECTION ---
-            if (folderItems.isNotEmpty()) {
-              item(key = "folders_header") {
-                SectionHeader(title = "Folders (${folderItems.size})")
-              }
-
-              if (mediaLayoutMode == MediaLayoutMode.GRID) {
-                val chunkedFolders = folderItems.chunked(folderGridColumns)
-                items(
-                  items = chunkedFolders,
-                  key = { chunk -> "folder_row_${chunk.first().path}" }
-                ) { rowItems ->
-                  Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                  ) {
-                    for (folderItem in rowItems) {
-                      Box(modifier = Modifier.weight(1f)) {
-                        val folderModel = app.marlboroadvance.mpvex.domain.media.model.VideoFolder(
-                          bucketId = folderItem.path,
-                          name = folderItem.name,
-                          path = folderItem.path,
-                          videoCount = folderItem.videoCount,
-                          audioCount = folderItem.audioCount,
-                          totalSize = folderItem.totalSize,
-                          totalDuration = folderItem.totalDuration,
-                          lastModified = folderItem.lastModified / 1000,
-                          newCount = folderItem.newCount,
-                          unwatchedVideoCount = folderItem.unwatchedVideoCount,
-                        )
-                        val isRecentlyPlayed = recentlyPlayedFilePath?.let {
-                          File(it).parent == folderItem.path
-                        } ?: false
-                        val isWatched = (folderItem.videoCount > 0 || folderItem.audioCount > 0) && folderItem.unwatchedVideoCount == 0
-
-                        FolderCard(
-                          folder = folderModel,
-                          uiSettings = uiSettings,
-                          isSelected = folderSelectionManager.isSelected(folderItem),
-                          isRecentlyPlayed = isRecentlyPlayed,
-                          isNeverPlayed = false,
-                          isWatched = isWatched,
-                          onClick = {
-                            if (isInSelectionMode) {
-                              folderSelectionManager.toggle(folderItem)
-                            } else {
-                              onFolderClick(folderItem)
-                            }
-                          },
-                          onLongClick = { onFolderLongClick(folderItem) },
-                          onThumbClick = {
-                            if (isInSelectionMode) {
-                              folderSelectionManager.toggle(folderItem)
-                            } else {
-                              onFolderClick(folderItem)
-                            }
-                          },
-                          isGridMode = true,
-                          gridColumns = folderGridColumns,
-                          newVideoCount = folderItem.newCount
-                        )
-                      }
-                    }
-                    val emptySlots = folderGridColumns - rowItems.size
-                    repeat(emptySlots) {
-                      Spacer(modifier = Modifier.weight(1f))
-                    }
-                  }
-                }
-              } else {
-                // List Mode
-                items(
-                  items = folderItems,
-                  key = { "folder_${it.path}" }
-                ) { folderItem ->
-                  val folderModel = app.marlboroadvance.mpvex.domain.media.model.VideoFolder(
-                    bucketId = folderItem.path,
-                    name = folderItem.name,
-                    path = folderItem.path,
-                    videoCount = folderItem.videoCount,
-                    audioCount = folderItem.audioCount,
-                    totalSize = folderItem.totalSize,
-                    totalDuration = folderItem.totalDuration,
-                    lastModified = folderItem.lastModified / 1000,
-                    newCount = folderItem.newCount,
-                    unwatchedVideoCount = folderItem.unwatchedVideoCount,
-                  )
-                  val isRecentlyPlayed = recentlyPlayedFilePath?.let {
-                    File(it).parent == folderItem.path
-                  } ?: false
-                  val isWatched = (folderItem.videoCount > 0 || folderItem.audioCount > 0) && folderItem.unwatchedVideoCount == 0
-
-                  FolderCard(
-                    folder = folderModel,
-                    uiSettings = uiSettings,
-                    isSelected = folderSelectionManager.isSelected(folderItem),
-                    isRecentlyPlayed = isRecentlyPlayed,
-                    isNeverPlayed = false,
-                    isWatched = isWatched,
-                    onClick = {
-                      if (isInSelectionMode) {
-                        folderSelectionManager.toggle(folderItem)
-                      } else {
-                        onFolderClick(folderItem)
-                      }
-                    },
-                    onLongClick = { onFolderLongClick(folderItem) },
-                    onThumbClick = {
-                      if (isInSelectionMode) {
-                        folderSelectionManager.toggle(folderItem)
-                      } else {
-                        onFolderClick(folderItem)
-                      }
-                    },
-                    isGridMode = false,
-                    gridColumns = 1,
-                    newVideoCount = folderItem.newCount
-                  )
-                }
-              }
-            }
-
-            // Divider spacer
-            if (folderItems.isNotEmpty() && videoItems.isNotEmpty()) {
-              item(key = "section_divider") {
-                Spacer(modifier = Modifier.height(8.dp))
-              }
-            }
-
-            // --- MEDIA SECTION ---
-            if (videoItems.isNotEmpty()) {
-              item(key = "media_header") {
-                SectionHeader(title = "Media (${videoItems.size})")
-              }
-
-              if (mediaLayoutMode == MediaLayoutMode.GRID) {
-                val chunkedVideos = videoItems.chunked(videoGridColumns)
-                items(
-                  items = chunkedVideos,
-                  key = { chunk -> "video_row_${chunk.first().video.id}" }
-                ) { rowItems ->
-                  Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                  ) {
-                    for (videoItem in rowItems) {
-                      Box(modifier = Modifier.weight(1f)) {
-                        val isOldAndUnplayed = newVideoIds.contains(videoItem.video.id)
-                        val isWatched = watchedVideoIds.contains(videoItem.video.id)
-                        val isRecentlyPlayed = recentlyPlayedFilePath == videoItem.video.path
-
-                        VideoCard(
-                          video = videoItem.video,
-                          uiSettings = uiSettings,
-                          isSelected = videoSelectionManager.isSelected(videoItem.video),
-                          onClick = {
-                            if (isInSelectionMode) {
-                              videoSelectionManager.toggle(videoItem.video)
-                            } else {
-                              onVideoClick(videoItem.video)
-                            }
-                          },
-                          onLongClick = { onVideoLongClick(videoItem.video) },
-                          onThumbClick = {
-                            if (isInSelectionMode) {
-                              videoSelectionManager.toggle(videoItem.video)
-                            } else if (tapThumbnailToSelect) {
-                              videoSelectionManager.toggle(videoItem.video)
-                            } else {
-                              onVideoClick(videoItem.video)
-                            }
-                          },
-                          isGridMode = true,
-                          gridColumns = videoGridColumns,
-                          showSubtitleIndicator = showSubtitleIndicator,
-                          isOldAndUnplayed = isOldAndUnplayed,
-                          isWatched = isWatched,
-                          isRecentlyPlayed = isRecentlyPlayed
-                        )
-                      }
-                    }
-                    val emptySlots = videoGridColumns - rowItems.size
-                    repeat(emptySlots) {
-                      Spacer(modifier = Modifier.weight(1f))
-                    }
-                  }
-                }
-              } else {
-                // List Mode
-                items(
-                  items = videoItems,
-                  key = { "video_${it.video.id}" }
-                ) { videoItem ->
-                  val isOldAndUnplayed = newVideoIds.contains(videoItem.video.id)
-                  val isWatched = watchedVideoIds.contains(videoItem.video.id)
-                  val isRecentlyPlayed = recentlyPlayedFilePath == videoItem.video.path
-
-                  VideoCard(
-                    video = videoItem.video,
-                    uiSettings = uiSettings,
-                    isSelected = videoSelectionManager.isSelected(videoItem.video),
-                    onClick = {
-                      if (isInSelectionMode) {
-                        videoSelectionManager.toggle(videoItem.video)
-                      } else {
-                        onVideoClick(videoItem.video)
-                      }
-                    },
-                    onLongClick = { onVideoLongClick(videoItem.video) },
-                    onThumbClick = {
-                      if (isInSelectionMode) {
-                        videoSelectionManager.toggle(videoItem.video)
-                      } else if (tapThumbnailToSelect) {
-                        videoSelectionManager.toggle(videoItem.video)
-                      } else {
-                        onVideoClick(videoItem.video)
-                      }
-                    },
-                    isGridMode = false,
-                    gridColumns = 1,
-                    showSubtitleIndicator = showSubtitleIndicator,
-                    isOldAndUnplayed = isOldAndUnplayed,
-                    isWatched = isWatched,
-                    isRecentlyPlayed = isRecentlyPlayed
-                  )
-                }
-              }
-            }
-          }
+      },
+      onLongClick = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> onFolderLongClick(item)
+          is FileSystemItem.VideoFile -> onVideoLongClick(item.video)
         }
-      }
-    }
-
-    Box(modifier = Modifier.weight(1f)) {
-      PullRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        modifier = Modifier.fillMaxSize(),
-        listState = listState,
-        content = contentBlock
-      )
-    }
+      },
+      onToggleSelection = { item ->
+        when (item) {
+          is FileSystemItem.Folder -> folderSelectionManager.toggle(item)
+          is FileSystemItem.VideoFile -> videoSelectionManager.toggle(item.video)
+        }
+      },
+      modifier = Modifier.weight(1f),
+      emptyTitle = "Empty folder",
+      emptyMessage = "This folder contains no videos or subfolders",
+      isRefreshing = isRefreshing,
+      onRefresh = onRefresh,
+      isInSelectionMode = isInSelectionMode,
+      recentlyPlayedFilePath = recentlyPlayedFilePath,
+      newVideoIds = newVideoIds,
+      watchedVideoIds = watchedVideoIds,
+      scrollTriggerKey = scrollTriggerKey,
+      showSections = true,
+    )
   }
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1389,7 +1389,9 @@ private fun FileSystemBrowserContent(
       },
       modifier = Modifier.weight(1f),
       emptyTitle = "Empty folder",
-      emptyMessage = "This folder contains no videos or subfolders"
+      emptyMessage = "This folder contains no videos or subfolders",
+      isRefreshing = isRefreshing,
+      onRefresh = onRefresh
     )
   }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1616,6 +1616,42 @@ fun FileSystemSortDialog(
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
   val showAudioFiles by browserPreferences.showAudioFiles.collectAsState()
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val folderGridColumnSelector = if (mediaLayoutMode == app.marlboroadvance.mpvex.preferences.MediaLayoutMode.GRID) {
+    app.marlboroadvance.mpvex.ui.browser.dialogs.GridColumnSelector(
+      label = "Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      currentValue = folderGridColumns,
+      onValueChange = {
+        if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
+        else browserPreferences.folderGridColumnsPortrait.set(it)
+      },
+      valueRange = if (isLandscape) 3f..5f else 2f..4f,
+      steps = if (isLandscape) 1 else 1,
+    )
+  } else null
+
+  val videoGridColumnSelector = if (mediaLayoutMode == app.marlboroadvance.mpvex.preferences.MediaLayoutMode.GRID) {
+    app.marlboroadvance.mpvex.ui.browser.dialogs.GridColumnSelector(
+      label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      currentValue = videoGridColumns,
+      onValueChange = {
+        if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
+        else browserPreferences.videoGridColumnsPortrait.set(it)
+      },
+      valueRange = if (isLandscape) 3f..5f else 1f..3f,
+      steps = if (isLandscape) 1 else 1,
+    )
+  } else null
 
   SortDialog(
     isOpen = isOpen,
@@ -1682,13 +1718,18 @@ fun FileSystemSortDialog(
       secondOptionLabel = "Grid",
       firstOptionIcon = Icons.AutoMirrored.Filled.ViewList,
       secondOptionIcon = Icons.Filled.GridView,
-      isFirstOptionSelected = true, // Always list mode
-      onViewModeChange = { /* Disabled - do nothing */ },
+      isFirstOptionSelected = mediaLayoutMode == app.marlboroadvance.mpvex.preferences.MediaLayoutMode.LIST,
+      onViewModeChange = { isFirstOption ->
+        browserPreferences.mediaLayoutMode.set(
+          if (isFirstOption) app.marlboroadvance.mpvex.preferences.MediaLayoutMode.LIST
+          else app.marlboroadvance.mpvex.preferences.MediaLayoutMode.GRID
+        )
+      },
     ),
-    folderGridColumnSelector = null,
-    videoGridColumnSelector = null,
+    folderGridColumnSelector = folderGridColumnSelector,
+    videoGridColumnSelector = videoGridColumnSelector,
     enableViewModeOptions = isAtRoot,
-    enableLayoutModeOptions = false, // Disabled/grayed out
+    enableLayoutModeOptions = true, // Enabled for FileSystem/Tree view too!
     contentToggles = listOf(
       ContentToggle(
         label = "Audio Files",

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -690,6 +690,7 @@ object FolderListScreen : Screen {
               onFolderLongClick = { folder ->
                 selectionManager.handleLongClick(folder)
               },
+              scrollTriggerKey = "${folderSortType.name}:${folderSortOrder.name}",
             )
             }
           }
@@ -919,6 +920,7 @@ private fun FolderListContent(
   onRefresh: suspend () -> Unit,
   onFolderClick: (VideoFolder) -> Unit,
   onFolderLongClick: (VideoFolder) -> Unit,
+  scrollTriggerKey: Any? = null,
 ) {
   val showLoading = isLoading && !hasCompletedInitialLoad
 
@@ -936,7 +938,8 @@ private fun FolderListContent(
     onRefresh = onRefresh,
     isInSelectionMode = selectionManager.isInSelectionMode,
     recentlyPlayedFilePath = recentlyPlayedFilePath,
-    playedFolderPaths = playedFolderPaths
+    playedFolderPaths = playedFolderPaths,
+    scrollTriggerKey = scrollTriggerKey,
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -108,6 +108,7 @@ import app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight
 import app.marlboroadvance.mpvex.ui.browser.cards.FolderCard
 import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.components.SelectionOverflowAction
 import app.marlboroadvance.mpvex.ui.browser.dialogs.DeleteConfirmationDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.GridColumnSelector
@@ -919,99 +920,18 @@ private fun FolderListContent(
   onFolderClick: (VideoFolder) -> Unit,
   onFolderLongClick: (VideoFolder) -> Unit,
 ) {
-  val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
   val showLoading = isLoading && !hasCompletedInitialLoad
-  val showEmpty = folders.isEmpty() && hasCompletedInitialLoad && !foldersWereDeleted
 
-  // Scrollbar alpha animation
-  val isAtTop by remember {
-    derivedStateOf {
-      if (isGridMode) {
-        gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
-      } else {
-        listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-      }
-    }
-  }
-
-  val hasEnoughItems = folders.size > 20
-  val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-    targetValue = if (isAtTop || !hasEnoughItems) 0f else 1f,
-    animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
-    label = "scrollbarAlpha",
+  UnifiedExplorerContent(
+    items = folders,
+    isLoading = showLoading,
+    uiSettings = uiSettings,
+    isSelected = { selectionManager.isSelected(it) },
+    onClick = { onFolderClick(it) },
+    onLongClick = { onFolderLongClick(it) },
+    emptyTitle = "No video folders found",
+    emptyMessage = "Add videos to your device to see folders here"
   )
-
-  PullRefreshBox(
-    isRefreshing = isRefreshing,
-    onRefresh = onRefresh,
-    listState = listState,
-    modifier = Modifier.fillMaxSize(),
-  ) {
-    if (showLoading || showEmpty) {
-      Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        if (showLoading) {
-          LoadingState(
-            icon = Icons.Filled.Folder,
-            title = "Scanning for videos...",
-            message = scanStatus ?: "Please wait while we search your device",
-          )
-        } else if (showEmpty) {
-          EmptyState(
-            icon = Icons.Filled.Folder,
-            title = "No video folders found",
-            message = "Add some video files to your device to see them here",
-          )
-        }
-      }
-    } else {
-      if (isGridMode) {
-        GridContent(
-          folders = folders,
-          foldersWithNewCount = foldersWithNewCount,
-          uiSettings = uiSettings,
-          recentlyPlayedFilePath = recentlyPlayedFilePath,
-          playedFolderPaths = playedFolderPaths,
-          folderGridColumns = folderGridColumns,
-          tapThumbnailToSelect = tapThumbnailToSelect,
-          navigationBarHeight = navigationBarHeight,
-          gridState = gridState,
-          scrollbarAlpha = scrollbarAlpha,
-          selectionManager = selectionManager,
-          onFolderClick = onFolderClick,
-          onFolderLongClick = onFolderLongClick,
-        )
-      } else {
-        ListContent(
-          folders = folders,
-          foldersWithNewCount = foldersWithNewCount,
-          uiSettings = uiSettings,
-          recentlyPlayedFilePath = recentlyPlayedFilePath,
-          playedFolderPaths = playedFolderPaths,
-          tapThumbnailToSelect = tapThumbnailToSelect,
-          navigationBarHeight = navigationBarHeight,
-          listState = listState,
-          scrollbarAlpha = scrollbarAlpha,
-          selectionManager = selectionManager,
-          onFolderClick = onFolderClick,
-          onFolderLongClick = onFolderLongClick,
-        )
-      }
-
-      // Show background enrichment progress
-      if (scanStatus != null && !showLoading) {
-        androidx.compose.material3.LinearProgressIndicator(
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(2.dp),
-          color = MaterialTheme.colorScheme.secondary,
-          trackColor = MaterialTheme.colorScheme.surfaceVariant
-        )
-      }
-    }
-  }
 }
 
 @Composable

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -934,7 +934,9 @@ private fun FolderListContent(
     emptyMessage = "Add videos to your device to see folders here",
     isRefreshing = isRefreshing,
     onRefresh = onRefresh,
-    isInSelectionMode = selectionManager.isInSelectionMode
+    isInSelectionMode = selectionManager.isInSelectionMode,
+    recentlyPlayedFilePath = recentlyPlayedFilePath,
+    playedFolderPaths = playedFolderPaths
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -929,6 +929,7 @@ private fun FolderListContent(
     isSelected = { selectionManager.isSelected(it) },
     onClick = { onFolderClick(it) },
     onLongClick = { onFolderLongClick(it) },
+    onToggleSelection = { selectionManager.toggle(it) },
     emptyTitle = "No video folders found",
     emptyMessage = "Add videos to your device to see folders here",
     isRefreshing = isRefreshing,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -932,7 +932,8 @@ private fun FolderListContent(
     emptyTitle = "No video folders found",
     emptyMessage = "Add videos to your device to see folders here",
     isRefreshing = isRefreshing,
-    onRefresh = onRefresh
+    onRefresh = onRefresh,
+    isInSelectionMode = selectionManager.isInSelectionMode
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -930,7 +930,9 @@ private fun FolderListContent(
     onClick = { onFolderClick(it) },
     onLongClick = { onFolderLongClick(it) },
     emptyTitle = "No video folders found",
-    emptyMessage = "Add videos to your device to see folders here"
+    emptyMessage = "Add videos to your device to see folders here",
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -940,6 +940,7 @@ private fun FolderListContent(
     recentlyPlayedFilePath = recentlyPlayedFilePath,
     playedFolderPaths = playedFolderPaths,
     scrollTriggerKey = scrollTriggerKey,
+    gridColumns = folderGridColumns,
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -70,6 +70,7 @@ import app.marlboroadvance.mpvex.presentation.components.pullrefresh.PullRefresh
 import app.marlboroadvance.mpvex.ui.browser.cards.M3UVideoCard
 import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.components.SelectionOverflowAction
 import app.marlboroadvance.mpvex.ui.browser.selection.rememberSelectionManager
 import app.marlboroadvance.mpvex.ui.player.PlayerActivity
@@ -562,158 +563,17 @@ private fun PlaylistVideoListContent(
   modifier: Modifier = Modifier,
   isM3uPlaylist: Boolean = false,
 ) {
-  val gesturePreferences = koinInject<GesturePreferences>()
-  val browserPreferences = koinInject<app.marlboroadvance.mpvex.preferences.BrowserPreferences>()
-  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-  val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
-
-  // Find the most recently played video (highest lastPlayedAt timestamp)
-  val mostRecentlyPlayedItem = remember(videoItems) {
-    videoItems.filter { it.playlistItem.lastPlayedAt > 0 }
-      .maxByOrNull { it.playlistItem.lastPlayedAt }
-  }
-
-  when {
-    isLoading -> {
-      Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        CircularProgressIndicator(
-          modifier = Modifier.size(48.dp),
-          color = MaterialTheme.colorScheme.primary,
-        )
-      }
-    }
-
-    videoItems.isEmpty() -> {
-      Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        androidx.compose.foundation.layout.Column(
-          horizontalAlignment = Alignment.CenterHorizontally,
-          verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
-        ) {
-          Icon(
-            imageVector = Icons.AutoMirrored.Outlined.PlaylistAdd,
-            contentDescription = null,
-            modifier = Modifier.size(64.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-          Text(
-            text = "No videos in playlist",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-          Text(
-            text = "Add videos to get started",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
-      }
-    }
-
-    else -> {
-      // Only show scrollbar if list has more than 20 items
-      val hasEnoughItems = videoItems.size > 20
-
-      // Animate scrollbar alpha
-      val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-        targetValue = if (!hasEnoughItems) 0f else 1f,
-        animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
-        label = "scrollbarAlpha",
-      )
-
-      // Reorderable state
-      val reorderableLazyListState = rememberReorderableLazyListState(listState) { from, to ->
-        if (isReorderMode) {
-          onReorder(from.index, to.index)
-        }
-      }
-
-      LazyColumnScrollbar(
-        state = listState,
-        settings = ScrollbarSettings(
-          thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-          thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-        ),
-        modifier = modifier.fillMaxSize(),
-      ) {
-        LazyColumn(
-          state = listState,
-          modifier = Modifier.fillMaxSize(),
-          contentPadding = PaddingValues(start = 8.dp, end = 8.dp),
-        ) {
-          items(
-            count = videoItems.size,
-            key = { index -> videoItems[index].playlistItem.id },
-          ) { index ->
-            ReorderableItem(reorderableLazyListState, key = videoItems[index].playlistItem.id) {
-              val item = videoItems[index]
-
-              val progressPercentage = if (item.playlistItem.lastPosition > 0 && item.video.duration > 0) {
-                item.playlistItem.lastPosition.toFloat() / item.video.duration.toFloat() * 100f
-              } else null
-
-              Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-              ) {
-                // Use M3UVideoCard for streaming URLs, VideoCard for local files
-                if (isM3uPlaylist) {
-                  M3UVideoCard(
-                    title = item.video.displayName,
-                    url = item.video.path,
-                    uiSettings = uiSettings,
-                    onClick = { onVideoItemClick(item) },
-                    onLongClick = { onVideoItemLongClick(item) },
-                    isSelected = selectionManager.isSelected(item),
-                    isRecentlyPlayed = item.playlistItem.id == mostRecentlyPlayedItem?.playlistItem?.id,
-                    modifier = Modifier.weight(1f),
-                  )
-                } else {
-                  VideoCard(
-                    video = item.video,
-                    uiSettings = uiSettings,
-                    progressPercentage = progressPercentage,
-                    isRecentlyPlayed = item.playlistItem.id == mostRecentlyPlayedItem?.playlistItem?.id,
-                    isSelected = selectionManager.isSelected(item),
-                    onClick = { onVideoItemClick(item) },
-                    onLongClick = { onVideoItemLongClick(item) },
-                    onThumbClick = if (tapThumbnailToSelect) {
-                      { onVideoItemLongClick(item) }
-                    } else {
-                      { onVideoItemClick(item) }
-                    },
-                    showSubtitleIndicator = showSubtitleIndicator,
-                    modifier = Modifier.weight(1f),
-                  )
-                }
-
-                // Drag handle - only show when in reorder mode, positioned at the end
-                if (isReorderMode) {
-                  IconButton(
-                    onClick = { },
-                    modifier = Modifier
-                      .size(48.dp)
-                      .draggableHandle(),
-                  ) {
-                    Icon(
-                      imageVector = Icons.Filled.DragHandle,
-                      contentDescription = "Drag to reorder",
-                      tint = MaterialTheme.colorScheme.primary,
-                    )
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  UnifiedExplorerContent(
+    items = videoItems,
+    isLoading = isLoading,
+    uiSettings = uiSettings,
+    isSelected = { selectionManager.isSelected(it) },
+    onClick = onVideoItemClick,
+    onLongClick = onVideoItemLongClick,
+    modifier = modifier,
+    emptyTitle = "No videos in this playlist",
+    emptyMessage = "Add videos from the browser to build your playlist"
+  )
 }
 
 @Composable

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -570,6 +570,7 @@ private fun PlaylistVideoListContent(
     isSelected = { selectionManager.isSelected(it) },
     onClick = onVideoItemClick,
     onLongClick = onVideoItemLongClick,
+    onToggleSelection = { selectionManager.toggle(it) },
     modifier = modifier,
     emptyTitle = "No videos in this playlist",
     emptyMessage = "Add videos from the browser to build your playlist",

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -572,7 +572,8 @@ private fun PlaylistVideoListContent(
     onLongClick = onVideoItemLongClick,
     modifier = modifier,
     emptyTitle = "No videos in this playlist",
-    emptyMessage = "Add videos from the browser to build your playlist"
+    emptyMessage = "Add videos from the browser to build your playlist",
+    isInSelectionMode = selectionManager.isInSelectionMode
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
@@ -70,6 +70,7 @@ import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.presentation.components.pullrefresh.PullRefreshBox
 import app.marlboroadvance.mpvex.ui.browser.cards.PlaylistCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.dialogs.DeleteConfirmationDialog
 import app.marlboroadvance.mpvex.ui.browser.selection.rememberSelectionManager
 import app.marlboroadvance.mpvex.ui.browser.sheets.PlaylistActionSheet
@@ -397,132 +398,15 @@ object PlaylistScreen : Screen {
     modifier: Modifier = Modifier,
     isInSelectionMode: Boolean = false,
   ) {
-    val browserPreferences = koinInject<app.marlboroadvance.mpvex.preferences.BrowserPreferences>()
-    val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-    val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
-
-    val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
-
-    // Check if at top of list to hide scrollbar during pull-to-refresh
-    val isAtTop by remember {
-      derivedStateOf {
-        if (isGridMode) {
-          gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
-        } else {
-          listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-        }
-      }
-    }
-
-    // Only show scrollbar if list has more than 20 items
-    val hasEnoughItems = playlistsWithCount.size > 20
-
-    // Animate scrollbar alpha
-    val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-      targetValue = if (isAtTop || !hasEnoughItems) 0f else 1f,
-      animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
-      label = "scrollbarAlpha",
+    UnifiedExplorerContent(
+      items = playlistsWithCount,
+      isLoading = false,
+      uiSettings = uiSettings,
+      isSelected = { selectionManager.isSelected(it) },
+      onClick = onPlaylistClick,
+      onLongClick = onPlaylistLongClick,
+      modifier = modifier,
+      emptyTitle = "No playlists found",
+      emptyMessage = "Create a playlist to see it listed here"
     )
-
-    PullRefreshBox(
-      isRefreshing = isRefreshing,
-      onRefresh = onRefresh,
-      listState = listState,
-      modifier = modifier.fillMaxSize(),
-    ) {
-      if (isGridMode) {
-        // Grid layout
-        val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
-        Box(
-          modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = navigationBarHeight)
-        ) {
-          LazyVerticalGridScrollbar(
-            state = gridState,
-            settings = ScrollbarSettings(
-              thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-              thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-            ),
-          ) {
-            LazyVerticalGrid(
-              columns = GridCells.Fixed(folderGridColumns),
-              state = gridState,
-              modifier = Modifier.fillMaxSize(),
-              contentPadding = PaddingValues(
-                start = if (folderGridColumns == 1) 20.dp else 8.dp,
-                end = if (folderGridColumns == 1) 20.dp else 8.dp,
-                top = if (folderGridColumns == 1) 20.dp else 8.dp,
-              ),
-              horizontalArrangement = Arrangement.spacedBy(8.dp),
-              verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-              items(
-                count = playlistsWithCount.size,
-                key = { playlistsWithCount[it].playlist.id },
-              ) { index ->
-                val playlistWithCount = playlistsWithCount[index]
-                PlaylistCard(
-                  playlist = playlistWithCount.playlist,
-                  itemCount = playlistWithCount.itemCount,
-                  uiSettings = uiSettings,
-
-                  isSelected = selectionManager.isSelected(playlistWithCount),
-                  onClick = { onPlaylistClick(playlistWithCount) },
-                  onLongClick = { onPlaylistLongClick(playlistWithCount) },
-                  onThumbClick = { onPlaylistClick(playlistWithCount) },
-                  isGridMode = true,
-                  gridColumns = folderGridColumns,
-                )
-              }
-            }
-          }
-        }
-      } else {
-        // List layout
-        val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
-        Box(
-          modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = navigationBarHeight)
-        ) {
-          LazyColumnScrollbar(
-            state = listState,
-            settings = ScrollbarSettings(
-              thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-              thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-            ),
-          ) {
-            LazyColumn(
-              state = listState,
-              modifier = Modifier.fillMaxSize(),
-              contentPadding = PaddingValues(
-                start = 8.dp,
-                end = 8.dp,
-              ),
-              verticalArrangement = Arrangement.spacedBy(0.dp),
-            ) {
-              items(playlistsWithCount, key = { it.playlist.id }) { playlistWithCount ->
-                PlaylistCard(
-                  playlist = playlistWithCount.playlist,
-                  itemCount = playlistWithCount.itemCount,
-                  uiSettings = uiSettings,
-
-                  isSelected = selectionManager.isSelected(playlistWithCount),
-                  onClick = { onPlaylistClick(playlistWithCount) },
-                  onLongClick = { onPlaylistLongClick(playlistWithCount) },
-                  onThumbClick = { onPlaylistClick(playlistWithCount) },
-                  isGridMode = false,
-                )
-              }
-            }
-          }
-        }
-      }
-    }
   }
-

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
@@ -405,6 +405,7 @@ object PlaylistScreen : Screen {
       isSelected = { selectionManager.isSelected(it) },
       onClick = onPlaylistClick,
       onLongClick = onPlaylistLongClick,
+      onToggleSelection = { selectionManager.toggle(it) },
       modifier = modifier,
       emptyTitle = "No playlists found",
       emptyMessage = "Create a playlist to see it listed here",

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
@@ -409,6 +409,7 @@ object PlaylistScreen : Screen {
       emptyTitle = "No playlists found",
       emptyMessage = "Create a playlist to see it listed here",
       isRefreshing = isRefreshing,
-      onRefresh = onRefresh
+      onRefresh = onRefresh,
+      isInSelectionMode = isInSelectionMode
     )
   }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistScreen.kt
@@ -407,6 +407,8 @@ object PlaylistScreen : Screen {
       onLongClick = onPlaylistLongClick,
       modifier = modifier,
       emptyTitle = "No playlists found",
-      emptyMessage = "Create a playlist to see it listed here"
+      emptyMessage = "Create a playlist to see it listed here",
+      isRefreshing = isRefreshing,
+      onRefresh = onRefresh
     )
   }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -75,6 +75,7 @@ import app.marlboroadvance.mpvex.ui.browser.cards.FolderCard
 import app.marlboroadvance.mpvex.ui.browser.cards.PlaylistCard
 import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.playlist.PlaylistDetailScreen
 import app.marlboroadvance.mpvex.ui.browser.selection.rememberSelectionManager
 import app.marlboroadvance.mpvex.ui.browser.sheets.PlayLinkSheet
@@ -416,291 +417,25 @@ private fun RecentItemsContent(
   listState: LazyListState,
   gridState: LazyGridState,
 ) {
-  val gesturePreferences = koinInject<GesturePreferences>()
-  val browserPreferences = koinInject<app.marlboroadvance.mpvex.preferences.BrowserPreferences>()
-  val thumbnailRepository = koinInject<ThumbnailRepository>()
-  val density = LocalDensity.current
-  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-  val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
-  val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
-  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
-
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-
-  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
-
-  val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
-
   val coroutineScope = rememberCoroutineScope()
-  val isRefreshing = remember { mutableStateOf(false) }
 
-  val thumbWidthDp = if (isGridMode) {
-    (360.dp / videoGridColumns)
-  } else {
-    160.dp
-  }
-  val aspect = 16f / 9f
-  val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
-  val thumbHeightPx = (thumbWidthPx / aspect).toInt()
-
-  val recentVideos = remember(recentItems) {
-    recentItems.filterIsInstance<RecentlyPlayedItem.VideoItem>().map { it.video }
-  }
-
-  LaunchedEffect(recentVideos.size, showVideoThumbnails, thumbWidthPx, thumbHeightPx) {
-    if (showVideoThumbnails && recentVideos.isNotEmpty()) {
-      thumbnailRepository.startFolderThumbnailGeneration(
-        folderId = "recently_played",
-        videos = recentVideos,
-        widthPx = thumbWidthPx,
-        heightPx = thumbHeightPx,
-      )
-    }
-  }
-
-  val isAtTop by remember {
-    derivedStateOf {
-      if (isGridMode) {
-        gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
-      } else {
-        listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+  UnifiedExplorerContent(
+    items = recentItems,
+    isLoading = false,
+    uiSettings = uiSettings,
+    isSelected = { selectionManager.isSelected(it) },
+    onClick = { item ->
+      when (item) {
+        is RecentlyPlayedItem.VideoItem -> onVideoClick(item.video)
+        is RecentlyPlayedItem.PlaylistItem -> {
+          coroutineScope.launch {
+            onPlaylistClick(item)
+          }
+        }
       }
-    }
-  }
-
-  val hasEnoughItems = recentItems.size > 20
-
-  val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-    targetValue = if (!hasEnoughItems) 0f else 1f,
-    animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
-    label = "scrollbarAlpha",
+    },
+    onLongClick = { item -> selectionManager.handleLongClick(item) },
+    emptyTitle = "No recently played items",
+    emptyMessage = "Your recently played videos and playlists will appear here"
   )
-
-  PullRefreshBox(
-    isRefreshing = isRefreshing,
-    onRefresh = { },
-    listState = listState,
-    modifier = modifier.fillMaxSize(),
-  ) {
-    if (isGridMode) {
-      val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
-      Box(
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(bottom = navigationBarHeight)
-      ) {
-        LazyVerticalGridScrollbar(
-          state = gridState,
-          settings = ScrollbarSettings(
-            thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-            thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-          ),
-        ) {
-          LazyVerticalGrid(
-            columns = GridCells.Fixed(videoGridColumns),
-            state = gridState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = if (videoGridColumns == 1) 20.dp else 8.dp,
-              end = if (videoGridColumns == 1) 20.dp else 8.dp,
-              top = if (videoGridColumns == 1) 20.dp else 8.dp,
-              bottom = if (isInSelectionMode) 88.dp else 16.dp
-            ),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-          ) {
-            items(
-              count = recentItems.size,
-              key = { index ->
-                when (val item = recentItems[index]) {
-                  is RecentlyPlayedItem.VideoItem -> "video_${item.video.id}_${item.timestamp}"
-                  is RecentlyPlayedItem.PlaylistItem -> "playlist_${item.playlist.id}_${item.timestamp}"
-                }
-              },
-            ) { index ->
-              when (val item = recentItems[index]) {
-                is RecentlyPlayedItem.VideoItem -> {
-                  VideoCard(
-                    video = item.video,
-                    uiSettings = uiSettings,
-                    progressPercentage = item.progress,
-                    isWatched = item.isWatched,
-                    isSelected = selectionManager.isSelected(item),
-                    isRecentlyPlayed = recentlyPlayedFilePath == item.video.path,
-                    onClick = {
-                      if (selectionManager.isInSelectionMode) {
-                        selectionManager.toggle(item)
-                      } else {
-                        onVideoClick(item.video)
-                      }
-                    },
-                    onLongClick = { selectionManager.handleLongClick(item) },
-                    onThumbClick = if (tapThumbnailToSelect) {
-                      { selectionManager.toggle(item) }
-                    } else {
-                      {
-                        if (selectionManager.isInSelectionMode) {
-                          selectionManager.toggle(item)
-                        } else {
-                          onVideoClick(item.video)
-                        }
-                      }
-                    },
-                    isGridMode = true,
-                    gridColumns = videoGridColumns,
-                    showSubtitleIndicator = showSubtitleIndicator,
-                  )
-                }
-
-                is RecentlyPlayedItem.PlaylistItem -> {
-                  PlaylistCard(
-                    playlist = item.playlist,
-                    itemCount = item.videoCount,
-                    uiSettings = uiSettings,
-                    mostRecentVideoPath = item.mostRecentVideoPath,
-                    thumbnailSize = thumbWidthDp,
-                    thumbnailAspectRatio = 16f / 9f,
-                    isSelected = selectionManager.isSelected(item),
-                    onClick = {
-                      if (selectionManager.isInSelectionMode) {
-                        selectionManager.toggle(item)
-                      } else {
-                        coroutineScope.launch {
-                          onPlaylistClick(item)
-                        }
-                      }
-                    },
-                    onLongClick = { selectionManager.handleLongClick(item) },
-                    onThumbClick = {
-                      if (tapThumbnailToSelect) {
-                        selectionManager.toggle(item)
-                      } else {
-                        if (selectionManager.isInSelectionMode) {
-                          selectionManager.toggle(item)
-                        } else {
-                          coroutineScope.launch {
-                            onPlaylistClick(item)
-                          }
-                        }
-                      }
-                    },
-                    isGridMode = true,
-                    gridColumns = videoGridColumns,
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
-    } else {
-      val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
-      Box(
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(bottom = navigationBarHeight)
-      ) {
-        LazyColumnScrollbar(
-          state = listState,
-          settings = ScrollbarSettings(
-            thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-            thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-          ),
-        ) {
-          LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = 8.dp,
-              end = 8.dp,
-              bottom = if (isInSelectionMode) 88.dp else 16.dp
-            ),
-          ) {
-            items(
-              count = recentItems.size,
-              key = { index ->
-                when (val item = recentItems[index]) {
-                  is RecentlyPlayedItem.VideoItem -> "video_${item.video.id}_${item.timestamp}"
-                  is RecentlyPlayedItem.PlaylistItem -> "playlist_${item.playlist.id}_${item.timestamp}"
-                }
-              },
-            ) { index ->
-              when (val item = recentItems[index]) {
-                is RecentlyPlayedItem.VideoItem -> {
-                  VideoCard(
-                    video = item.video,
-                    uiSettings = uiSettings,
-                    progressPercentage = item.progress,
-                    isWatched = item.isWatched,
-                    isSelected = selectionManager.isSelected(item),
-                    isRecentlyPlayed = recentlyPlayedFilePath == item.video.path,
-                    onClick = {
-                      if (selectionManager.isInSelectionMode) {
-                        selectionManager.toggle(item)
-                      } else {
-                        onVideoClick(item.video)
-                      }
-                    },
-                    onLongClick = { selectionManager.handleLongClick(item) },
-                    onThumbClick = if (tapThumbnailToSelect) {
-                      { selectionManager.toggle(item) }
-                    } else {
-                      {
-                        if (selectionManager.isInSelectionMode) {
-                          selectionManager.toggle(item)
-                        } else {
-                          onVideoClick(item.video)
-                        }
-                      }
-                    },
-                    isGridMode = false,
-                    showSubtitleIndicator = showSubtitleIndicator,
-                  )
-                }
-
-                is RecentlyPlayedItem.PlaylistItem -> {
-                  PlaylistCard(
-                    playlist = item.playlist,
-                    itemCount = item.videoCount,
-                    uiSettings = uiSettings,
-                    mostRecentVideoPath = item.mostRecentVideoPath,
-                    thumbnailSize = 128.dp, // Match VideoCard list size
-                    thumbnailAspectRatio = 16f / 9f,
-                    isSelected = selectionManager.isSelected(item),
-                    onClick = {
-                      if (selectionManager.isInSelectionMode) {
-                        selectionManager.toggle(item)
-                      } else {
-                        coroutineScope.launch {
-                          onPlaylistClick(item)
-                        }
-                      }
-                    },
-                    onLongClick = { selectionManager.handleLongClick(item) },
-                    onThumbClick = {
-                      if (tapThumbnailToSelect) {
-                        selectionManager.toggle(item)
-                      } else {
-                        if (selectionManager.isInSelectionMode) {
-                          selectionManager.toggle(item)
-                        } else {
-                          coroutineScope.launch {
-                            onPlaylistClick(item)
-                          }
-                        }
-                      }
-                    },
-                    isGridMode = false,
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -439,6 +439,7 @@ private fun RecentItemsContent(
       }
     },
     onLongClick = { item -> selectionManager.handleLongClick(item) },
+    onToggleSelection = { selectionManager.toggle(it) },
     emptyTitle = "No recently played items",
     emptyMessage = "Your recently played videos and playlists will appear here",
     isRefreshing = isRefreshing,

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -111,10 +111,10 @@ object RecentlyPlayedScreen : Screen {
     val enableRecentlyPlayed by advancedPreferences.enableRecentlyPlayed.collectAsState()
     val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
 
-    // FAB visibility for scroll-based hiding
     val isFabVisible = remember { mutableStateOf(true) }
     val isFabExpanded = remember { mutableStateOf(false) }
     val showLinkDialog = remember { mutableStateOf(false) }
+    val isRefreshing = remember { mutableStateOf(false) }
     
     val coroutineScope = rememberCoroutineScope()
     
@@ -333,6 +333,8 @@ object RecentlyPlayedScreen : Screen {
             isInSelectionMode = selectionManager.isInSelectionMode,
             listState = listState,
             gridState = gridState,
+            isRefreshing = isRefreshing,
+            onRefresh = { viewModel.refresh() }
           )
         }
       }
@@ -416,6 +418,8 @@ private fun RecentItemsContent(
   isInSelectionMode: Boolean = false,
   listState: LazyListState,
   gridState: LazyGridState,
+  isRefreshing: androidx.compose.runtime.MutableState<Boolean>,
+  onRefresh: suspend () -> Unit,
 ) {
   val coroutineScope = rememberCoroutineScope()
 
@@ -436,6 +440,10 @@ private fun RecentItemsContent(
     },
     onLongClick = { item -> selectionManager.handleLongClick(item) },
     emptyTitle = "No recently played items",
-    emptyMessage = "Your recently played videos and playlists will appear here"
+    emptyMessage = "Your recently played videos and playlists will appear here",
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh,
+    modifier = modifier,
+    isInSelectionMode = isInSelectionMode
   )
 }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/selection/UnifiedExplorerModels.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/selection/UnifiedExplorerModels.kt
@@ -1,0 +1,76 @@
+package app.marlboroadvance.mpvex.ui.browser.selection
+
+import android.content.Context
+
+/**
+ * Standard item types for the Unified Explorer UI
+ */
+enum class ItemType {
+  FOLDER,
+  VIDEO,
+  PLAYLIST,
+  RECENT
+}
+
+/**
+ * Polymorphic item representing any selectable/displayable card in lists and grids
+ */
+interface ExplorerItem {
+  val id: String
+  val title: String
+  val subtitle: String?
+  val type: ItemType
+  val originalObject: Any
+}
+
+data class FolderExplorerItem(
+  override val id: String,
+  override val title: String,
+  override val subtitle: String?,
+  override val originalObject: Any
+) : ExplorerItem {
+  override val type: ItemType = ItemType.FOLDER
+}
+
+data class VideoExplorerItem(
+  override val id: String,
+  override val title: String,
+  override val subtitle: String?,
+  override val originalObject: Any
+) : ExplorerItem {
+  override val type: ItemType = ItemType.VIDEO
+}
+
+data class PlaylistExplorerItem(
+  override val id: String,
+  override val title: String,
+  override val subtitle: String?,
+  override val originalObject: Any
+) : ExplorerItem {
+  override val type: ItemType = ItemType.PLAYLIST
+}
+
+data class RecentExplorerItem(
+  override val id: String,
+  override val title: String,
+  override val subtitle: String?,
+  override val originalObject: Any
+) : ExplorerItem {
+  override val type: ItemType = ItemType.RECENT
+}
+
+/**
+ * Strategy interface driving data filter operations and custom item actions in Unified Explorer
+ */
+interface ExplorerStrategy {
+  /**
+   * Filter the given list of items based on a search query
+   */
+  fun filterItems(items: List<ExplorerItem>, query: String): List<ExplorerItem> {
+    if (query.isBlank()) return items
+    return items.filter {
+      it.title.contains(query, ignoreCase = true) ||
+          (it.subtitle?.contains(query, ignoreCase = true) == true)
+    }
+  }
+}

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -90,6 +90,7 @@ import app.marlboroadvance.mpvex.BuildConfig
 import app.marlboroadvance.mpvex.ui.browser.cards.VideoCard
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserBottomBar
 import app.marlboroadvance.mpvex.ui.browser.components.BrowserTopBar
+import app.marlboroadvance.mpvex.ui.browser.components.UnifiedExplorerContent
 import app.marlboroadvance.mpvex.ui.browser.components.SelectionOverflowAction
 import app.marlboroadvance.mpvex.ui.browser.dialogs.AddToPlaylistDialog
 import app.marlboroadvance.mpvex.ui.browser.dialogs.DeleteConfirmationDialog
@@ -613,25 +614,14 @@ fun VideoListContent(
   sortOrder: SortOrder = SortOrder.Ascending,
 ) {
   val thumbnailRepository = koinInject<ThumbnailRepository>()
-  val gesturePreferences = koinInject<GesturePreferences>()
   val browserPreferences = koinInject<BrowserPreferences>()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
-  val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
-  val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
-  val density = LocalDensity.current
-  val navigationBarHeight = app.marlboroadvance.mpvex.ui.browser.LocalNavigationBarHeight.current
-  // Must match the thumbnail size logic inside `VideoCard` for this screen,
-  // otherwise the cache keys won't line up and the UI won't receive updates.
+  val density = androidx.compose.ui.platform.LocalDensity.current
   val thumbWidthDp = if (mediaLayoutMode == MediaLayoutMode.GRID) 160.dp else 128.dp
   val aspect = 16f / 9f
   val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
-  val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+  val thumbHeightPx = (thumbWidthPx / aspect).toInt()
 
   LaunchedEffect(folderId, showVideoThumbnails, videosWithInfo.size, thumbWidthPx, thumbHeightPx) {
     if (showVideoThumbnails && videosWithInfo.isNotEmpty()) {
@@ -644,259 +634,18 @@ fun VideoListContent(
     }
   }
 
-  when {
-    isLoading && videosWithInfo.isEmpty() -> {
-      Box(
-        modifier = modifier
-          .fillMaxSize()
-          .padding(bottom = 80.dp), // Account for bottom navigation bar
-        contentAlignment = Alignment.Center,
-      ) {
-        CircularProgressIndicator(
-          modifier = Modifier.size(48.dp),
-          color = MaterialTheme.colorScheme.primary,
-        )
-      }
-    }
-
-    videosWithInfo.isEmpty() && !isLoading && videosWereDeletedOrMoved -> {
-      Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-      ) {
-        EmptyState(
-          icon = Icons.Filled.VideoLibrary,
-          title = "No videos in this folder",
-          message = "Videos you add to this folder will appear here",
-        )
-      }
-    }
-
-    else -> {
-      val rememberedListIndex = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedListOffset = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedGridIndex = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedGridOffset = rememberSaveable { mutableIntStateOf(0) }
-      
-      val initialListIndex = if (rememberedListIndex.intValue > 0) {
-          rememberedListIndex.intValue
-      } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
-          var foundIndex = 0
-          for (i in videosWithInfo.indices) {
-              if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
-                  foundIndex = i
-                  break
-              }
-          }
-          foundIndex
-      } else 0
-      
-      val initialGridIndex = if (rememberedGridIndex.intValue > 0) {
-          rememberedGridIndex.intValue
-      } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
-          var foundIndex = 0
-          for (i in videosWithInfo.indices) {
-              if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
-                  foundIndex = i
-                  break
-              }
-          }
-          foundIndex
-      } else 0
-      
-      val listState = rememberLazyListState(
-          initialFirstVisibleItemIndex = initialListIndex,
-          initialFirstVisibleItemScrollOffset = rememberedListOffset.intValue
-      )
-      
-      val gridState = rememberLazyGridState(
-          initialFirstVisibleItemIndex = initialGridIndex,
-          initialFirstVisibleItemScrollOffset = rememberedGridOffset.intValue
-      )
-
-      val isInitialSortLoad = remember { mutableStateOf(true) }
-      LaunchedEffect(sortType.name, sortOrder.name) {
-          if (isInitialSortLoad.value) {
-              isInitialSortLoad.value = false
-              return@LaunchedEffect
-          }
-          rememberedListIndex.intValue = 0
-          rememberedGridIndex.intValue = 0
-          listState.scrollToItem(0)
-          gridState.scrollToItem(0)
-      }
-      
-      LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-          rememberedListIndex.intValue = listState.firstVisibleItemIndex
-          rememberedListOffset.intValue = listState.firstVisibleItemScrollOffset
-      }
-      
-      LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset) {
-          rememberedGridIndex.intValue = gridState.firstVisibleItemIndex
-          rememberedGridOffset.intValue = gridState.firstVisibleItemScrollOffset
-      }
-
-      FabScrollHelper.trackScrollForFabVisibility(
-        listState = listState,
-        gridState = if (mediaLayoutMode == MediaLayoutMode.GRID) gridState else null,
-        isFabVisible = isFabVisible,
-        expanded = false,
-        onExpandedChange = {},
-      )
-      
-      val coroutineScope = rememberCoroutineScope()
-
-      val isAtTop by remember {
-        derivedStateOf {
-          if (mediaLayoutMode == MediaLayoutMode.GRID) {
-            gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
-          } else {
-            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-          }
-        }
-      }
-
-      val hasEnoughItems = videosWithInfo.size > 20
-
-      val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-        targetValue = if (isAtTop || !hasEnoughItems) 0f else 1f,
-        animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
-        label = "scrollbarAlpha",
-      )
-
-      PullRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        listState = listState,
-        modifier = modifier.fillMaxSize(),
-      ) {
-
-        val columns = when (mediaLayoutMode) {
-          MediaLayoutMode.LIST -> 1
-          MediaLayoutMode.GRID -> videoGridColumns
-        }
-
-        if (mediaLayoutMode == MediaLayoutMode.GRID) {
-          Box(
-            modifier = Modifier
-              .fillMaxSize()
-              .padding(bottom = navigationBarHeight)
-          ) {
-            LazyVerticalGridScrollbar(
-              state = gridState,
-              settings = ScrollbarSettings(
-                thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-                thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-              ),
-            ) {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(columns),
-                state = gridState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(
-                  start = if (columns == 1) 12.dp else 8.dp,
-                  end = if (columns == 1) 12.dp else 8.dp,
-                  top = if (columns == 1) 12.dp else 8.dp,
-                  bottom = if (showFloatingBottomBar) 88.dp else 16.dp
-                ),
-                horizontalArrangement = Arrangement.spacedBy(if (columns == 1) 0.dp else 8.dp),
-                verticalArrangement = Arrangement.spacedBy(if (columns == 1) 10.dp else 8.dp),
-            ) {
-            items(
-              count = videosWithInfo.size,
-              key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
-            ) { index ->
-              val videoWithInfo = videosWithInfo[index]
-              val isRecentlyPlayed = recentlyPlayedFilePath?.let { 
-                videoWithInfo.video.path == it || videoWithInfo.video.uri.toString() == it 
-              } ?: false
-
-              VideoCard(
-                video = videoWithInfo.video,
-                uiSettings = uiSettings,
-                progressPercentage = videoWithInfo.progressPercentage,
-                isRecentlyPlayed = isRecentlyPlayed,
-                isSelected = selectionManager.isSelected(videoWithInfo.video),
-                isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
-                isWatched = videoWithInfo.isWatched,
-                isNeverPlayed = videoWithInfo.isNeverPlayed,
-                onClick = { onVideoClick(videoWithInfo.video) },
-                onLongClick = { onVideoLongClick(videoWithInfo.video) },
-                onThumbClick = if (tapThumbnailToSelect) {
-                  { onVideoLongClick(videoWithInfo.video) }
-                } else {
-                  { onVideoClick(videoWithInfo.video) }
-                },
-                isGridMode = mediaLayoutMode == MediaLayoutMode.GRID,
-                gridColumns = videoGridColumns,
-                showSubtitleIndicator = showSubtitleIndicator,
-                allowThumbnailGeneration = false,
-              )
-            }
-            }
-          }
-        }
-        } else {
-          Box(
-            modifier = Modifier
-              .fillMaxSize()
-              .padding(bottom = navigationBarHeight)
-          ) {
-            LazyColumnScrollbar(
-              state = listState,
-              settings = ScrollbarSettings(
-                thumbUnselectedColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f * scrollbarAlpha),
-                thumbSelectedColor = MaterialTheme.colorScheme.primary.copy(alpha = scrollbarAlpha),
-              ),
-            ) {
-              LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-                contentPadding = PaddingValues(
-                  start = 8.dp,
-                  end = 8.dp,
-                  bottom = if (showFloatingBottomBar) 88.dp else 16.dp
-                ),
-            ) {
-              items(
-                count = videosWithInfo.size,
-                key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
-              ) { index ->
-                val videoWithInfo = videosWithInfo[index]
-                val isRecentlyPlayed = recentlyPlayedFilePath?.let { 
-                videoWithInfo.video.path == it || videoWithInfo.video.uri.toString() == it 
-              } ?: false
-
-                VideoCard(
-                  video = videoWithInfo.video,
-                  uiSettings = uiSettings,
-                  progressPercentage = videoWithInfo.progressPercentage,
-                  isRecentlyPlayed = isRecentlyPlayed,
-                  isSelected = selectionManager.isSelected(videoWithInfo.video),
-                  isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
-                  isWatched = videoWithInfo.isWatched,
-                  isNeverPlayed = videoWithInfo.isNeverPlayed,
-                  onClick = { onVideoClick(videoWithInfo.video) },
-                  onLongClick = { onVideoLongClick(videoWithInfo.video) },
-                  onThumbClick = if (tapThumbnailToSelect) {
-                    { onVideoLongClick(videoWithInfo.video) }
-                  } else {
-                    { onVideoClick(videoWithInfo.video) }
-                  },
-                  isGridMode = false,
-                  showSubtitleIndicator = showSubtitleIndicator,
-                  allowThumbnailGeneration = false,
-                )
-              }
-            }
-          }
-        }
-        }
-      }
-      }
-    }
-  }
+  UnifiedExplorerContent(
+    items = videosWithInfo,
+    isLoading = isLoading,
+    uiSettings = uiSettings,
+    isSelected = { selectionManager.isSelected(it.video) },
+    onClick = { onVideoClick(it.video) },
+    onLongClick = { onVideoLongClick(it.video) },
+    modifier = modifier,
+    emptyTitle = "No videos in this folder",
+    emptyMessage = "Videos you add to this folder will appear here"
+  )
+}
 
 @Composable
 fun VideoSortDialog(

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -641,6 +641,7 @@ fun VideoListContent(
     isSelected = { selectionManager.isSelected(it.video) },
     onClick = { onVideoClick(it.video) },
     onLongClick = { onVideoLongClick(it.video) },
+    onToggleSelection = { selectionManager.toggle(it.video) },
     modifier = modifier,
     emptyTitle = "No videos in this folder",
     emptyMessage = "Videos you add to this folder will appear here",

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -647,7 +647,9 @@ fun VideoListContent(
     emptyMessage = "Videos you add to this folder will appear here",
     isRefreshing = isRefreshing,
     onRefresh = onRefresh,
-    isInSelectionMode = selectionManager.isInSelectionMode
+    isInSelectionMode = selectionManager.isInSelectionMode,
+    recentlyPlayedFilePath = recentlyPlayedFilePath,
+    autoScrollToLastPlayed = autoScrollToLastPlayed
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -645,7 +645,8 @@ fun VideoListContent(
     emptyTitle = "No videos in this folder",
     emptyMessage = "Videos you add to this folder will appear here",
     isRefreshing = isRefreshing,
-    onRefresh = onRefresh
+    onRefresh = onRefresh,
+    isInSelectionMode = selectionManager.isInSelectionMode
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -643,7 +643,9 @@ fun VideoListContent(
     onLongClick = { onVideoLongClick(it.video) },
     modifier = modifier,
     emptyTitle = "No videos in this folder",
-    emptyMessage = "Videos you add to this folder will appear here"
+    emptyMessage = "Videos you add to this folder will appear here",
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh
   )
 }
 

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -649,7 +649,8 @@ fun VideoListContent(
     onRefresh = onRefresh,
     isInSelectionMode = selectionManager.isInSelectionMode,
     recentlyPlayedFilePath = recentlyPlayedFilePath,
-    autoScrollToLastPlayed = autoScrollToLastPlayed
+    autoScrollToLastPlayed = autoScrollToLastPlayed,
+    scrollTriggerKey = "${sortType.name}:${sortOrder.name}"
   )
 }
 


### PR DESCRIPTION
# Unified Explorer Refactoring Summary

This pull request consolidates all video library, directory, tree view, playlist, and history browsers into a single strategy-driven `UnifiedExplorerContent` component, resolving visual, gesture, and layout divergence.

---

### Key Improvements

#### 1. Core Architecture Unification
* **bd08878** — Created the central `UnifiedExplorerContent` component, unifying all list/grid browsers into a single generic strategy.
* **7973c5e** & **3df68f2** — Consolidated pull-to-refresh mechanics across all library, history, and system views.

#### 2. Layout, Gestures & Selection Tuning
* **ab8f744** — Secured thumbnail clicking behaviors and unified range selection gestures (including tap-to-select mode).
* **3df68f2** & **7dcdc52** — Fixed top/bottom padding constraints and resolved bottom navigation bar overlapping issues.

#### 3. State & Visual Parity
* **eff9277** & **7dcdc52** — Restored dynamic folders watched/unplayed dimming, reactive "NEW" badges, and media item highlighting.
* **d68b398** — Properly wired last played/recently played state mapping across `VideoWithPlaybackInfo` and `RecentlyPlayedItem` models.
* **eff9277** — Integrated auto-scroll to the last played file or folder on entry.

#### 4. Navigation & Sorting Fixes
* **c4eb081** & **948d0b7** — Restored instant scroll-to-top behavior across Folder, Tree, and Video List views whenever sorting changes.

#### 5. Tree View & Section Layout
* **aad9510** — Restored full layout controls (List/Grid toggling) within the Tree View.
* **5da8a83** & **fb253e6** — Grouped Tree View into distinct `Folders` and `Media` sections under a single high-performance lazy scroll list, allowing folders and videos to use independent grid column scales simultaneously without UI crashes.

---
**Developed and engineered by:** @estiaksoyeb
