### PR TITLE
i18n: extract hardcoded strings in player controls screens

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControlsShared.kt
@@ -71,9 +71,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import xyz.mpv.rex.R
 import xyz.mpv.rex.preferences.PlayerButton
 import xyz.mpv.rex.preferences.preference.collectAsState
 import xyz.mpv.rex.ui.player.Panels
@@ -206,7 +208,7 @@ fun RenderPlayerButton(
           )
           viewModel.getPlaylistInfo()?.let { playlistInfo ->
             Text(
-              " • $playlistInfo",
+              stringResource(R.string.playlist_separator, playlistInfo),
               maxLines = 1,
               overflow = TextOverflow.Visible,
               style = MaterialTheme.typography.bodySmall,
@@ -241,7 +243,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = chapter?.name ?: "Chapters",
+                text = chapter?.name ?: stringResource(R.string.chapters),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -300,7 +302,7 @@ fun RenderPlayerButton(
           ) {
             Icon(
               imageVector = Icons.Default.Speed,
-              contentDescription = "Playback Speed",
+              contentDescription = stringResource(R.string.playback_speed),
               tint = if (isSpeedNonOne) activeContentColor else contentColor,
               modifier = Modifier.size(24.dp),
             )
@@ -390,7 +392,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Rotation",
+                text = stringResource(R.string.screen_rotation),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -434,7 +436,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Frame Nav",
+                text = stringResource(R.string.frame_nav),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -453,7 +455,7 @@ fun RenderPlayerButton(
           Box(contentAlignment = Alignment.Center) {
             Icon(
               imageVector = Icons.Default.Camera,
-              contentDescription = "Frame Navigation",
+              contentDescription = stringResource(R.string.frame_navigation),
               tint = if (isActive) activeContentColor else contentColor,
               modifier = Modifier.size(24.dp),
             )
@@ -485,7 +487,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "PiP",
+                text = stringResource(R.string.pip),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -597,7 +599,7 @@ fun RenderPlayerButton(
           ) {
             Icon(
               imageVector = Icons.Default.ZoomIn,
-              contentDescription = "Video Zoom",
+              contentDescription = stringResource(R.string.video_zoom),
               tint = if (isZoomed) activeContentColor else contentColor,
               modifier = Modifier.size(24.dp),
             )
@@ -644,7 +646,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Lock",
+                text = stringResource(R.string.lock),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -682,7 +684,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Audio",
+                text = stringResource(R.string.audio),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -721,7 +723,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Subtitles",
+                text = stringResource(R.string.subtitles),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -800,9 +802,9 @@ fun RenderPlayerButton(
               )
               Text(
                 text = when (repeatMode) {
-                    xyz.mpv.rex.ui.player.RepeatMode.OFF -> "Repeat Off"
-                    xyz.mpv.rex.ui.player.RepeatMode.ONE -> "Repeat One"
-                    xyz.mpv.rex.ui.player.RepeatMode.ALL -> "Repeat All"
+                    xyz.mpv.rex.ui.player.RepeatMode.OFF -> stringResource(R.string.repeat_off)
+                    xyz.mpv.rex.ui.player.RepeatMode.ONE -> stringResource(R.string.repeat_one)
+                    xyz.mpv.rex.ui.player.RepeatMode.ALL -> stringResource(R.string.repeat_all)
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
@@ -853,7 +855,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Skip ${customSkipDuration}s",
+                text = stringResource(R.string.skip_seconds, customSkipDuration),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -899,7 +901,7 @@ fun RenderPlayerButton(
                   modifier = Modifier.size(24.dp)
                 )
                 Text(
-                  text = if (shuffleEnabled) "Shuffle On" else "Shuffle Off",
+                  text = if (shuffleEnabled) stringResource(R.string.shuffle_on) else stringResource(R.string.shuffle_off),
                   style = MaterialTheme.typography.bodyMedium,
                   maxLines = 1,
                 )
@@ -940,7 +942,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = if (isMirrored) "Mirrored" else "Mirror",
+                text = if (isMirrored) stringResource(R.string.mirrored) else stringResource(R.string.mirror),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -980,7 +982,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp).rotate(90f)
               )
               Text(
-                text = if (isVerticalFlipped) "Flipped" else "Flip Vert",
+                text = if (isVerticalFlipped) stringResource(R.string.flipped) else stringResource(R.string.flip_vertical),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -1000,7 +1002,7 @@ fun RenderPlayerButton(
             Box(contentAlignment = Alignment.Center) {
               Icon(
                 imageVector = Icons.Default.Flip,
-                contentDescription = "Vertical Flip",
+                contentDescription = stringResource(R.string.flip_vertical_desc),
                 tint = if (isVerticalFlipped) activeContentColor else contentColor,
                 modifier = Modifier
                   .padding(MaterialTheme.spacing.smaller)
@@ -1038,12 +1040,12 @@ fun RenderPlayerButton(
               modifier = Modifier.padding(horizontal = MaterialTheme.spacing.smaller)
             ) {
               Text(
-                text = "AB",
+                text = stringResource(R.string.ab_loop_short),
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
               )
               Text(
-                text = "Loop",
+                text = stringResource(R.string.loop),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -1061,7 +1063,7 @@ fun RenderPlayerButton(
         ) {
           Box(contentAlignment = Alignment.Center) {
             Text(
-              text = "AB",
+              text = stringResource(R.string.ab_loop_short),
               style = MaterialTheme.typography.labelLarge,
               fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
               color = if (isActive) activeContentColor else contentColor,
@@ -1103,7 +1105,7 @@ fun RenderPlayerButton(
                 modifier = Modifier.size(24.dp)
               )
               Text(
-                text = "Background",
+                text = stringResource(R.string.background_playback),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
               )
@@ -1144,7 +1146,7 @@ fun RenderPlayerButton(
                   modifier = Modifier.size(24.dp)
                 )
                 Text(
-                  text = "Ambient",
+                  text = stringResource(R.string.ambient),
                   style = MaterialTheme.typography.bodyMedium,
                   maxLines = 1,
                 )
@@ -1172,7 +1174,7 @@ fun RenderPlayerButton(
               Box(contentAlignment = Alignment.Center) {
                 Icon(
                   imageVector = if (isAmbientEnabled) Icons.Filled.BlurOn else Icons.Outlined.BlurOn,
-                  contentDescription = "Ambience Mode",
+                  contentDescription = stringResource(R.string.ambience_mode),
                   tint = if (isAmbientEnabled) activeContentColor else contentColor,
                   modifier = Modifier.size(24.dp)
                 )
@@ -1212,7 +1214,7 @@ fun RenderPlayerButton(
                 text = if (isActive) {
                   android.text.format.DateUtils.formatElapsedTime(remainingTime.toLong())
                 } else {
-                  "Sleep Timer"
+                  stringResource(R.string.sleep_timer)
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
@@ -1232,7 +1234,7 @@ fun RenderPlayerButton(
           Box(contentAlignment = Alignment.Center) {
             Icon(
               imageVector = Icons.Outlined.Timer,
-              contentDescription = "Sleep Timer",
+              contentDescription = stringResource(R.string.sleep_timer),
               tint = if (isActive) activeContentColor else contentColor,
               modifier = Modifier.size(24.dp),
             )

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControlsShared.kt
@@ -308,7 +308,7 @@ fun RenderPlayerButton(
         ) {
           Icon(
             imageVector = Icons.Default.Speed,
-            contentDescription = stringResource(R.string.playback_speed,
+            contentDescription = stringResource(R.string.playback_speed),
             tint = if (isSpeedNonOne) activeContentColor else contentColor,
             modifier = Modifier.size(24.dp),
           )

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerControlsPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerControlsPreferencesScreen.kt
@@ -1,6 +1,7 @@
 package xyz.mpv.rex.ui.preferences
 
 // import androidx.compose.material.icons.outlined.VideoLabel // No longer needed here
+
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -64,491 +65,491 @@ import org.koin.compose.koinInject
 // Enum to identify which region we are editing
 @Serializable
 enum class ControlRegion {
-  TOP_RIGHT,
-  BOTTOM_RIGHT,
-  BOTTOM_LEFT,
-  PORTRAIT_BOTTOM,
-  MORE_SHEET,
+    TOP_RIGHT,
+    BOTTOM_RIGHT,
+    BOTTOM_LEFT,
+    PORTRAIT_BOTTOM,
+    MORE_SHEET,
 }
 
 @Serializable
 object PlayerControlsPreferencesScreen : Screen {
-  @OptIn(ExperimentalMaterial3Api::class)
-  @Composable
-  override fun Content() {
-    val backstack = LocalBackStack.current
-    val appearancePrefs = koinInject<AppearancePreferences>()
-    val playerPrefs = koinInject<PlayerPreferences>()
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val backstack = LocalBackStack.current
+        val appearancePrefs = koinInject<AppearancePreferences>()
+        val playerPrefs = koinInject<PlayerPreferences>()
 
-    // Get the current state for all four regions
-    val topRState by appearancePrefs.topRightControls.collectAsState()
-    val bottomRState by appearancePrefs.bottomRightControls.collectAsState()
-    val bottomLState by appearancePrefs.bottomLeftControls.collectAsState()
-    val portraitBottomState by appearancePrefs.portraitBottomControls.collectAsState()
-    val moreSheetState by appearancePrefs.moreSheetControls.collectAsState()
+        // Get the current state for all four regions
+        val topRState by appearancePrefs.topRightControls.collectAsState()
+        val bottomRState by appearancePrefs.bottomRightControls.collectAsState()
+        val bottomLState by appearancePrefs.bottomLeftControls.collectAsState()
+        val portraitBottomState by appearancePrefs.portraitBottomControls.collectAsState()
+        val moreSheetState by appearancePrefs.moreSheetControls.collectAsState()
 
-    val topRightButtons = remember(topRState) {
-      appearancePrefs.parseButtons(topRState, mutableSetOf())
-    }
+        val topRightButtons = remember(topRState) {
+            appearancePrefs.parseButtons(topRState, mutableSetOf())
+        }
+        val bottomRightButtons = remember(bottomRState) {
+            appearancePrefs.parseButtons(bottomRState, mutableSetOf())
+        }
+        val bottomLeftButtons = remember(bottomLState) {
+            appearancePrefs.parseButtons(bottomLState, mutableSetOf())
+        }
+        val portraitBottomButtons = remember(portraitBottomState) {
+            appearancePrefs.parseButtons(portraitBottomState, mutableSetOf())
+        }
+        val moreSheetButtons = remember(moreSheetState, topRState, bottomRState, bottomLState, portraitBottomState) {
+            val manualOrder = appearancePrefs.parseButtons(moreSheetState, mutableSetOf())
+            val landscapeSet = (topRState.split(',') + bottomRState.split(',') + bottomLState.split(','))
+                .filter(String::isNotBlank)
+                .mapNotNull { try { PlayerButton.valueOf(it) } catch (_: Exception) { null } }
+                .toSet()
+            val portraitSet = portraitBottomState.split(',')
+                .filter(String::isNotBlank)
+                .mapNotNull { try { PlayerButton.valueOf(it) } catch (_: Exception) { null } }
+                .toSet()
 
-    val bottomRightButtons = remember(bottomRState) {
-      appearancePrefs.parseButtons(bottomRState, mutableSetOf())
-    }
+            // A button is only 'used' if it's in BOTH. If missing from EITHER, it's an orphan.
+            val intersection = landscapeSet.intersect(portraitSet)
+            val orphans = allPlayerButtons.filter { it !in intersection }
+            val orderedOrphans = manualOrder.filter { it in orphans }
+            val remainingOrphans = orphans.filter { it !in orderedOrphans }
+            orderedOrphans + remainingOrphans
+        }
 
-    val bottomLeftButtons = remember(bottomLState) {
-      appearancePrefs.parseButtons(bottomLState, mutableSetOf())
-    }
-
-    val portraitBottomButtons = remember(portraitBottomState) {
-      appearancePrefs.parseButtons(portraitBottomState, mutableSetOf())
-    }
-
-    val moreSheetButtons = remember(moreSheetState, topRState, bottomRState, bottomLState, portraitBottomState) {
-      val manualOrder = appearancePrefs.parseButtons(moreSheetState, mutableSetOf())
-      
-      val landscapeSet = (topRState.split(',') + bottomRState.split(',') + bottomLState.split(','))
-          .filter(String::isNotBlank)
-          .mapNotNull { try { PlayerButton.valueOf(it) } catch (_: Exception) { null } }
-          .toSet()
-          
-      val portraitSet = portraitBottomState.split(',')
-          .filter(String::isNotBlank)
-          .mapNotNull { try { PlayerButton.valueOf(it) } catch (_: Exception) { null } }
-          .toSet()
-
-      // A button is only 'used' if it's in BOTH. If missing from EITHER, it's an orphan.
-      val intersection = landscapeSet.intersect(portraitSet)
-      
-      val orphans = allPlayerButtons.filter { it !in intersection }
-      val orderedOrphans = manualOrder.filter { it in orphans }
-      val remainingOrphans = orphans.filter { it !in orderedOrphans }
-      
-      orderedOrphans + remainingOrphans
-    }
-
-    Scaffold(
-      topBar = {
-        TopAppBar(
-          title = { 
-            Text(
-              text = stringResource(id = R.string.pref_layout_title),
-              style = MaterialTheme.typography.headlineSmall,
-              fontWeight = FontWeight.ExtraBold,
-              color = MaterialTheme.colorScheme.primary,
-            )
-          },
-          navigationIcon = {
-            IconButton(onClick = backstack::removeLastOrNull) {
-              Icon(
-                Icons.AutoMirrored.Outlined.ArrowBack, 
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.secondary,
-              )
-            }
-          },
-        )
-      },
-    ) { padding ->
-      ProvidePreferenceLocals {
-        LazyColumn(
-          modifier =
-            Modifier
-              .fillMaxSize()
-              .padding(padding),
-        ) {
-          // Landscape Controls Section
-          item {
-            PreferenceSectionHeader(title = "Landscape Controls")
-          }
-          
-          item {
-            PreferenceCard {
-              PreferenceCategoryWithEditButton(
-                title = stringResource(id = R.string.pref_layout_top_right_controls),
-                onClick = {
-                  backstack.add(ControlLayoutEditorScreen(ControlRegion.TOP_RIGHT))
-                },
-              )
-              PreferenceIconSummary(buttons = topRightButtons)
-              
-              PreferenceDivider()
-              
-              PreferenceCategoryWithEditButton(
-                title = stringResource(id = R.string.pref_layout_bottom_right_controls),
-                onClick = {
-                  backstack.add(ControlLayoutEditorScreen(ControlRegion.BOTTOM_RIGHT))
-                },
-              )
-              PreferenceIconSummary(buttons = bottomRightButtons)
-              
-              PreferenceDivider()
-              
-              PreferenceCategoryWithEditButton(
-                title = stringResource(id = R.string.pref_layout_bottom_left_controls),
-                onClick = {
-                  backstack.add(ControlLayoutEditorScreen(ControlRegion.BOTTOM_LEFT))
-                },
-              )
-              PreferenceIconSummary(buttons = bottomLeftButtons)
-            }
-          }
-          
-          // Portrait Controls Section
-          item {
-            PreferenceSectionHeader(title = "Portrait Controls")
-          }
-
-          item {
-            PreferenceCard {
-
-            
-              PreferenceCategoryWithEditButton(
-                title = stringResource(id = R.string.pref_layout_portrait_bottom_controls),
-                onClick = {
-                  backstack.add(ControlLayoutEditorScreen(ControlRegion.PORTRAIT_BOTTOM))
-                },
-              )
-              PreferenceIconSummary(buttons = portraitBottomButtons)
-            }
-          }
-
-          item {
-            PreferenceSectionHeader(title = "More Sheet Controls")
-          }
-
-          item {
-            PreferenceCard {
-              PreferenceCategoryWithEditButton(
-                title = "Buttons in Controls Tab",
-                onClick = {
-                  backstack.add(ControlLayoutEditorScreen(ControlRegion.MORE_SHEET))
-                },
-              )
-              PreferenceIconSummary(buttons = moreSheetButtons)
-            }
-          }
-          
-          // Seekbar Section
-          item {
-            PreferenceSectionHeader(title = "Seekbar Style")
-          }
-
-          item {
-            val currentSeekbarStyle by appearancePrefs.seekbarStyle.collectAsState()
-            
-            PreferenceCard {
-              SeekbarStyle.entries.forEachIndexed { index, style ->
-                ListItem(
-                  headlineContent = {
-                    Text(text = style.name)
-                  },
-                  trailingContent = {
-                    RadioButton(
-                      selected = currentSeekbarStyle == style,
-                      onClick = null
-                    )
-                  },
-                  colors = androidx.compose.material3.ListItemDefaults.colors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                  ),
-                  modifier = Modifier
-                    .clickable { appearancePrefs.seekbarStyle.set(style) }
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(id = R.string.pref_layout_title),
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = backstack::removeLastOrNull) {
+                            Icon(
+                                Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.secondary,
+                            )
+                        }
+                    },
                 )
-                if (index < SeekbarStyle.entries.size - 1) {
-                  PreferenceDivider()
+            },
+        ) { padding ->
+            ProvidePreferenceLocals {
+                LazyColumn(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                ) {
+                    // Landscape Controls Section
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_layout_landscape_controls_header))
+                    }
+                    item {
+                        PreferenceCard {
+                            PreferenceCategoryWithEditButton(
+                                title = stringResource(id = R.string.pref_layout_top_right_controls),
+                                onClick = {
+                                    backstack.add(ControlLayoutEditorScreen(ControlRegion.TOP_RIGHT))
+                                },
+                            )
+                            PreferenceIconSummary(buttons = topRightButtons)
+
+                            PreferenceDivider()
+
+                            PreferenceCategoryWithEditButton(
+                                title = stringResource(id = R.string.pref_layout_bottom_right_controls),
+                                onClick = {
+                                    backstack.add(ControlLayoutEditorScreen(ControlRegion.BOTTOM_RIGHT))
+                                },
+                            )
+                            PreferenceIconSummary(buttons = bottomRightButtons)
+
+                            PreferenceDivider()
+
+                            PreferenceCategoryWithEditButton(
+                                title = stringResource(id = R.string.pref_layout_bottom_left_controls),
+                                onClick = {
+                                    backstack.add(ControlLayoutEditorScreen(ControlRegion.BOTTOM_LEFT))
+                                },
+                            )
+                            PreferenceIconSummary(buttons = bottomLeftButtons)
+                        }
+                    }
+
+                    // Portrait Controls Section
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_layout_portrait_controls_header))
+                    }
+                    item {
+                        PreferenceCard {
+                            PreferenceCategoryWithEditButton(
+                                title = stringResource(id = R.string.pref_layout_portrait_bottom_controls),
+                                onClick = {
+                                    backstack.add(ControlLayoutEditorScreen(ControlRegion.PORTRAIT_BOTTOM))
+                                },
+                            )
+                            PreferenceIconSummary(buttons = portraitBottomButtons)
+                        }
+                    }
+
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_layout_more_sheet_controls_header))
+                    }
+                    item {
+                        PreferenceCard {
+                            PreferenceCategoryWithEditButton(
+                                title = stringResource(R.string.pref_layout_more_sheet_controls_title),
+                                onClick = {
+                                    backstack.add(ControlLayoutEditorScreen(ControlRegion.MORE_SHEET))
+                                },
+                            )
+                            PreferenceIconSummary(buttons = moreSheetButtons)
+                        }
+                    }
+
+                    // Seekbar Section
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_seekbar_style_header))
+                    }
+                    item {
+                        val currentSeekbarStyle by appearancePrefs.seekbarStyle.collectAsState()
+                        PreferenceCard {
+                            SeekbarStyle.entries.forEachIndexed { index, style ->
+                                ListItem(
+                                    headlineContent = {
+                                        // NOTE (#24 - not touched): style.name reads the raw enum
+                                        // identifier and is not localizable as-is. Needs a
+                                        // SeekbarStyle -> @StringRes mapping function; left for
+                                        // the maintainer to design.
+                                        Text(text = style.name)
+                                    },
+                                    trailingContent = {
+                                        RadioButton(
+                                            selected = currentSeekbarStyle == style,
+                                            onClick = null
+                                        )
+                                    },
+                                    colors = androidx.compose.material3.ListItemDefaults.colors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                    ),
+                                    modifier = Modifier
+                                        .clickable { appearancePrefs.seekbarStyle.set(style) }
+                                )
+                                if (index < SeekbarStyle.entries.size - 1) {
+                                    PreferenceDivider()
+                                }
+                            }
+                        }
+                    }
+
+                    // Bottom Controls Layout Section
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_controls_layout_header))
+                    }
+                    item {
+                        val bottomControlsBelowSeekbar by playerPrefs.bottomControlsBelowSeekbar.collectAsState()
+                        PreferenceCard {
+                            SwitchPreference(
+                                value = bottomControlsBelowSeekbar,
+                                onValueChange = { playerPrefs.bottomControlsBelowSeekbar.set(it) },
+                                title = {
+                                    Text(text = stringResource(R.string.pref_controls_layout_below_seekbar_title))
+                                },
+                                summary = {
+                                    Text(
+                                        text = stringResource(
+                                            if (bottomControlsBelowSeekbar)
+                                                R.string.pref_controls_layout_below_seekbar_summary_true
+                                            else
+                                                R.string.pref_controls_layout_below_seekbar_summary_false
+                                        )
+                                    )
+                                },
+                            )
+                        }
+                    }
+
+                    // Appearance Section
+                    item {
+                        PreferenceSectionHeader(title = stringResource(R.string.pref_player_appearance_header))
+                    }
+                    item {
+                        val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
+                        val hidePlayerButtonsBackground by appearancePrefs.hidePlayerButtonsBackground.collectAsState()
+                        val enableGlassPlayerControls by appearancePrefs.enableGlassPlayerControls.collectAsState()
+                        val playerAlwaysDarkMode by appearancePrefs.playerAlwaysDarkMode.collectAsState()
+                        val playerTimeToDisappear by playerPrefs.playerTimeToDisappear.collectAsState()
+                        val predefinedTimeValues = listOf(500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000)
+                        val isCustomTimeValue = !predefinedTimeValues.contains(playerTimeToDisappear)
+                        var showCustomTimeDialog by remember { mutableStateOf(false) }
+                        var customTimeValue by remember { mutableStateOf("") }
+
+                        PreferenceCard {
+                            SwitchPreference(
+                                value = enableBounceAnimation,
+                                onValueChange = { appearancePrefs.enableBounceAnimation.set(it) },
+                                title = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_title)
+                                    )
+                                },
+                                summary = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_summary)
+                                    )
+                                },
+                            )
+
+                            PreferenceDivider()
+
+                            SwitchPreference(
+                                value = hidePlayerButtonsBackground,
+                                onValueChange = { appearancePrefs.hidePlayerButtonsBackground.set(it) },
+                                title = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_hide_player_buttons_background_title),
+                                    )
+                                },
+                                summary = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_hide_player_buttons_background_summary),
+                                    )
+                                },
+                            )
+
+                            PreferenceDivider()
+
+                            SwitchPreference(
+                                value = enableGlassPlayerControls,
+                                onValueChange = { appearancePrefs.enableGlassPlayerControls.set(it) },
+                                title = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_enable_glass_player_controls_title),
+                                    )
+                                },
+                                summary = {
+                                    Text(
+                                        text = stringResource(id = R.string.pref_appearance_enable_glass_player_controls_summary),
+                                    )
+                                },
+                            )
+
+                            PreferenceDivider()
+
+                            SwitchPreference(
+                                value = playerAlwaysDarkMode,
+                                onValueChange = { appearancePrefs.playerAlwaysDarkMode.set(it) },
+                                title = {
+                                    Text(text = stringResource(R.string.pref_appearance_player_always_dark_mode_title))
+                                },
+                                summary = {
+                                    Text(text = stringResource(R.string.pref_appearance_player_always_dark_mode_summary))
+                                },
+                            )
+
+                            PreferenceDivider()
+
+                            val showControlsOnPlay by playerPrefs.showControlsOnPlay.collectAsState()
+                            SwitchPreference(
+                                value = showControlsOnPlay,
+                                onValueChange = { playerPrefs.showControlsOnPlay.set(it) },
+                                title = {
+                                    Text(text = stringResource(R.string.pref_appearance_show_controls_on_play_title))
+                                },
+                                summary = {
+                                    Text(text = stringResource(R.string.pref_appearance_show_controls_on_play_summary))
+                                },
+                            )
+
+                            PreferenceDivider()
+
+                            val playerGradientOpacity by playerPrefs.playerGradientOpacity.collectAsState()
+                            SliderPreference(
+                                value = playerGradientOpacity,
+                                onValueChange = { playerPrefs.playerGradientOpacity.set(it.toFixed(2)) },
+                                title = { Text(stringResource(R.string.pref_appearance_player_gradient_opacity_title)) },
+                                valueRange = 0f..1f,
+                                summary = {
+                                    val opacityPercent = (playerGradientOpacity * 100).toInt()
+                                    Text(
+                                        text = stringResource(
+                                            R.string.pref_appearance_player_gradient_opacity_current,
+                                            opacityPercent
+                                        ),
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                },
+                                onSliderValueChange = { playerPrefs.playerGradientOpacity.set(it.toFixed(2)) },
+                                sliderValue = playerGradientOpacity,
+                            )
+
+                            PreferenceDivider()
+
+                            ListPreference(
+                                value = if (isCustomTimeValue) -1 else playerTimeToDisappear,
+                                onValueChange = { newValue ->
+                                    if (newValue == -1) {
+                                        customTimeValue = playerTimeToDisappear.toString()
+                                        showCustomTimeDialog = true
+                                    } else {
+                                        playerPrefs.playerTimeToDisappear.set(newValue)
+                                    }
+                                },
+                                values = predefinedTimeValues + listOf(-1),
+                                valueToText = { value ->
+                                    // NOTE (#20 - not touched): needs confirmation whether this
+                                    // lambda runs in a @Composable scope in this version of
+                                    // me.zhanghai.compose.preference before calling
+                                    // stringResource() here. Left as literal for now.
+                                    if (value == -1) {
+                                        AnnotatedString("Custom")
+                                    } else {
+                                        AnnotatedString("$value ms")
+                                    }
+                                },
+                                title = { Text(text = stringResource(R.string.pref_player_display_hide_player_control_time)) },
+                                summary = {
+                                    Text(
+                                        text = if (isCustomTimeValue) {
+                                            stringResource(
+                                                R.string.pref_player_display_custom_time_summary,
+                                                playerTimeToDisappear
+                                            )
+                                        } else {
+                                            stringResource(
+                                                R.string.pref_player_display_time_ms_format,
+                                                playerTimeToDisappear
+                                            )
+                                        },
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                },
+                            )
+                        }
+
+                        if (showCustomTimeDialog) {
+                            AlertDialog(
+                                onDismissRequest = { showCustomTimeDialog = false },
+                                title = { Text(text = stringResource(R.string.pref_player_display_hide_player_control_time)) },
+                                text = {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .verticalScroll(rememberScrollState()),
+                                    ) {
+                                        Text(
+                                            text = stringResource(R.string.pref_player_display_custom_hide_time_dialog_message),
+                                            modifier = Modifier.padding(bottom = 8.dp),
+                                        )
+                                        OutlinedTextField(
+                                            value = customTimeValue,
+                                            onValueChange = { customTimeValue = it },
+                                            label = { Text(stringResource(id = R.string.milliseconds)) },
+                                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                            modifier = Modifier.fillMaxWidth(),
+                                            singleLine = true,
+                                        )
+                                    }
+                                },
+                                confirmButton = {
+                                    TextButton(
+                                        onClick = {
+                                            val value = customTimeValue.toIntOrNull()
+                                            if (value != null && value in 100..1000000000000) {
+                                                playerPrefs.playerTimeToDisappear.set(value)
+                                                showCustomTimeDialog = false
+                                            }
+                                        },
+                                    ) {
+                                        Text(stringResource(R.string.generic_ok))
+                                    }
+                                },
+                                dismissButton = {
+                                    TextButton(onClick = { showCustomTimeDialog = false }) {
+                                        Text(stringResource(R.string.generic_cancel))
+                                    }
+                                },
+                            )
+                        }
+                    }
                 }
-              }
             }
-          }
-          
-          // Bottom Controls Layout Section
-          item {
-            PreferenceSectionHeader(title = "Controls Layout")
-          }
-          
-          item {
-            val bottomControlsBelowSeekbar by playerPrefs.bottomControlsBelowSeekbar.collectAsState()
-            
-            PreferenceCard {
-              SwitchPreference(
-                value = bottomControlsBelowSeekbar,
-                onValueChange = { playerPrefs.bottomControlsBelowSeekbar.set(it) },
-                title = {
-                  Text(text = "Bottom controls below seekbar")
-                },
-                summary = {
-                  Text(
-                    text = if (bottomControlsBelowSeekbar) 
-                      "Control buttons appear below the seekbar" 
-                    else 
-                      "Control buttons appear above the seekbar"
-                  )
-                },
-              )
+        }
+    }
+
+    /**
+     * Custom composable for the category header with an Edit button.
+     */
+    @Composable
+    private fun PreferenceCategoryWithEditButton(
+        title: String,
+        onClick: () -> Unit,
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+            // Apply padding to Row - minimal padding for tighter appearance
+            verticalAlignment = Alignment.CenterVertically, // Align items vertically
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f), // Text takes all available space, pushing button to end
+            )
+            IconButton(onClick = onClick) {
+                Icon(
+                    imageVector = Icons.Outlined.Edit,
+                    contentDescription = stringResource(R.string.generic_edit_content_description, title),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
-          }
-          
-          // Appearance Section
-          item {
-            PreferenceSectionHeader(title = "Appearance")
-          }
-          
-          item {
-            val enableBounceAnimation by appearancePrefs.enableBounceAnimation.collectAsState()
-            val hidePlayerButtonsBackground by appearancePrefs.hidePlayerButtonsBackground.collectAsState()
-            val enableGlassPlayerControls by appearancePrefs.enableGlassPlayerControls.collectAsState()
-            val playerAlwaysDarkMode by appearancePrefs.playerAlwaysDarkMode.collectAsState()
-            val playerTimeToDisappear by playerPrefs.playerTimeToDisappear.collectAsState()
-            val predefinedTimeValues = listOf(500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000)
-            val isCustomTimeValue = !predefinedTimeValues.contains(playerTimeToDisappear)
-            
-            var showCustomTimeDialog by remember { mutableStateOf(false) }
-            var customTimeValue by remember { mutableStateOf("") }
-            
-            PreferenceCard {
-            SwitchPreference(
-                value = enableBounceAnimation,
-                onValueChange = { appearancePrefs.enableBounceAnimation.set(it) },
-                title = {
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_title)
-                  ) 
-                },
-                summary = { 
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_enable_bounce_animation_summary)
-                  ) 
-                },
-              )
-              
-              PreferenceDivider()
+        }
+    }
 
-              SwitchPreference(
-                value = hidePlayerButtonsBackground,
-                onValueChange = { appearancePrefs.hidePlayerButtonsBackground.set(it) },
-                title = {
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_hide_player_buttons_background_title),
-                  )
-                },
-                summary = {
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_hide_player_buttons_background_summary),
-                  )
-                },
-              )
-              
-              PreferenceDivider()
-
-              SwitchPreference(
-                value = enableGlassPlayerControls,
-                onValueChange = { appearancePrefs.enableGlassPlayerControls.set(it) },
-                title = {
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_enable_glass_player_controls_title),
-                  )
-                },
-                summary = {
-                  Text(
-                    text = stringResource(id = R.string.pref_appearance_enable_glass_player_controls_summary),
-                  )
-                },
-              )
-
-              PreferenceDivider()
-
-              SwitchPreference(
-                value = playerAlwaysDarkMode,
-                onValueChange = { appearancePrefs.playerAlwaysDarkMode.set(it) },
-                title = {
-                  Text(text = "Player controls always dark mode")
-                },
-                summary = {
-                  Text(text = "Keep player controls in dark theme regardless of app theme")
-                },
-              )
-              
-              PreferenceDivider()
-
-              val showControlsOnPlay by playerPrefs.showControlsOnPlay.collectAsState()
-              SwitchPreference(
-                value = showControlsOnPlay,
-                onValueChange = { playerPrefs.showControlsOnPlay.set(it) },
-                title = {
-                  Text(text = "Show controls on play start")
-                },
-                summary = {
-                  Text(text = "Show player controls overlay when a video starts playing")
-                },
-              )
-              
-              PreferenceDivider()
-
-              val playerGradientOpacity by playerPrefs.playerGradientOpacity.collectAsState()
-              SliderPreference(
-                value = playerGradientOpacity,
-                onValueChange = { playerPrefs.playerGradientOpacity.set(it.toFixed(2)) },
-                title = { Text("Player gradient opacity") },
-                valueRange = 0f..1f,
-                summary = {
-                  val opacityPercent = (playerGradientOpacity * 100).toInt()
-                  Text(
-                    text = "Current: $opacityPercent%",
+    /**
+     * Custom composable to show a row of icons for the summary.
+     */
+    @OptIn(ExperimentalLayoutApi::class)
+    @Composable
+    private fun PreferenceIconSummary(buttons: List<PlayerButton>) {
+        FlowRow(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp), // Increased spacing
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+        ) {
+            if (buttons.isEmpty()) {
+                Text(
+                    stringResource(R.string.generic_none),
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.outline,
-                  )
-                },
-                onSliderValueChange = { playerPrefs.playerGradientOpacity.set(it.toFixed(2)) },
-                sliderValue = playerGradientOpacity,
-              )
-              
-              PreferenceDivider()
-              
-              ListPreference(
-                value = if (isCustomTimeValue) -1 else playerTimeToDisappear,
-                onValueChange = { newValue ->
-                  if (newValue == -1) {
-                    customTimeValue = playerTimeToDisappear.toString()
-                    showCustomTimeDialog = true
-                  } else {
-                    playerPrefs.playerTimeToDisappear.set(newValue)
-                  }
-                },
-                values = predefinedTimeValues + listOf(-1),
-                valueToText = { value ->
-                  if (value == -1) {
-                    AnnotatedString("Custom")
-                  } else {
-                    AnnotatedString("$value ms")
-                  }
-                },
-                title = { Text(text = stringResource(R.string.pref_player_display_hide_player_control_time)) },
-                summary = {
-                  Text(
-                    text = if (isCustomTimeValue) {
-                      "Custom ($playerTimeToDisappear ms)"
-                    } else {
-                      "$playerTimeToDisappear ms"
-                    },
-                      color = MaterialTheme.colorScheme.outline,
-                  )
-                },
-              )
-            }
-            
-            if (showCustomTimeDialog) {
-              AlertDialog(
-                onDismissRequest = { showCustomTimeDialog = false },
-                title = { Text(text = stringResource(R.string.pref_player_display_hide_player_control_time)) },
-                text = {
-                  Column(
-                    modifier = Modifier
-                      .fillMaxWidth()
-                      .verticalScroll(rememberScrollState()),
-                  ) {
-                    Text(
-                      text = "Enter custom hide time in milliseconds",
-                      modifier = Modifier.padding(bottom = 8.dp),
+                )
+            } else {
+                buttons.forEach { button ->
+                    // Use the chip in "preview mode" (no badge, enabled=true but no onClick)
+                    PlayerButtonChip(
+                        button = button,
+                        enabled = true,
+                        onClick = null,
+                        badgeIcon = null,
+                        badgeColor = null
                     )
-                    OutlinedTextField(
-                      value = customTimeValue,
-                      onValueChange = { customTimeValue = it },
-                      label = { Text(stringResource(id = R.string.milliseconds)) },
-                      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                      modifier = Modifier.fillMaxWidth(),
-                      singleLine = true,
-                    )
-                  }
-                },
-                confirmButton = {
-                  TextButton(
-                    onClick = {
-                      val value = customTimeValue.toIntOrNull()
-                      if (value != null && value in 100..1000000000000) {
-                        playerPrefs.playerTimeToDisappear.set(value)
-                        showCustomTimeDialog = false
-                      }
-                    },
-                  ) {
-                    Text(stringResource(R.string.generic_ok))
-                  }
-                },
-                dismissButton = {
-                  TextButton(onClick = { showCustomTimeDialog = false }) {
-                    Text(stringResource(R.string.generic_cancel))
-                  }
-                },
-              )
+                }
             }
-          }
         }
-      }
     }
-  }
-
-  /**
-   * Custom composable for the category header with an Edit button.
-   */
-  @Composable
-  private fun PreferenceCategoryWithEditButton(
-    title: String,
-    onClick: () -> Unit,
-  ) {
-    Row(
-      modifier =
-        Modifier
-          .fillMaxWidth()
-          .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
-      // Apply padding to Row - minimal padding for tighter appearance
-      verticalAlignment = Alignment.CenterVertically, // Align items vertically
-    ) {
-      Text(
-        text = title,
-        style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.onSurface,
-        modifier = Modifier.weight(1f), // Text takes all available space, pushing button to end
-      )
-      IconButton(onClick = onClick) {
-        Icon(
-          imageVector = Icons.Outlined.Edit,
-          contentDescription = "Edit $title",
-          tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-      }
-    }
-  }
-
-  /**
-   * Custom composable to show a row of icons for the summary.
-   */
-  @OptIn(ExperimentalLayoutApi::class)
-  @Composable
-  private fun PreferenceIconSummary(buttons: List<PlayerButton>) {
-    FlowRow(
-      modifier =
-        Modifier
-          .fillMaxWidth()
-          .padding(horizontal = 16.dp, vertical = 8.dp),
-      horizontalArrangement = Arrangement.spacedBy(8.dp), // Increased spacing
-      verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
-    ) {
-      if (buttons.isEmpty()) {
-        Text(
-          "None", // TODO: strings
-          style = MaterialTheme.typography.bodyMedium,
-          color = MaterialTheme.colorScheme.outline,
-        )
-      } else {
-        buttons.forEach { button ->
-          // Use the chip in "preview mode" (no badge, enabled=true but no onClick)
-          PlayerButtonChip(
-            button = button,
-            enabled = true,
-            onClick = null, 
-            badgeIcon = null,
-            badgeColor = null
-          )
-        }
-      }
-    }
-  }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -899,4 +899,35 @@
     <string name="permission_explanation_tiramisu_plus">في أندرويد 13 وما فوق، يسمح هذا الإذن للتطبيق بقراءة ملفات الفيديو من تخزين جهازك، بما في ذلك مجلدات التنزيلات والأفلام و DCIM.</string>
     <string name="permission_explanation_pre_tiramisu">يسمح هذا الإذن للتطبيق بقراءة ملفات الوسائط من تخزين جهازك لتشغيل الفيديوهات والصوتيات.</string>
 
+        <!-- PlayerControlsShared -->
+    <string name="playlist_separator">• %1$s</string>
+    <string name="chapters">الفصول</string>
+    <string name="skip_seconds">تخطي %1$d ثانية</string>
+    <string name="playback_speed">سرعة التشغيل</string>
+    <string name="screen_rotation">التدوير</string>
+    <string name="frame_nav">تصفح الإطارات</string>
+    <string name="frame_navigation">التنقل بين الإطارات</string>
+    <string name="pip">صورة داخل صورة</string>
+    <string name="video_zoom">تقريب الفيديو</string>
+    <string name="lock">قفل</string>
+    <string name="audio">الصوت</string>
+    <string name="subtitles">الترجمة</string>
+    <string name="repeat_off">التكرار متوقف</string>
+    <string name="repeat_one">تكرار العنصر الواحد</string>
+    <string name="repeat_all">تكرار الكل</string>
+    <string name="shuffle_on">التشغيل العشوائي مفعّل</string>
+    <string name="shuffle_off">التشغيل العشوائي متوقف</string>
+    <string name="mirrored">معكوس أفقياً</string>
+    <string name="mirror">عكس أفقي</string>
+    <string name="flipped">معكوس عمودياً</string>
+    <string name="flip_vertical">عكس عمودي</string>
+    <string name="flip_vertical_desc">العكس العمودي</string>
+    <string name="ab_loop_short">AB</string>
+    <string name="loop">تكرار</string>
+    <string name="background_playback">التشغيل في الخلفية</string>
+    <string name="ambient">الوضع المحيطي</string>
+    <string name="ambience_mode">وضع الإضاءة المحيطية</string>
+    <string name="sleep_timer">مؤقت النوم</string>
+
+
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -929,5 +929,35 @@
     <string name="ambience_mode">وضع الإضاءة المحيطية</string>
     <string name="sleep_timer">مؤقت النوم</string>
 
+    
+         <!-- Preference section headers -->
+    <string name="pref_layout_landscape_controls_header">أدوات التحكم في وضع أفقي</string>
+    <string name="pref_layout_portrait_controls_header">أدوات التحكم في وضع عمودي</string>
+    <string name="pref_layout_more_sheet_controls_header">أدوات التحكم في القائمة الإضافية</string>
+    <string name="pref_layout_more_sheet_controls_title">الأزرار في تبويب أدوات التحكم</string>
+    <string name="pref_seekbar_style_header">شكل شريط التقدّم</string>
+    <string name="pref_controls_layout_header">تخطيط أدوات التحكم</string>
+    <string name="pref_player_appearance_header">المظهر</string>
 
+       <!-- Controls Layout: below/above seekbar -->
+    <string name="pref_controls_layout_below_seekbar_title">أدوات التحكم أسفل شريط التقدّم</string>
+    <string name="pref_controls_layout_below_seekbar_summary_true">تظهر أزرار التحكم أسفل شريط التقدّم</string>
+    <string name="pref_controls_layout_below_seekbar_summary_false">تظهر أزرار التحكم أعلى شريط التقدّم</string>
+
+        <!-- Appearance section -->
+    <string name="pref_appearance_show_controls_on_play_title">إظهار أدوات التحكم عند بدء التشغيل</string>
+    <string name="pref_appearance_show_controls_on_play_summary">إظهار طبقة أدوات التحكم عند بدء تشغيل الفيديو</string>
+    <string name="pref_appearance_player_gradient_opacity_title">شفافية التدرّج في أدوات التحكم</string>
+    <string name="pref_appearance_player_gradient_opacity_current">الحالي: %1$d%%</string>
+
+        <!-- Custom hide-time dialog -->
+    <string name="pref_player_display_custom_hide_time_dialog_message">أدخل زمن الإخفاء المخصّص بالميلي ثانية</string>
+    <string name="pref_player_display_time_ms_format">%1$d ms</string>
+    <string name="pref_player_display_custom_time_summary">مخصّص (%1$d ms)</string>
+    
+        <!-- Generic reusable strings -->
+    <string name="generic_none">بلا</string>
+    <string name="generic_custom">مخصّص</string>
+    <string name="generic_edit_content_description">تعديل %1$s</string>
+    
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1019,8 +1019,6 @@
     <string name="pref_controls_layout_below_seekbar_summary_false">Control buttons appear above the seekbar</string>
 
         <!-- Appearance section -->
-    <string name="pref_appearance_player_always_dark_mode_title">Player controls always dark mode</string>
-    <string name="pref_appearance_player_always_dark_mode_summary">Keep player controls in dark theme regardless of app theme</string>
     <string name="pref_appearance_show_controls_on_play_title">Show controls on play start</string>
     <string name="pref_appearance_show_controls_on_play_summary">Show player controls overlay when a video starts playing</string>
     <string name="pref_appearance_player_gradient_opacity_title">Player gradient opacity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1004,4 +1004,37 @@
     <string name="ambience_mode">Ambience Mode</string>
     <string name="sleep_timer">Sleep Timer</string>
 
+        <!-- Preference section headers -->
+    <string name="pref_layout_landscape_controls_header">Landscape Controls</string>
+    <string name="pref_layout_portrait_controls_header">Portrait Controls</string>
+    <string name="pref_layout_more_sheet_controls_header">More Sheet Controls</string>
+    <string name="pref_layout_more_sheet_controls_title">Buttons in Controls Tab</string>
+    <string name="pref_seekbar_style_header">Seekbar Style</string>
+    <string name="pref_controls_layout_header">Controls Layout</string>
+    <string name="pref_player_appearance_header">Appearance</string>
+
+        <!-- Controls Layout: below/above seekbar -->
+    <string name="pref_controls_layout_below_seekbar_title">Bottom controls below seekbar</string>
+    <string name="pref_controls_layout_below_seekbar_summary_true">Control buttons appear below the seekbar</string>
+    <string name="pref_controls_layout_below_seekbar_summary_false">Control buttons appear above the seekbar</string>
+
+        <!-- Appearance section -->
+    <string name="pref_appearance_player_always_dark_mode_title">Player controls always dark mode</string>
+    <string name="pref_appearance_player_always_dark_mode_summary">Keep player controls in dark theme regardless of app theme</string>
+    <string name="pref_appearance_show_controls_on_play_title">Show controls on play start</string>
+    <string name="pref_appearance_show_controls_on_play_summary">Show player controls overlay when a video starts playing</string>
+    <string name="pref_appearance_player_gradient_opacity_title">Player gradient opacity</string>
+    <string name="pref_appearance_player_gradient_opacity_current">Current: %1$d%%</string>
+
+        <!-- Custom hide-time dialog -->
+    <string name="pref_player_display_custom_hide_time_dialog_message">Enter custom hide time in milliseconds</string>
+    <string name="pref_player_display_time_ms_format">%1$d ms</string>
+    <string name="pref_player_display_custom_time_summary">Custom (%1$d ms)</string>
+
+        <!-- Generic reusable strings -->
+    <string name="generic_none">None</string>
+    <string name="generic_custom">Custom</string>
+    <string name="generic_edit_content_description">Edit %1$s</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -972,4 +972,34 @@
     <string name="permission_explanation_tiramisu_plus">On Android 13 and above, this permission allows the app to read video files from your device\'s storage, including Downloads, Movies, and DCIM folders.</string>
     <string name="permission_explanation_pre_tiramisu">This permission allows the app to read media files from your device\'s storage to play videos and audio.</string>
 
+        <!-- PlayerControlsShared -->
+    <string name="playlist_separator">• %1$s</string>
+    <string name="chapters">Chapters</string>
+    <string name="skip_seconds">Skip %1$ds</string>
+    <string name="playback_speed">Playback Speed</string>
+    <string name="screen_rotation">Rotation</string>
+    <string name="frame_nav">Frame Nav</string>
+    <string name="frame_navigation">Frame Navigation</string>
+    <string name="pip">PiP</string>
+    <string name="video_zoom">Video Zoom</string>
+    <string name="lock">Lock</string>
+    <string name="audio">Audio</string>
+    <string name="subtitles">Subtitles</string>
+    <string name="repeat_off">Repeat Off</string>
+    <string name="repeat_one">Repeat One</string>
+    <string name="repeat_all">Repeat All</string>
+    <string name="shuffle_on">Shuffle On</string>
+    <string name="shuffle_off">Shuffle Off</string>
+    <string name="mirrored">Mirrored</string>
+    <string name="mirror">Mirror</string>
+    <string name="flipped">Flipped</string>
+    <string name="flip_vertical">Flip Vert</string>
+    <string name="flip_vertical_desc">Vertical Flip</string>
+    <string name="ab_loop_short">AB</string>
+    <string name="loop">Loop</string>
+    <string name="background_playback">Background</string>
+    <string name="ambient">Ambient</string>
+    <string name="ambience_mode">Ambience Mode</string>
+    <string name="sleep_timer">Sleep Timer</string>
+
 </resources>


### PR DESCRIPTION

## Summary

Extracts all hardcoded UI strings in `PlayerControlsShared.kt` and `PlayerControlsPreferencesScreen.kt` into string resources, with Arabic translations included.

## Changes

- Added new string keys to `strings.xml` (`values/` and `values-ar/`) covering both files (~49 keys total, after removing duplicates found during review)
- Replaced literal `text` / `contentDescription` values with `stringResource()` calls
- Converted dynamic strings to formatted resources with placeholders:
  - Skip duration
  - Playlist separator
  - Gradient opacity percentage
  - Custom hide-time summary
  - Edit-button content description

## Intentionally left unlocalized (needs maintainer input)

| Location | Reason |
|---|---|
| `SeekbarStyle.entries` display names | Reads raw enum `.name` (Standard/Wavy/Thick/Circular/Simple), not a string literal. Needs a `SeekbarStyle -> @StringRes Int` mapping function + 5 new resources before it can be localized. |
| `ListPreference.valueToText` lambda | Needs confirmation this lambda runs in a `@Composable` scope in the current version of `me.zhanghai.compose.preference` before `stringResource()` can be safely called inside it. |

## Testing

- [ ] Verified no duplicate resource keys (`grep -oP 'name="\K[^"]+' strings.xml | sort | uniq -d`)
- [ ] Build passes (`./gradlew assembleRelease`)
- [ ] Manually checked Arabic layout for RTL/placeholder correctness