### PR TITLE
Fix progress bars not showing in tree (file manager) view

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/components/UnifiedExplorerContent.kt
@@ -64,6 +64,7 @@ fun <T> UnifiedExplorerContent(
   playedFolderPaths: Set<String> = emptySet(),
   newVideoIds: Set<Long> = emptySet(),
   watchedVideoIds: Set<Long> = emptySet(),
+  videoPlaybackProgress: Map<Long, Float> = emptyMap(),
   autoScrollToLastPlayed: Boolean = false,
   scrollTriggerKey: Any? = null,
   gridColumns: Int? = null,
@@ -290,6 +291,7 @@ fun <T> UnifiedExplorerContent(
                         playedFolderPaths = playedFolderPaths,
                         newVideoIds = newVideoIds,
                         watchedVideoIds = watchedVideoIds,
+                        videoPlaybackProgress = videoPlaybackProgress,
                         showSections = showSections
                       )
                     }
@@ -335,6 +337,7 @@ fun <T> UnifiedExplorerContent(
                   playedFolderPaths = playedFolderPaths,
                   newVideoIds = newVideoIds,
                   watchedVideoIds = watchedVideoIds,
+                  videoPlaybackProgress = videoPlaybackProgress,
                   showSections = showSections
                 )
               }
@@ -395,6 +398,7 @@ fun <T> UnifiedExplorerContent(
                         playedFolderPaths = playedFolderPaths,
                         newVideoIds = newVideoIds,
                         watchedVideoIds = watchedVideoIds,
+                        videoPlaybackProgress = videoPlaybackProgress,
                         showSections = showSections
                       )
                     }
@@ -440,6 +444,7 @@ fun <T> UnifiedExplorerContent(
                   playedFolderPaths = playedFolderPaths,
                   newVideoIds = newVideoIds,
                   watchedVideoIds = watchedVideoIds,
+                  videoPlaybackProgress = videoPlaybackProgress,
                   showSections = showSections
                 )
               }
@@ -493,6 +498,7 @@ fun <T> UnifiedExplorerContent(
               playedFolderPaths = playedFolderPaths,
               newVideoIds = newVideoIds,
               watchedVideoIds = watchedVideoIds,
+              videoPlaybackProgress = videoPlaybackProgress,
               showSections = showSections
             )
           }
@@ -555,6 +561,7 @@ fun <T> UnifiedExplorerContent(
                       playedFolderPaths = playedFolderPaths,
                       newVideoIds = newVideoIds,
                       watchedVideoIds = watchedVideoIds,
+                      videoPlaybackProgress = videoPlaybackProgress,
                       showSections = showSections
                     )
                   }
@@ -587,6 +594,7 @@ fun <T> UnifiedExplorerContent(
                 playedFolderPaths = playedFolderPaths,
                 newVideoIds = newVideoIds,
                 watchedVideoIds = watchedVideoIds,
+                videoPlaybackProgress = videoPlaybackProgress,
                 showSections = showSections
               )
             }
@@ -641,6 +649,7 @@ private fun <T> ExplorerItemCard(
   playedFolderPaths: Set<String> = emptySet(),
   newVideoIds: Set<Long> = emptySet(),
   watchedVideoIds: Set<Long> = emptySet(),
+  videoPlaybackProgress: Map<Long, Float> = emptyMap(),
   showSections: Boolean = false,
 ) {
   when (item) {
@@ -807,8 +816,10 @@ private fun <T> ExplorerItemCard(
         isGridMode = isGridMode,
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
+        progressPercentage = videoPlaybackProgress[item.video.id],
         isOldAndUnplayed = isOldAndUnplayed,
         isWatched = isWatched,
+        isNeverPlayed = videoPlaybackProgress[item.video.id] == null,
         isRecentlyPlayed = isRecentlyPlayed
       )
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -1448,6 +1448,7 @@ private fun FileSystemBrowserContent(
       listState = listState,
       newVideoIds = newVideoIds,
       watchedVideoIds = watchedVideoIds,
+      videoPlaybackProgress = videoFilesWithPlayback,
       scrollTriggerKey = scrollTriggerKey,
       showSections = true,
     )


### PR DESCRIPTION
### Summary
Playback progress bars now render on video thumbnails in **Tree View** (File Manager
mode), matching the behaviour already present in **Folder View** (Album mode) and in the
file-manager search results. Fixes #173.

### Root cause
Both view modes render their items through the same `ExplorerItemCard` `when(item)`
dispatcher in `UnifiedExplorerContent.kt`, but they supply different item types:

- **Folder View** supplies `VideoWithPlaybackInfo`. Its branch passes
  `progressPercentage = item.progressPercentage` to `VideoCard`, so the
  `LinearProgressIndicator` overlay is drawn.
- **Tree View** supplies `FileSystemItem.VideoFile`. That branch called `VideoCard`
  **without** a `progressPercentage` argument, so it defaulted to `null`
  (`VideoCard`'s `progressPercentage: Float? = null`) and the bar was never drawn.

`FileSystemItem.VideoFile` carries no progress field, and although the progress data
(`FileSystemBrowserViewModel.videoFilesWithPlayback: Map<Long, Float>`, keyed by
`video.id`) was already collected in the screen and in scope one level above the render,
it was never threaded down into the tree-browse render path. The tree-view **search**
path already handled this correctly (its branch passes
`progressPercentage = videoFilesWithPlayback[videoFile.video.id]` and
`isNeverPlayed = videoFilesWithPlayback[videoFile.video.id] == null`); only the normal
tree-browse path dropped it.

### Implementation
Threaded the existing `videoFilesWithPlayback` map into the browse render path, mirroring
the working search path. Two files:

- `app/src/main/kotlin/xyz/mpv/rex/ui/browser/components/UnifiedExplorerContent.kt`
  - Added `videoPlaybackProgress: Map<Long, Float> = emptyMap()` to the
    `UnifiedExplorerContent` signature.
  - Added the same defaulted parameter to the private `ExplorerItemCard` and forwarded it
    at every internal `ExplorerItemCard(...)` call site.
  - In the `is FileSystemItem.VideoFile ->` branch, passed
    `progressPercentage = videoPlaybackProgress[item.video.id]` and
    `isNeverPlayed = videoPlaybackProgress[item.video.id] == null` to `VideoCard`,
    matching the search path and the `VideoWithPlaybackInfo` branch.
- `app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserScreen.kt`
  - At the tree-browse `UnifiedExplorerContent(...)` call in `FileSystemBrowserContent`,
    passed `videoPlaybackProgress = videoFilesWithPlayback` (already a parameter of that
    composable, sourced from `viewModel.videoFilesWithPlayback.collectAsState()`).

The new parameter is defaulted (`emptyMap()`), so every other caller of
`UnifiedExplorerContent` / `ExplorerItemCard` compiles unchanged. The bar remains gated by
the existing `uiSettings.showProgressBar` check inside `VideoCard`.

Net change: 2 files, +12 lines, no deletions.

### Testing
I don't have an Android device/emulator set up locally, so I've confirmed this by matching
the existing, working search-path pattern rather than by running it — a visual check on
device would be appreciated:

1. Switch the browser to **Tree View** (File Manager mode).
2. Open a folder, play a video partway, then return to the browser.
3. Confirm the progress bar renders over that video's thumbnail (grid and list layouts),
   and that never-played videos show no bar. Confirm Folder View is unchanged.
