### PR TITLE
feat(update): enable in-app updater

### DIFF
--- a/app/src/main/java/app/marlboroadvance/mpvex/MainActivity.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/MainActivity.kt
@@ -2,8 +2,6 @@ package app.marlboroadvance.mpvex
 
 import android.os.Bundle
 import android.util.Log
-import android.content.Intent
-import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -39,6 +37,7 @@ import app.marlboroadvance.mpvex.preferences.AppearancePreferences
 import app.marlboroadvance.mpvex.preferences.preference.collectAsState
 import app.marlboroadvance.mpvex.presentation.Screen
 import app.marlboroadvance.mpvex.repository.NetworkRepository
+import app.marlboroadvance.mpvex.utils.update.MeteredDownloadDialog
 import app.marlboroadvance.mpvex.utils.update.UpdateDialog
 import app.marlboroadvance.mpvex.utils.update.UpdateViewModel
 import app.marlboroadvance.mpvex.ui.browser.MainScreen
@@ -221,6 +220,8 @@ class MainActivity : ComponentActivity() {
 
       // Display Update Dialog when appropriate (only if update feature is enabled)
       if (BuildConfig.ENABLE_UPDATE_FEATURE && updateViewModel != null) {
+        val meteredWarningRelease by updateViewModel.meteredWarningRelease.collectAsState()
+
         when (updateState) {
           is UpdateViewModel.UpdateState.Available -> {
             val release = (updateState as UpdateViewModel.UpdateState.Available).release
@@ -231,16 +232,8 @@ class MainActivity : ComponentActivity() {
               actionLabel = if (isDownloading) "Downloading..." else "Download",
               currentVersion = currentVersion,
               onDismiss = { updateViewModel.dismiss() },
-              onAction = { 
-                // Redirect to GitHub releases page as requested by user
-                context.startActivity(
-                  Intent(
-                    Intent.ACTION_VIEW, 
-                    (release.htmlUrl ?: "https://github.com/sfsakhawat999/mpvRex/releases/latest").toUri()
-                  )
-                )
-                // updateViewModel.downloadUpdate(release) // Kept in code but disabled for now
-              },
+              // Download the architecture-matched APK in-app (warns first on mobile data).
+              onAction = { updateViewModel.requestDownload(release) },
               onIgnore = { updateViewModel.ignoreVersion(release.tagName.removePrefix("v")) }
             )
           }
@@ -253,20 +246,21 @@ class MainActivity : ComponentActivity() {
               actionLabel = "Install",
               currentVersion = currentVersion,
               onDismiss = { updateViewModel.dismiss() },
-              onAction = { 
-                // Redirect to GitHub releases page as requested by user
-                context.startActivity(
-                  Intent(
-                    Intent.ACTION_VIEW, 
-                    (release.htmlUrl ?: "https://github.com/sfsakhawat999/mpvRex/releases/latest").toUri()
-                  )
-                )
-                // updateViewModel.installUpdate(release) // Kept in code but disabled for now
-              },
+              // Launch the system installer (asks for "install unknown apps" first if needed).
+              onAction = { updateViewModel.installUpdate(release) },
               onIgnore = { updateViewModel.ignoreVersion(release.tagName.removePrefix("v")) }
             )
           }
           else -> {}
+        }
+
+        // Confirm before downloading a large APK over a metered (mobile data) connection.
+        meteredWarningRelease?.let { release ->
+          MeteredDownloadDialog(
+            sizeBytes = release.assets.firstOrNull { it.name.endsWith(".apk") }?.size ?: 0L,
+            onConfirm = { updateViewModel.confirmMeteredDownload() },
+            onDismiss = { updateViewModel.cancelMeteredDownload() }
+          )
         }
       }
     }

--- a/app/src/main/java/app/marlboroadvance/mpvex/utils/update/UpdateFeature.kt
+++ b/app/src/main/java/app/marlboroadvance/mpvex/utils/update/UpdateFeature.kt
@@ -2,7 +2,11 @@ package app.marlboroadvance.mpvex.utils.update
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Build
+import android.provider.Settings
+import android.widget.Toast
+import androidx.core.net.toUri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -247,10 +251,51 @@ class UpdateManager(
         if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
             return
         }
-        
-         context.externalCacheDir?.listFiles()?.forEach { 
+
+         context.externalCacheDir?.listFiles()?.forEach {
              if (it.name.endsWith(".apk")) it.delete()
          }
+    }
+
+    /**
+     * Whether the app is allowed to install APKs. On Android 8+ the user must grant the
+     * "Install unknown apps" permission to this app specifically before an install can succeed.
+     */
+    fun canInstallPackages(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else {
+            true
+        }
+    }
+
+    /**
+     * Sends the user to the system "Install unknown apps" settings screen for this app so they
+     * can grant the permission, then return and retry the install.
+     */
+    fun requestInstallPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        Toast.makeText(
+            context,
+            "Allow installing apps from mpvRex, then tap Install again",
+            Toast.LENGTH_LONG
+        ).show()
+        val intent = Intent(
+            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            "package:${context.packageName}".toUri()
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+
+    /**
+     * Whether the active network is metered (mobile data, metered hotspot). Used to warn the user
+     * before downloading a large APK over cellular.
+     */
+    fun isMeteredConnection(): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return false
+        return connectivityManager.isActiveNetworkMetered
     }
 }
 
@@ -268,6 +313,11 @@ class UpdateViewModel(application: Application) : AndroidViewModel(application) 
     
     private val _isDownloading = MutableStateFlow(false)
     val isDownloading: StateFlow<Boolean> = _isDownloading.asStateFlow()
+
+    // Set to the pending release when a download is requested on a metered (mobile data)
+    // connection, so the UI can ask the user to confirm before spending their data.
+    private val _meteredWarningRelease = MutableStateFlow<Release?>(null)
+    val meteredWarningRelease: StateFlow<Release?> = _meteredWarningRelease.asStateFlow()
 
     private val prefs = application.getSharedPreferences("mpvEx_prefs", Context.MODE_PRIVATE)
     private val _isAutoUpdateEnabled = MutableStateFlow(
@@ -337,12 +387,39 @@ class UpdateViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    /**
+     * Entry point for the "Download" action. Warns first if on a metered connection, otherwise
+     * starts the download immediately.
+     */
+    fun requestDownload(release: Release) {
+        if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
+            return
+        }
+        if (updateManager.isMeteredConnection()) {
+            _meteredWarningRelease.value = release
+        } else {
+            downloadUpdate(release)
+        }
+    }
+
+    /** User confirmed they want to download over a metered connection. */
+    fun confirmMeteredDownload() {
+        val release = _meteredWarningRelease.value ?: return
+        _meteredWarningRelease.value = null
+        downloadUpdate(release)
+    }
+
+    /** User declined to download over a metered connection. */
+    fun cancelMeteredDownload() {
+        _meteredWarningRelease.value = null
+    }
+
     fun downloadUpdate(release: Release) {
         // No-op if update feature is disabled
         if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
             return
         }
-        
+
         viewModelScope.launch {
             _isDownloading.value = true
             try {
@@ -365,6 +442,13 @@ class UpdateViewModel(application: Application) : AndroidViewModel(application) 
             return
         }
         
+        // On Android 8+ the app needs the "Install unknown apps" permission. If it isn't granted,
+        // send the user to grant it; they return and tap Install again. State stays ReadyToInstall.
+        if (!updateManager.canInstallPackages()) {
+            updateManager.requestInstallPermission()
+            return
+        }
+
         val file = updateManager.getApkFile(release) ?: return
         val context = getApplication<Application>()
         val uri = FileProvider.getUriForFile(
@@ -496,6 +580,42 @@ fun UpdateDialog(
                         Text("Cancel")
                     }
                 }
+            }
+        }
+    )
+}
+
+@Composable
+fun MeteredDownloadDialog(
+    sizeBytes: Long,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.CloudDownload,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+        },
+        title = { Text(text = "Download on mobile data?") },
+        text = {
+            Text(
+                text = "You're on a metered connection. Downloading the update " +
+                    "(${MediaFormatter.formatFileSize(sizeBytes)}) may use your mobile data.",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("Download")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
             }
         }
     )


### PR DESCRIPTION
## Summary

Closes #134.

Updating mpvRex was fully manual: open the releases page, figure out which APK matches the phone's CPU architecture, download it, and sideload it. The in-app updater already existed in the codebase but its buttons were wired to just open the GitHub releases page in a browser. This PR re-enables the updater end to end.

## What changed

- **In-app download + install** — the **Download** / **Install** actions now download the device-matched APK (`arm64-v8a` / `armeabi-v7a` / `x86` / `x86_64`, falling back to `universal`) into the app cache with a progress bar, then launch the system installer — instead of redirecting to the browser.
- **"Install unknown apps" permission flow** — if the permission isn't granted (required on Android 8+), the user is sent to the system settings screen for mpvRex with a short toast, then returns and taps **Install** again. The dialog stays in the `ReadyToInstall` state so nothing is lost.
- **Metered-network warning** — added `MeteredDownloadDialog`, shown before downloading over mobile data so users don't unexpectedly spend cellular data on a ~37 MB download.

## Notes / behaviour

- The install is an **in-place update** (same package name + signing key + higher `versionCode`), so user settings, playlists, and watch history are preserved — it is not a duplicate install.
- Android always shows one final system "Update this app?" confirmation; that is an OS security boundary and cannot be bypassed by a normal app.
- The feature remains gated behind `BuildConfig.ENABLE_UPDATE_FEATURE`, so F-Droid-style builds (different signing key) stay disabled and avoid signature-mismatch installs.
- `FileProvider` already exposes `external-cache-path`, where the APK is downloaded, so no manifest change was needed.

## Testing

- `./gradlew :app:compileDebugKotlin` passes (no new warnings from the changed files).
- Manual verification of the update → download → install path on a device is recommended before merge.
