### PR TITLE
refactor: keep language-neutral aspect-ratio constants inline

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/AspectRatioSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/AspectRatioSheet.kt
@@ -71,16 +71,13 @@ fun AspectRatioSheet(
   val presetRatios =
     listOf(
       AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_default), -1.0),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_4_3), 4.0 / 3.0),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_16_9), 16.0 / 9.0),
-      AspectRatio(
-        stringResource(R.string.player_sheets_aspect_ratio_preset_16_10),
-        16.0 / 10.0,
-      ),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_21_9), 21.0 / 9.0),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_32_9), 32.0 / 9.0),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_2_35_1), 2.35),
-      AspectRatio(stringResource(R.string.player_sheets_aspect_ratio_preset_2_39_1), 2.39),
+      AspectRatio("4:3", 4.0 / 3.0),
+      AspectRatio("16:9", 16.0 / 9.0),
+      AspectRatio("16:10", 16.0 / 10.0),
+      AspectRatio("21:9", 21.0 / 9.0),
+      AspectRatio("32:9", 32.0 / 9.0),
+      AspectRatio("2.35:1", 2.35),
+      AspectRatio("2.39:1", 2.39),
     )
 
   PlayerSheet(onDismissRequest) {
@@ -325,7 +322,7 @@ private fun AddCustomRatioRow(
 
       // Colon separator
       Text(
-        text = stringResource(R.string.player_sheets_aspect_ratio_separator),
+        text = ":",
         style = MaterialTheme.typography.headlineMedium,
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(horizontal = MaterialTheme.spacing.extraSmall),

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/FrameNavigationSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/FrameNavigationSheet.kt
@@ -112,15 +112,14 @@ fun FrameNavigationSheet(
   val duration by MPVLib.propInt["duration"].collectAsState()
   val pos = position ?: 0
   val dur = duration ?: 0
-  val timestampFormat = stringResource(R.string.player_sheets_frame_navigation_timestamp_value)
 
   // Format timestamp based on current position
   val timestamp =
-    remember(pos, timestampFormat) {
+    remember(pos) {
       val hours = pos / 3600
       val minutes = (pos % 3600) / 60
       val seconds = pos % 60
-      String.format(Locale.US, timestampFormat, hours, minutes, seconds)
+      String.format(Locale.US, "%1\$02d:%2\$02d:%3\$02d", hours, minutes, seconds)
     }
 
   // Pause playback when the sheet opens

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,13 +494,6 @@
     <string name="player_sheets_aspect_ratio_title">Aspect Ratio</string>
     <string name="player_sheets_aspect_ratio_presets">Presets</string>
     <string name="player_sheets_aspect_ratio_preset_default">Default</string>
-    <string name="player_sheets_aspect_ratio_preset_4_3" translatable="false">4:3</string>
-    <string name="player_sheets_aspect_ratio_preset_16_9" translatable="false">16:9</string>
-    <string name="player_sheets_aspect_ratio_preset_16_10" translatable="false">16:10</string>
-    <string name="player_sheets_aspect_ratio_preset_21_9" translatable="false">21:9</string>
-    <string name="player_sheets_aspect_ratio_preset_32_9" translatable="false">32:9</string>
-    <string name="player_sheets_aspect_ratio_preset_2_35_1" translatable="false">2.35:1</string>
-    <string name="player_sheets_aspect_ratio_preset_2_39_1" translatable="false">2.39:1</string>
     <string name="player_sheets_aspect_ratio_custom_toggle">Custom...</string>
     <string name="player_sheets_aspect_ratio_custom_section">Custom</string>
     <string name="player_sheets_aspect_ratio_manual_zoom_pan_title">Manual Zoom &amp; Pan (Camera Offset)</string>
@@ -510,14 +503,12 @@
     <string name="player_sheets_aspect_ratio_reset_pan">Reset Pan</string>
     <string name="player_sheets_aspect_ratio_add_custom_title">Add Custom Ratio (e.g. 16:9)</string>
     <string name="player_sheets_aspect_ratio_width">Width</string>
-    <string name="player_sheets_aspect_ratio_separator" translatable="false">:</string>
     <string name="player_sheets_aspect_ratio_height">Height</string>
     <string name="player_sheets_aspect_ratio_custom_ratio_label" translatable="false">%1$s:%2$s</string>
     <string name="player_sheets_aspect_ratio_invalid">Invalid</string>
     <string name="player_sheets_aspect_ratio_add">Add</string>
 
     <string name="player_sheets_frame_navigation_title">Frame Navigation</string>
-    <string name="player_sheets_frame_navigation_timestamp_value" formatted="false" translatable="false">%1$02d:%2$02d:%3$02d</string>
     <string name="player_sheets_frame_navigation_frame_label">Frame:\u0020</string>
     <string name="player_sheets_frame_navigation_frame_count" translatable="false">%1$d / %2$d</string>
     <string name="player_sheets_frame_navigation_current_frame" translatable="false">%1$d</string>


### PR DESCRIPTION
## Summary
Follow-up to #160 addressing @estiaksoyeb's review: the aspect-ratio values (`4:3`, `16:9`, `21:9`, `2.35:1`, etc.), the `:` separator, and the `HH:MM:SS` timestamp format are language-independent constants, so they don't need to live in `strings.xml`. This moves them back to inline Kotlin literals for readability, while keeping genuinely translatable text (`Default`, `Presets`, labels) extracted.

## Changes
- `AspectRatioSheet.kt`: numeric preset ratios back to inline literals
- `FrameNavigationSheet.kt`: `HH:MM:SS` timestamp format inlined
- `strings.xml`: removed the 9 now-unused non-translatable entries

Thanks @estiaksoyeb for the suggestion.