### PR TITLE
i18n: extract hardcoded strings

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/states/PermissionDeniedState.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/states/PermissionDeniedState.kt
@@ -131,7 +131,7 @@ fun PermissionDeniedState(
 
         // Title
         Text(
-          text = "Storage Access Required",
+          text = stringResource(R.string.storage_access_required),
           style = MaterialTheme.typography.headlineMedium,
           fontWeight = FontWeight.Bold,
           textAlign = TextAlign.Center,
@@ -156,12 +156,12 @@ fun PermissionDeniedState(
             Text(
               text = if (isPlayStoreBuild) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                  "mpvRex requires \"Photos and videos\" permission to access and play your video files stored on your device."
+                  stringResource(R.string.permission_required_photos_videos)
                 } else {
-                  "mpvRex requires \"Storage\" permission to access and play your media files stored on your device."
+                  stringResource(R.string.permission_required_storage)
                 }
               } else {
-                "mpvRex requires \"All file access\" permission to discover media and subtitles on your device due to a change in security policy in Android 11 and later versions."
+                stringResource(R.string.permission_required_all_files)
               },
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurface,
@@ -203,7 +203,7 @@ fun PermissionDeniedState(
           shape = RoundedCornerShape(16.dp),
         ) {
           Text(
-            text = "ALLOW ACCESS",
+            text = stringResource(R.string.allow_access),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.SemiBold,
           )
@@ -222,7 +222,7 @@ fun PermissionDeniedState(
           )
           Spacer(modifier = Modifier.width(6.dp))
           Text(
-            text = "Why do I see this?",
+            text = stringResource(R.string.why_do_i_see_this),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
           )
@@ -249,7 +249,7 @@ fun PermissionDeniedState(
       },
       title = {
         Text(
-          text = "Why this permission is needed",
+          text = stringResource(R.string.why_this_permission_is_needed),
           style = MaterialTheme.typography.headlineSmall,
           fontWeight = FontWeight.Bold,
         )
@@ -265,56 +265,56 @@ fun PermissionDeniedState(
           if (isPlayStoreBuild) {
             // Play Store build explanation
             Text(
-              text = "mpvRex needs access to your video files to provide its core functionality as a media player.",
+              text = stringResource(R.string.permission_explanation_playstore_intro),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Text(
               text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                "On Android 13 and above, this permission allows the app to read video files from your device's storage, including Downloads, Movies, and DCIM folders."
+                stringResource(R.string.permission_explanation_tiramisu_plus)
               } else {
-                "This permission allows the app to read media files from your device's storage to play videos and audio."
+                stringResource(R.string.permission_explanation_pre_tiramisu)
               },
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Text(
-              text = "The permission is used exclusively for:",
+              text = stringResource(R.string.permission_used_exclusively_for),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
               fontWeight = FontWeight.Medium,
             )
 
             Text(
-              text = "• Discovering and displaying your video files\n• Playing media content\n• Loading subtitle files",
+              text = stringResource(R.string.permission_usage_bullet_list),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
           } else {
             // Standard build explanation
             Text(
-              text = "mpvRex has always required storage access permission as it's essential for the app to find all media and subtitle files on your device, including the ones that are not supported by the system.",
+              text = stringResource(R.string.permission_explanation_standard_intro),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Text(
-              text = "However, due to a change in security policy, apps built for Android 11 and above now require additional permission to continue accessing the same.",
+              text = stringResource(R.string.permission_security_policy_change),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Text(
-              text = "Please know that this permission is only used for the auto-discovery of media/subtitle files on your device and will not allow us to access the private data files stored by other apps in any way.",
+              text = stringResource(R.string.permission_privacy_assurance_standard),
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
           }
 
           Text(
-            text = "mpvRex is an open source project. You can review the source code and verify how permissions are used by visiting our GitHub repository at:",
+            text = stringResource(R.string.opensource_github_notice),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
           )
@@ -356,7 +356,7 @@ fun PermissionDeniedState(
           )
 
           Text(
-            text = "Be rest assured, your privacy is our utmost priority, and we neither access your files for other purposes nor transfer or store them to our servers. They remain safe on your device.",
+            text = stringResource(R.string.privacy_assurance_final),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.Medium,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/SlideToUnlock.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/SlideToUnlock.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import xyz.mpv.rex.R
 
 @Composable
 fun SlideToUnlock(

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/SlideToUnlock.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/SlideToUnlock.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -48,13 +49,13 @@ fun SlideToUnlock(
   onDraggingChanged: (Boolean) -> Unit = {},
 ) {
   val coroutineScope = rememberCoroutineScope()
-  
+
   var containerWidthPx by remember { mutableFloatStateOf(0f) }
   val sliderSize = 56.dp
-  
+
   val offsetX = remember { Animatable(0f) }
   var isDragging by remember { mutableStateOf(false) }
-  
+
   Box(
     modifier = modifier
       .width(200.dp)
@@ -69,7 +70,7 @@ fun SlideToUnlock(
     val sliderSizePx = containerWidthPx * (56f / 192f) // Accounting for padding (200 - 8)
     val maxOffset = if (containerWidthPx > 0f) containerWidthPx - sliderSizePx else 0f
     val unlockThreshold = if (maxOffset > 0f) maxOffset * 0.85f else Float.MAX_VALUE
-    
+
     // Background text - slightly to the right
     Box(
       modifier = Modifier
@@ -79,17 +80,17 @@ fun SlideToUnlock(
       contentAlignment = Alignment.Center,
     ) {
       Text(
-        text = "Slide to Unlock",
+        text = stringResource(R.string.slide_to_unlock),
         color = Color.White.copy(alpha = 0.7f),
         fontSize = 16.sp,
         fontWeight = FontWeight.Medium,
       )
     }
-    
+
     // Slider button
     val progress = if (maxOffset > 0f) (offsetX.value / maxOffset).coerceIn(0f, 1f) else 0f
     val showUnlockIcon = progress > 0.5f
-    
+
     Box(
       modifier = Modifier
         .offset { IntOffset(offsetX.value.roundToInt(), 0) }
@@ -98,7 +99,7 @@ fun SlideToUnlock(
         .background(MaterialTheme.colorScheme.primary)
         .pointerInput(containerWidthPx) {
           if (containerWidthPx <= 0f) return@pointerInput
-          
+
           detectHorizontalDragGestures(
             onDragStart = {
               isDragging = true
@@ -147,7 +148,7 @@ fun SlideToUnlock(
       ) { showUnlock ->
         Icon(
           imageVector = if (showUnlock) Icons.Filled.LockOpen else Icons.Filled.Lock,
-          contentDescription = "Slide to unlock",
+          contentDescription = stringResource(R.string.slide_to_unlock),
           tint = Color.White,
           modifier = Modifier.size(28.dp),
         )

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/MoreSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/MoreSheet.kt
@@ -119,7 +119,11 @@ fun MoreSheet(
     }
   }
 
-  val tabs = listOf("Controls", "Settings", "Interaction")
+  val tabs = listOf(
+    stringResource(R.string.player_sheets_tab_controls),
+    stringResource(R.string.player_sheets_tab_settings),
+    stringResource(R.string.player_sheets_tab_interaction),
+  )
 
   PlayerSheet(
     onDismissRequest,
@@ -186,7 +190,7 @@ fun MoreSheet(
           2 -> InteractionTab()
         }
       }
-      
+
       Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
     }
   }
@@ -206,13 +210,13 @@ fun SettingsTab(
   val decoderPreferences = koinInject<DecoderPreferences>()
   val anime4kManager = koinInject<Anime4KManager>()
   val statisticsPage by advancedPreferences.enabledStatisticsPage.collectAsState()
-  
+
   val enableAnime4K by decoderPreferences.enableAnime4K.collectAsState()
   val anime4kMode by decoderPreferences.anime4kMode.collectAsState()
   val anime4kQuality by decoderPreferences.anime4kQuality.collectAsState()
   val gpuNext by decoderPreferences.gpuNext.collectAsState()
   val useVulkan by decoderPreferences.useVulkan.collectAsState()
-  
+
   val scope = rememberCoroutineScope()
   val activity = LocalContext.current as PlayerActivity
 
@@ -303,7 +307,7 @@ fun SettingsTab(
           )
         }
       }
-      
+
       // Shaders Controls
       if (enableAnime4K && (!gpuNext || useVulkan)) {
         // Auto-detect resolution to disable for 4K+
@@ -317,10 +321,10 @@ fun SettingsTab(
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary
         )
-        
+
         if (isHighRes) {
             Text(
-                text = "Not available for 4K/8K video",
+                text = stringResource(R.string.anime4k_not_available_high_res),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.padding(bottom = 4.dp)
@@ -338,7 +342,7 @@ fun SettingsTab(
               leadingIcon = null,
               onClick = {
                 decoderPreferences.anime4kMode.set(mode.name)
-                
+
                 // Apply shaders immediately (runtime change)
                 scope.launch(Dispatchers.IO) {
                   runCatching {
@@ -475,16 +479,16 @@ fun ControlsTab(
   val buttons = remember(moreSheetControlsPref, visibleOnScreen, chapters, hasPlaylistSupport) {
       // Start with buttons the user explicitly wants in the More Sheet (respect order)
       val userOrderedMoreButtons = appearancePreferences.parseButtons(moreSheetControlsPref, mutableSetOf())
-      
+
       // Calculate "Orphaned" buttons: items in ALL buttons that are NOT on screen AND NOT in the More Sheet pref
       val allAvailable = xyz.mpv.rex.preferences.allPlayerButtons
       val orphanedButtons = allAvailable.filter { it !in visibleOnScreen && it !in userOrderedMoreButtons }
-      
+
       // Combine them: User Order first, then the rest
       (userOrderedMoreButtons + orphanedButtons).filter { button ->
           // Don't show if already visible on screen
           if (visibleOnScreen.contains(button)) return@filter false
-          
+
           // Functional filters (don't show buttons that can't work)
           when (button) {
               PlayerButton.SHUFFLE -> hasPlaylistSupport
@@ -503,7 +507,7 @@ fun ControlsTab(
   }
   val currentZoom by viewModel.videoZoom.collectAsState()
   val aspect by viewModel.videoAspect.collectAsState()
-  
+
   val activity = LocalContext.current as PlayerActivity
   val mpvDecoder by MPVLib.propString["hwdec-current"].collectAsState("")
   val decoder by remember { derivedStateOf { xyz.mpv.rex.ui.player.Decoder.getDecoderFromValue(mpvDecoder ?: "auto") } }
@@ -531,7 +535,7 @@ fun ControlsTab(
           .verticalScroll(rememberScrollState())
   ) {
       Text(
-          text = "Extended Controls",
+          text = stringResource(R.string.player_sheets_extended_controls_title),
           style = MaterialTheme.typography.titleLarge,
           modifier = Modifier.padding(bottom = MaterialTheme.spacing.medium)
       )
@@ -617,7 +621,7 @@ fun InteractionTab() {
       checked = showSeekBarWhenSeeking,
       onCheckedChange = { playerPreferences.showSeekBarWhenSeeking.set(it) }
     )
-    
+
     InteractionSwitch(
       label = stringResource(R.string.pref_gesture_use_single_tap_for_center_title),
       description = stringResource(R.string.pref_gesture_use_single_tap_for_center_summary),

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/SleepTimerSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/SleepTimerSheet.kt
@@ -64,7 +64,7 @@ fun SleepTimerSheet(
         .padding(vertical = 8.dp),
       verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-      
+
       // Title and Value display (centered Column matching PlaybackSpeedSheet)
       Column(
         modifier = Modifier
@@ -201,7 +201,7 @@ fun SleepTimerSheet(
               onDismissRequest()
             },
           ) {
-            Text(text = "Start Timer")
+            Text(text = stringResource(R.string.timer_start))
           }
           Button(
             onClick = onDismissRequest,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -869,4 +869,8 @@
     <string name="btn_label_ambient_mode">الوضع السينيمائي</string>
     <string name="btn_label_sleep_timer">مؤقت النوم</string>
     <string name="btn_label_none">لا شيء</string>
+
+
+    <string name="timer_start">بدء المؤقت</string>
+    <string name="slide_to_unlock">اسحب لفتح القفل</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -874,6 +874,12 @@
     <string name="timer_start">بدء المؤقت</string>
     <string name="slide_to_unlock">اسحب لفتح القفل</string>
 
+    <string name="player_sheets_tab_controls">التحكم</string>
+    <string name="player_sheets_tab_settings">الإعدادات</string>
+    <string name="player_sheets_tab_interaction">التفاعل</string>
+    <string name="anime4k_not_available_high_res">غير متوفر لفيديو 4K/8K</string>
+    <string name="player_sheets_extended_controls_title">أدوات تحكم إضافية</string>
+
     <string name="storage_access_required">الوصول للتخزين مطلوب</string>
     <string name="allow_access">السماح بالوصول</string>
     <string name="why_do_i_see_this">لماذا أرى هذا؟</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -873,4 +873,24 @@
 
     <string name="timer_start">بدء المؤقت</string>
     <string name="slide_to_unlock">اسحب لفتح القفل</string>
+
+    <string name="storage_access_required">الوصول للتخزين مطلوب</string>
+    <string name="allow_access">السماح بالوصول</string>
+    <string name="why_do_i_see_this">لماذا أرى هذا؟</string>
+    <string name="why_this_permission_is_needed">لماذا هذا الإذن مطلوب</string>
+    <string name="permission_explanation_playstore_intro">يحتاج mpvRex إلى الوصول لملفات الفيديو الخاصة بك لتوفير وظيفته الأساسية كمشغل وسائط.</string>
+    <string name="permission_used_exclusively_for">يُستخدم هذا الإذن حصرياً من أجل:</string>
+    <string name="permission_usage_bullet_list">• اكتشاف وعرض ملفات الفيديو الخاصة بك\n• تشغيل المحتوى الإعلامي\n• تحميل ملفات الترجمة</string>
+    <string name="permission_explanation_standard_intro">يتطلب mpvRex دائماً إذن الوصول للتخزين لأنه ضروري لعثور التطبيق على جميع ملفات الوسائط والترجمة الموجودة على جهازك، بما فيها الملفات غير المدعومة من طرف النظام.</string>
+    <string name="permission_security_policy_change">مع ذلك، بسبب تغيير في سياسة الأمان، تتطلب التطبيقات المبنية لأندرويد 11 وما فوق الآن إذناً إضافياً لمواصلة الوصول لنفس الملفات.</string>
+    <string name="permission_privacy_assurance_standard">يرجى العلم أن هذا الإذن يُستخدم فقط للاكتشاف التلقائي لملفات الوسائط/الترجمة على جهازك، ولن يسمح لنا بالوصول لملفات البيانات الخاصة المخزنة من طرف تطبيقات أخرى بأي شكل من الأشكال.</string>
+    <string name="opensource_github_notice">mpvRex مشروع مفتوح المصدر. يمكنك مراجعة الكود المصدري والتحقق من كيفية استخدام الأذونات بزيارة مستودعنا على GitHub في:</string>
+    <string name="privacy_assurance_final">كن مطمئناً، خصوصيتك هي أولويتنا القصوى، ولا نصل لملفاتك لأغراض أخرى ولا ننقلها أو نخزنها في خوادمنا. تبقى آمنة على جهازك.</string>
+    
+    <string name="permission_required_photos_videos">يحتاج mpvRex إذن \"الصور والفيديوهات\" للوصول لملفات الفيديو المخزنة على جهازك وتشغيلها.</string>
+    <string name="permission_required_storage">يحتاج mpvRex إذن \"التخزين\" للوصول لملفات الوسائط المخزنة على جهازك وتشغيلها.</string>
+    <string name="permission_required_all_files">يحتاج mpvRex إذن \"الوصول لجميع الملفات\" لاكتشاف ملفات الوسائط والترجمة على جهازك بسبب تغيير في سياسة الأمان في أندرويد 11 والإصدارات الأحدث.</string>
+    <string name="permission_explanation_tiramisu_plus">في أندرويد 13 وما فوق، يسمح هذا الإذن للتطبيق بقراءة ملفات الفيديو من تخزين جهازك، بما في ذلك مجلدات التنزيلات والأفلام و DCIM.</string>
+    <string name="permission_explanation_pre_tiramisu">يسمح هذا الإذن للتطبيق بقراءة ملفات الوسائط من تخزين جهازك لتشغيل الفيديوهات والصوتيات.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -942,4 +942,8 @@
     <string name="btn_label_ambient_mode">Ambience Mode</string>
     <string name="btn_label_sleep_timer">Sleep Timer</string>
     <string name="btn_label_none">None</string>
+
+
+    <string name="timer_start">Start Timer</string>
+    <string name="slide_to_unlock">Slide to Unlock</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -946,4 +946,24 @@
 
     <string name="timer_start">Start Timer</string>
     <string name="slide_to_unlock">Slide to Unlock</string>
+    
+    <string name="storage_access_required">Storage Access Required</string>
+    <string name="allow_access">ALLOW ACCESS</string>
+    <string name="why_do_i_see_this">Why do I see this?</string>
+    <string name="why_this_permission_is_needed">Why this permission is needed</string>
+    <string name="permission_explanation_playstore_intro">mpvRex needs access to your video files to provide its core functionality as a media player.</string>
+    <string name="permission_used_exclusively_for">The permission is used exclusively for:</string>
+    <string name="permission_usage_bullet_list">• Discovering and displaying your video files\n• Playing media content\n• Loading subtitle files</string>
+    <string name="permission_explanation_standard_intro">mpvRex has always required storage access permission as it\'s essential for the app to find all media and subtitle files on your device, including the ones that are not supported by the system.</string>
+    <string name="permission_security_policy_change">However, due to a change in security policy, apps built for Android 11 and above now require additional permission to continue accessing the same.</string>
+    <string name="permission_privacy_assurance_standard">Please know that this permission is only used for the auto-discovery of media/subtitle files on your device and will not allow us to access the private data files stored by other apps in any way.</string>
+    <string name="opensource_github_notice">mpvRex is an open source project. You can review the source code and verify how permissions are used by visiting our GitHub repository at:</string>
+    <string name="privacy_assurance_final">Be rest assured, your privacy is our utmost priority, and we neither access your files for other purposes nor transfer or store them to our servers. They remain safe on your device.</string>
+    
+    <string name="permission_required_photos_videos">mpvRex requires \"Photos and videos\" permission to access and play your video files stored on your device.</string>
+    <string name="permission_required_storage">mpvRex requires \"Storage\" permission to access and play your media files stored on your device.</string>
+    <string name="permission_required_all_files">mpvRex requires \"All file access\" permission to discover media and subtitles on your device due to a change in security policy in Android 11 and later versions.</string>
+    <string name="permission_explanation_tiramisu_plus">On Android 13 and above, this permission allows the app to read video files from your device\'s storage, including Downloads, Movies, and DCIM folders.</string>
+    <string name="permission_explanation_pre_tiramisu">This permission allows the app to read media files from your device\'s storage to play videos and audio.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -946,6 +946,12 @@
 
     <string name="timer_start">Start Timer</string>
     <string name="slide_to_unlock">Slide to Unlock</string>
+
+    <string name="player_sheets_tab_controls">Controls</string>
+    <string name="player_sheets_tab_settings">Settings</string>
+    <string name="player_sheets_tab_interaction">Interaction</string>
+    <string name="anime4k_not_available_high_res">Not available for 4K/8K video</string>
+    <string name="player_sheets_extended_controls_title">Extended Controls</string>
     
     <string name="storage_access_required">Storage Access Required</string>
     <string name="allow_access">ALLOW ACCESS</string>


### PR DESCRIPTION
## What
Extracts remaining hardcoded strings from `SleepTimerSheet.kt`, `SlideToUnlock.kt`, `PermissionDeniedState.kt`, and `MoreSheet.kt` into string resources.

## Changes
- **SlideToUnlock.kt**: extracted the visible "Slide to Unlock" text and the icon's `contentDescription` (previously hardcoded in English regardless of app language, which caused TalkBack to announce it in English even when the UI was set to another locale). Both now share a single `slide_to_unlock` resource since they carry the same meaning.
- **SleepTimerSheet.kt**: extracted the "Start Timer" button label into `timer_start`.
- **PermissionDeniedState.kt**: extracted 16 hardcoded strings covering the title, description, dialog explanation, and button labels. The permission-variant strings (Play Store vs standard build, SDK version checks) were split into separate keys instead of using a placeholder — keeps the conditional logic untouched and each variant independently translatable.
- **MoreSheet.kt**: extracted the "Controls"/"Settings"/"Interaction" tab labels (`player_sheets_tab_controls`, `player_sheets_tab_settings`, `player_sheets_tab_interaction`), the high-resolution Anime4K warning "Not available for 4K/8K video" (`anime4k_not_available_high_res`), and the "Extended Controls" section header (`player_sheets_extended_controls_title`).

## Notes
- Other hardcoded strings in `SleepTimerSheet.kt`/`SlideToUnlock.kt` (e.g. the `(Remaining)` suffix, the `${minutes}m` short labels) were left as-is, since combining them with existing resources or restructuring how they're built felt like a separate decision outside the scope of this PR.
- In `PermissionDeniedState.kt`, the GitHub URL and the `got_it` string (already existed) were left untouched.
- In `MoreSheet.kt`, technical/internal strings (MPV property keys like `video-params/w`, `hwdec-current`, command strings like `script-binding`, URL scheme/extension checks like `http://`/`.m3u8`) were intentionally left untouched — they're not user-facing text.