### PR TITLE
feat: add Copy File Path / Copy Folder Path actions

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/folderlist/FolderListScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.FolderCopy
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Share
@@ -521,6 +522,24 @@ object FolderListScreen : Screen {
                     if (allVideos.isNotEmpty()) {
                       MediaUtils.shareVideos(context, allVideos)
                     }
+                  }
+                },
+              ),
+              SelectionOverflowAction(
+                icon = Icons.Filled.FolderCopy,
+                label = context.getString(app.marlboroadvance.mpvex.R.string.copy_folder_path),
+                onClick = {
+                  val folders = selectionManager.getSelectedItems()
+                  if (folders.isNotEmpty()) {
+                    val text = folders.map { it.path }.distinct().joinToString("\n")
+                    val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                      as android.content.ClipboardManager
+                    clipboard.setPrimaryClip(android.content.ClipData.newPlainText("Folder Path", text))
+                    android.widget.Toast.makeText(
+                      context,
+                      app.marlboroadvance.mpvex.R.string.copy_path_toast_copied_folder,
+                      android.widget.Toast.LENGTH_SHORT,
+                    ).show()
                   }
                 },
               ),

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.FolderCopy
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Share
@@ -53,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
+import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.preferences.BrowserPreferences
 import app.marlboroadvance.mpvex.preferences.PlayerPreferences
@@ -231,6 +234,16 @@ fun MediaLibraryContent() {
               icon = Icons.Filled.Share,
               label = "Share",
               onClick = { selectionManager.shareSelected() },
+            ),
+            SelectionOverflowAction(
+              icon = Icons.Filled.ContentCopy,
+              label = context.getString(R.string.copy_file_path),
+              onClick = { selectionManager.copyFilePathSelected() },
+            ),
+            SelectionOverflowAction(
+              icon = Icons.Filled.FolderCopy,
+              label = context.getString(R.string.copy_folder_path),
+              onClick = { selectionManager.copyFolderPathSelected() },
             ),
           ),
           onSelectAll = { selectionManager.selectAll() },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.FolderCopy
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
@@ -284,6 +285,43 @@ data class PlaylistDetailScreen(val playlistId: Int) : Screen {
                   onClick = {
                     val videosToShare = selectionManager.getSelectedItems().map { it.video }
                     MediaUtils.shareVideos(context, videosToShare)
+                  },
+                ))
+                add(SelectionOverflowAction(
+                  icon = Icons.Filled.ContentCopy,
+                  label = context.getString(app.marlboroadvance.mpvex.R.string.copy_file_path),
+                  onClick = {
+                    val items = selectionManager.getSelectedItems()
+                    if (items.isNotEmpty()) {
+                      val text = items.joinToString("\n") { it.video.path }
+                      val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                        as android.content.ClipboardManager
+                      clipboard.setPrimaryClip(android.content.ClipData.newPlainText("File Path", text))
+                      android.widget.Toast.makeText(
+                        context,
+                        app.marlboroadvance.mpvex.R.string.copy_path_toast_copied_file,
+                        android.widget.Toast.LENGTH_SHORT,
+                      ).show()
+                    }
+                  },
+                ))
+                add(SelectionOverflowAction(
+                  icon = Icons.Filled.FolderCopy,
+                  label = context.getString(app.marlboroadvance.mpvex.R.string.copy_folder_path),
+                  onClick = {
+                    val items = selectionManager.getSelectedItems()
+                    if (items.isNotEmpty()) {
+                      val text = items.mapNotNull { java.io.File(it.video.path).parent }
+                        .distinct().joinToString("\n")
+                      val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                        as android.content.ClipboardManager
+                      clipboard.setPrimaryClip(android.content.ClipData.newPlainText("Folder Path", text))
+                      android.widget.Toast.makeText(
+                        context,
+                        app.marlboroadvance.mpvex.R.string.copy_path_toast_copied_folder,
+                        android.widget.Toast.LENGTH_SHORT,
+                      ).show()
+                    }
                   },
                 ))
               }

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/selection/SelectionManager.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/selection/SelectionManager.kt
@@ -1,5 +1,7 @@
 package app.marlboroadvance.mpvex.ui.browser.selection
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
@@ -11,11 +13,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.domain.media.model.Video
 import app.marlboroadvance.mpvex.ui.player.PlayerActivity
 import app.marlboroadvance.mpvex.utils.media.MediaUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.io.File
 
 /**
  * Manager for handling item selection and operations in browser screens
@@ -158,6 +162,36 @@ class SelectionManager<T, ID>(
     @Suppress("UNCHECKED_CAST")
     val videos = selected as List<Video>
     MediaUtils.shareVideos(context, videos)
+  }
+
+  /**
+   * Copy the file path(s) of the selected videos to the clipboard
+   */
+  fun copyFilePathSelected() {
+    val selected = getSelectedItems()
+    if (selected.isEmpty() || selected.first() !is Video) return
+
+    @Suppress("UNCHECKED_CAST")
+    val videos = selected as List<Video>
+    val text = videos.joinToString("\n") { it.path }
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("File Path", text))
+    Toast.makeText(context, R.string.copy_path_toast_copied_file, Toast.LENGTH_SHORT).show()
+  }
+
+  /**
+   * Copy the parent folder path(s) of the selected videos to the clipboard
+   */
+  fun copyFolderPathSelected() {
+    val selected = getSelectedItems()
+    if (selected.isEmpty() || selected.first() !is Video) return
+
+    @Suppress("UNCHECKED_CAST")
+    val videos = selected as List<Video>
+    val text = videos.mapNotNull { File(it.path).parent }.distinct().joinToString("\n")
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("Folder Path", text))
+    Toast.makeText(context, R.string.copy_path_toast_copied_folder, Toast.LENGTH_SHORT).show()
   }
 
   /**

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/browser/videolist/VideoListScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
+import app.marlboroadvance.mpvex.R
 import app.marlboroadvance.mpvex.utils.media.OpenDocumentTreeContract
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -32,6 +33,8 @@ import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.FolderCopy
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Share
@@ -308,6 +311,16 @@ data class VideoListScreen(
               icon = Icons.Filled.Share,
               label = "Share",
               onClick = { selectionManager.shareSelected() },
+            ),
+            SelectionOverflowAction(
+              icon = Icons.Filled.ContentCopy,
+              label = context.getString(R.string.copy_file_path),
+              onClick = { selectionManager.copyFilePathSelected() },
+            ),
+            SelectionOverflowAction(
+              icon = Icons.Filled.FolderCopy,
+              label = context.getString(R.string.copy_folder_path),
+              onClick = { selectionManager.copyFolderPathSelected() },
             ),
           ),
           onSelectAll = { selectionManager.selectAll() },

--- a/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/ui/player/controls/components/sheets/MoreSheet.kt
@@ -2,9 +2,15 @@ package app.marlboroadvance.mpvex.ui.player.controls.components.sheets
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.text.format.DateUtils
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -27,6 +33,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.FolderCopy
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material.icons.filled.Tune
@@ -62,6 +70,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -72,6 +82,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.marlboroadvance.mpvex.R
+import java.io.File
 import app.marlboroadvance.mpvex.domain.anime4k.Anime4KManager
 import app.marlboroadvance.mpvex.preferences.AdvancedPreferences
 import app.marlboroadvance.mpvex.preferences.AppearancePreferences
@@ -521,6 +532,24 @@ fun ControlsTab(
       }
   }
 
+  // Styling for the dedicated copy-path buttons (match the more-sheet button look, background forced)
+  val matchTheme by appearancePreferences.matchPlayerControlsToTheme.collectAsState()
+  val copyButtonSurfaceColor = if (matchTheme) {
+      MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f)
+  } else {
+      MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f)
+  }
+  val copyButtonContentColor = if (matchTheme) {
+      MaterialTheme.colorScheme.onPrimaryContainer
+  } else {
+      MaterialTheme.colorScheme.onSurface
+  }
+  val copyButtonBorder = BorderStroke(
+      1.dp,
+      if (matchTheme) MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+      else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+  )
+
   Column(
       modifier = Modifier
           .fillMaxWidth()
@@ -566,6 +595,83 @@ fun ControlsTab(
                   isMoreSheet = true
               )
           }
+
+          // Dedicated copy-path actions (always available from the player More sheet)
+          MoreSheetCopyButton(
+              icon = Icons.Filled.ContentCopy,
+              label = stringResource(R.string.copy_file_path),
+              buttonSize = 40.dp,
+              surfaceColor = copyButtonSurfaceColor,
+              contentColor = copyButtonContentColor,
+              border = copyButtonBorder,
+          ) {
+              val path = MPVLib.getPropertyString("path")
+              if (path != null) {
+                  val clipboard = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                  clipboard.setPrimaryClip(ClipData.newPlainText("File Path", path))
+                  Toast.makeText(activity, R.string.copy_path_toast_copied_file, Toast.LENGTH_SHORT).show()
+              } else {
+                  Toast.makeText(activity, R.string.copy_path_toast_no_path, Toast.LENGTH_SHORT).show()
+              }
+          }
+
+          MoreSheetCopyButton(
+              icon = Icons.Filled.FolderCopy,
+              label = stringResource(R.string.copy_folder_path),
+              buttonSize = 40.dp,
+              surfaceColor = copyButtonSurfaceColor,
+              contentColor = copyButtonContentColor,
+              border = copyButtonBorder,
+          ) {
+              val path = MPVLib.getPropertyString("path")
+              if (path != null) {
+                  val folderPath = File(path).parent ?: path
+                  val clipboard = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                  clipboard.setPrimaryClip(ClipData.newPlainText("Folder Path", folderPath))
+                  Toast.makeText(activity, R.string.copy_path_toast_copied_folder, Toast.LENGTH_SHORT).show()
+              } else {
+                  Toast.makeText(activity, R.string.copy_path_toast_no_path, Toast.LENGTH_SHORT).show()
+              }
+          }
+      }
+  }
+}
+
+@Composable
+private fun MoreSheetCopyButton(
+  icon: androidx.compose.ui.graphics.vector.ImageVector,
+  label: String,
+  buttonSize: androidx.compose.ui.unit.Dp,
+  surfaceColor: Color,
+  contentColor: Color,
+  border: BorderStroke,
+  onClick: () -> Unit,
+) {
+  Surface(
+      shape = CircleShape,
+      color = surfaceColor,
+      contentColor = contentColor,
+      border = border,
+      modifier = Modifier
+          .height(buttonSize)
+          .clip(CircleShape)
+          .clickable { onClick() },
+  ) {
+      Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.extraSmall),
+          modifier = Modifier.padding(horizontal = MaterialTheme.spacing.smaller),
+      ) {
+          Icon(
+              imageVector = icon,
+              contentDescription = null,
+              modifier = Modifier.size(24.dp),
+          )
+          Text(
+              text = label,
+              style = MaterialTheme.typography.bodyMedium,
+              maxLines = 1,
+          )
       }
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,6 +558,12 @@
     <string name="playlist_refresh_error">Failed to refresh playlist: %s</string>
     <string name="playlist_m3u_badge">M3U</string>
 
+    <string name="copy_file_path">Copy File Path</string>
+    <string name="copy_folder_path">Copy Folder Path</string>
+    <string name="copy_path_toast_copied_file">File path copied</string>
+    <string name="copy_path_toast_copied_folder">Folder path copied</string>
+    <string name="copy_path_toast_no_path">No file path available</string>
+
     <string name="open_file">Open file</string>
     <string name="recently_played">Recently played</string>
     <string name="open_link">Open link</string>


### PR DESCRIPTION
## Summary

Implements the request in #116 — actions to **copy a video's file path** or **copy its parent folder path** to the clipboard.

## Where it appears

| Location | Actions |
| --- | --- |
| Video list — selection overflow (after **Share**) | Copy File Path + Copy Folder Path |
| Media Library (all-videos) — selection overflow | Copy File Path + Copy Folder Path |
| Folder list — selection overflow | Copy Folder Path |
| Playlist detail (non-M3U) — selection overflow | Copy File Path + Copy Folder Path |
| Player **More sheet → Extended Controls** | Copy File Path + Copy Folder Path (currently playing file) |

## Screenshots

**File browser — selection overflow menu (after Share)**

![Copy actions in the browser selection overflow menu](https://github.com/s-shahriar/mpvRex/releases/download/assets-issue-116/copy-path-browser-overflow.png)

**Player — More sheet → Extended Controls**

![Copy actions in the player More sheet Extended Controls](https://github.com/s-shahriar/mpvRex/releases/download/assets-issue-116/copy-path-player-more-sheet.png)

## Implementation notes

- Video-typed screens reuse two new helpers on `SelectionManager`  (`copyFilePathSelected()` / `copyFolderPathSelected()`), mirroring the existing   `shareSelected()`.
- Folder list and playlist detail copy inline, since their items are not `Video`.
- Multi-selection joins paths with newlines; folder paths are de-duplicated.
- The More-sheet buttons are dedicated controls (not part of the configurable
  player layout), so they don't appear in the layout editor.
- New strings added to `strings.xml`; no behavior change to existing controls.

## Testing

Built and installed the debug variant on a physical device (Redmi K20 Pro, Android 16 / LineageOS) and verified each location copies the correct path and shows the confirmation toast.

Closes #116
