### PR TITLE
feat: Add Advanced Zoom Controls for Independent Video Scaling and Bl…

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
@@ -57,6 +57,10 @@ class PlayerPreferences(
   val defaultVideoPanY = preferenceStore.getFloat("default_video_pan_y", 0f)
   val panAndZoomEnabled = preferenceStore.getBoolean("pan_and_zoom_enabled", false)
 
+  val advancedZoomEnabled = preferenceStore.getBoolean("advanced_zoom_enabled", false)
+  val defaultVideoScaleX = preferenceStore.getFloat("default_video_scale_x", 1f)
+  val defaultVideoScaleY = preferenceStore.getFloat("default_video_scale_y", 1f)
+
   val includeSubtitlesInSnapshot = preferenceStore.getBoolean("include_subtitles_in_snapshot", false)
 
   val playlistMode = preferenceStore.getBoolean("playlist_mode", true)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -975,6 +975,22 @@ class PlayerViewModel(
       _videoPanX.value = mpvPanX
       _videoPanY.value = mpvPanY
     }
+
+    val prefAdvancedZoomEnabled = playerPreferences.advancedZoomEnabled.get()
+    _advancedZoomEnabled.value = prefAdvancedZoomEnabled
+    if (prefAdvancedZoomEnabled) {
+      val prefScaleX = playerPreferences.defaultVideoScaleX.get()
+      val prefScaleY = playerPreferences.defaultVideoScaleY.get()
+      MPVLib.setPropertyDouble("video-scale-x", prefScaleX.toDouble())
+      MPVLib.setPropertyDouble("video-scale-y", prefScaleY.toDouble())
+      _videoScaleX.value = prefScaleX
+      _videoScaleY.value = prefScaleY
+    } else {
+      MPVLib.setPropertyDouble("video-scale-x", 1.0)
+      MPVLib.setPropertyDouble("video-scale-y", 1.0)
+      _videoScaleX.value = 1f
+      _videoScaleY.value = 1f
+    }
   }
 
   fun changeVideoAspect(
@@ -1243,6 +1259,40 @@ class PlayerViewModel(
 
   fun resetVideoZoom() {
     setVideoZoom(0f)
+  }
+
+  private val _advancedZoomEnabled = MutableStateFlow(false)
+  val advancedZoomEnabled: StateFlow<Boolean> = _advancedZoomEnabled.asStateFlow()
+
+  private val _videoScaleX = MutableStateFlow(1f)
+  val videoScaleX: StateFlow<Float> = _videoScaleX.asStateFlow()
+
+  private val _videoScaleY = MutableStateFlow(1f)
+  val videoScaleY: StateFlow<Float> = _videoScaleY.asStateFlow()
+
+  fun setAdvancedZoomEnabled(enabled: Boolean) {
+    _advancedZoomEnabled.value = enabled
+    if (enabled) {
+      setVideoZoom(0f)
+    } else {
+      setVideoScaleX(1f)
+      setVideoScaleY(1f)
+    }
+  }
+
+  fun setVideoScaleX(scale: Float) {
+    _videoScaleX.value = scale
+    MPVLib.setPropertyDouble("video-scale-x", scale.toDouble())
+  }
+
+  fun setVideoScaleY(scale: Float) {
+    _videoScaleY.value = scale
+    MPVLib.setPropertyDouble("video-scale-y", scale.toDouble())
+  }
+
+  fun resetAdvancedZoom() {
+    setVideoScaleX(1f)
+    setVideoScaleY(1f)
   }
 
   // ==================== Frame Navigation ====================

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/GestureHandler.kt
@@ -130,6 +130,7 @@ fun GestureHandler(
   val swapVolumeAndBrightness by playerPreferences.swapVolumeAndBrightness.collectAsState()
   val pinchToZoomGesture by playerPreferences.pinchToZoomGesture.collectAsState()
   val panAndZoomEnabled by playerPreferences.panAndZoomEnabled.collectAsState()
+  val advancedZoomEnabled by viewModel.advancedZoomEnabled.collectAsState()
   val horizontalSwipeToSeek by playerPreferences.horizontalSwipeToSeek.collectAsState()
   val swipeToSubtitleSeek by playerPreferences.swipeToSubtitleSeek.collectAsState()
   val moveSubtitleByDragging by playerPreferences.moveSubtitleByDragging.collectAsState()
@@ -813,8 +814,8 @@ fun GestureHandler(
           }
         }
       }
-      .pointerInput(pinchToZoomGesture, panAndZoomEnabled, areControlsLocked, isVerticalGestureActive) {
-        if (!pinchToZoomGesture || areControlsLocked || isVerticalGestureActive) return@pointerInput
+      .pointerInput(pinchToZoomGesture, panAndZoomEnabled, areControlsLocked, isVerticalGestureActive, advancedZoomEnabled) {
+        if (!pinchToZoomGesture || areControlsLocked || isVerticalGestureActive || advancedZoomEnabled) return@pointerInput
 
         awaitEachGesture {
           var zoom = 0f
@@ -896,8 +897,8 @@ fun GestureHandler(
         }
       }
       // Single-finger pan (only when Pan & Zoom enabled and zoomed in)
-      .pointerInput(panAndZoomEnabled, pinchToZoomGesture, areControlsLocked, isVerticalGestureActive) {
-        if (!panAndZoomEnabled || !pinchToZoomGesture || areControlsLocked || isVerticalGestureActive) return@pointerInput
+      .pointerInput(panAndZoomEnabled, pinchToZoomGesture, areControlsLocked, isVerticalGestureActive, advancedZoomEnabled) {
+        if (!panAndZoomEnabled || !pinchToZoomGesture || areControlsLocked || isVerticalGestureActive || advancedZoomEnabled) return@pointerInput
 
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerSheets.kt
@@ -334,6 +334,10 @@ fun PlayerSheets(
       val currentRatio by viewModel.currentAspectRatio.composeCollectAsState()
       val videoZoom by viewModel.videoZoom.composeCollectAsState()
       val videoPanX by viewModel.videoPanX.composeCollectAsState()
+      val videoPanY by viewModel.videoPanY.composeCollectAsState()
+      val advancedZoomEnabled by viewModel.advancedZoomEnabled.composeCollectAsState()
+      val videoScaleX by viewModel.videoScaleX.composeCollectAsState()
+      val videoScaleY by viewModel.videoScaleY.composeCollectAsState()
       val customRatios =
         customRatiosSet.mapNotNull { str ->
           val parts = str.split("|")
@@ -353,6 +357,7 @@ fun PlayerSheets(
         customRatios = customRatios,
         videoZoom = videoZoom,
         videoPanX = videoPanX,
+        videoPanY = videoPanY,
         onZoomChange = { zoom ->
           viewModel.setVideoZoom(zoom)
           playerPreferences.defaultVideoZoom.set(zoom)
@@ -360,6 +365,34 @@ fun PlayerSheets(
         onPanXChange = { panX ->
           viewModel.setVideoPan(panX, viewModel.videoPanY.value)
           playerPreferences.defaultVideoPanX.set(panX)
+        },
+        onPanYChange = { panY ->
+          viewModel.setVideoPan(viewModel.videoPanX.value, panY)
+          playerPreferences.defaultVideoPanY.set(panY)
+        },
+        advancedZoomEnabled = advancedZoomEnabled,
+        videoScaleX = videoScaleX,
+        videoScaleY = videoScaleY,
+        onAdvancedZoomToggle = { enabled ->
+          viewModel.setAdvancedZoomEnabled(enabled)
+          playerPreferences.advancedZoomEnabled.set(enabled)
+          if (!enabled) {
+            playerPreferences.defaultVideoScaleX.set(1f)
+            playerPreferences.defaultVideoScaleY.set(1f)
+          }
+        },
+        onScaleXChange = { scale ->
+          viewModel.setVideoScaleX(scale)
+          playerPreferences.defaultVideoScaleX.set(scale)
+        },
+        onScaleYChange = { scale ->
+          viewModel.setVideoScaleY(scale)
+          playerPreferences.defaultVideoScaleY.set(scale)
+        },
+        onResetAdvancedZoom = {
+          viewModel.resetAdvancedZoom()
+          playerPreferences.defaultVideoScaleX.set(1f)
+          playerPreferences.defaultVideoScaleY.set(1f)
         },
         onSelectRatio = { ratio ->
           if (ratio < 0) {

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/AspectRatioSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/AspectRatioSheet.kt
@@ -15,10 +15,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.draw.scale
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -27,7 +32,11 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,8 +67,17 @@ fun AspectRatioSheet(
   customRatios: List<AspectRatio>,
   videoZoom: Float,
   videoPanX: Float,
+  videoPanY: Float,
   onZoomChange: (Float) -> Unit,
   onPanXChange: (Float) -> Unit,
+  onPanYChange: (Float) -> Unit,
+  advancedZoomEnabled: Boolean,
+  videoScaleX: Float,
+  videoScaleY: Float,
+  onAdvancedZoomToggle: (Boolean) -> Unit,
+  onScaleXChange: (Float) -> Unit,
+  onScaleYChange: (Float) -> Unit,
+  onResetAdvancedZoom: () -> Unit,
   onSelectRatio: (Double) -> Unit,
   onAddCustomRatio: (String, Double) -> Unit,
   onDeleteCustomRatio: (AspectRatio) -> Unit,
@@ -191,8 +209,94 @@ fun AspectRatioSheet(
           .padding(bottom = MaterialTheme.spacing.small),
       )
 
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = MaterialTheme.spacing.medium)
+          .padding(bottom = MaterialTheme.spacing.small),
+      ) {
+        Switch(
+          checked = advancedZoomEnabled,
+          onCheckedChange = onAdvancedZoomToggle,
+          modifier = Modifier.scale(0.8f),
+          thumbContent = {
+            Crossfade(
+              targetState = advancedZoomEnabled,
+              animationSpec = tween(durationMillis = 200),
+              label = "AdvancedZoomSwitchIconAnimation",
+            ) { isChecked ->
+              if (isChecked) {
+                Icon(
+                  imageVector = Icons.Default.Check,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+              } else {
+                Icon(
+                  imageVector = Icons.Default.Close,
+                  contentDescription = null,
+                  modifier = Modifier.size(SwitchDefaults.IconSize),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+              }
+            }
+          },
+        )
+        Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
+        Column {
+          Text(
+            text = stringResource(R.string.player_sheets_aspect_ratio_advanced_zoom_toggle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (advancedZoomEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+          Text(
+            text = stringResource(R.string.player_sheets_aspect_ratio_advanced_zoom_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+
+      if (advancedZoomEnabled) {
+        AdvancedZoomAxisControl(
+          label = stringResource(R.string.player_sheets_aspect_ratio_horizontal_zoom_value, videoScaleX),
+          value = videoScaleX,
+          onValueChange = onScaleXChange,
+          decreaseDescription = stringResource(R.string.player_sheets_aspect_ratio_decrease_horizontal_zoom),
+          increaseDescription = stringResource(R.string.player_sheets_aspect_ratio_increase_horizontal_zoom),
+          resetDescription = stringResource(R.string.player_sheets_aspect_ratio_reset_horizontal_zoom),
+        )
+
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+        AdvancedZoomAxisControl(
+          label = stringResource(R.string.player_sheets_aspect_ratio_vertical_zoom_value, videoScaleY),
+          value = videoScaleY,
+          onValueChange = onScaleYChange,
+          decreaseDescription = stringResource(R.string.player_sheets_aspect_ratio_decrease_vertical_zoom),
+          increaseDescription = stringResource(R.string.player_sheets_aspect_ratio_increase_vertical_zoom),
+          resetDescription = stringResource(R.string.player_sheets_aspect_ratio_reset_vertical_zoom),
+        )
+
+        if (videoScaleX != 1f || videoScaleY != 1f) {
+          Button(
+            onClick = onResetAdvancedZoom,
+            modifier = Modifier
+              .padding(horizontal = MaterialTheme.spacing.medium)
+              .padding(top = MaterialTheme.spacing.small),
+          ) {
+            Text(
+              text = stringResource(R.string.player_sheets_aspect_ratio_reset_advanced_zoom),
+              style = MaterialTheme.typography.labelMedium,
+            )
+          }
+        }
+      }
+
       // Zoom Slider
-      Column(
+      if (!advancedZoomEnabled) Column(
         modifier = Modifier
           .fillMaxWidth()
           .padding(horizontal = MaterialTheme.spacing.medium)
@@ -269,6 +373,49 @@ fun AspectRatioSheet(
         Slider(
           value = videoPanX,
           onValueChange = onPanXChange,
+          valueRange = -1f..1f,
+          modifier = Modifier.fillMaxWidth()
+        )
+      }
+
+      Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = MaterialTheme.spacing.medium)
+      ) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+          modifier = Modifier.fillMaxWidth()
+        ) {
+          Text(
+            text =
+              stringResource(
+                R.string.player_sheets_aspect_ratio_vertical_offset_value,
+                videoPanY,
+              ),
+            style = MaterialTheme.typography.bodyMedium
+          )
+
+          if (videoPanY != 0f) {
+            IconButton(
+              onClick = { onPanYChange(0f) },
+              modifier = Modifier.size(24.dp)
+            ) {
+              Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription = stringResource(R.string.player_sheets_aspect_ratio_reset_pan),
+                modifier = Modifier.size(16.dp)
+              )
+            }
+          }
+        }
+
+        Slider(
+          value = videoPanY,
+          onValueChange = onPanYChange,
           valueRange = -1f..1f,
           modifier = Modifier.fillMaxWidth()
         )
@@ -425,3 +572,72 @@ private fun calculateRatio(
 }
 
 private fun abs(value: Double): Double = if (value < 0) -value else value
+
+private const val ADVANCED_ZOOM_MIN = 0.5f
+private const val ADVANCED_ZOOM_MAX = 2.0f
+private const val ADVANCED_ZOOM_STEP = 0.05f
+
+@Composable
+private fun AdvancedZoomAxisControl(
+  label: String,
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  decreaseDescription: String,
+  increaseDescription: String,
+  resetDescription: String,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = MaterialTheme.spacing.medium)
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth()
+    ) {
+      Text(text = label, style = MaterialTheme.typography.bodyMedium)
+
+      if (value != 1f) {
+        IconButton(
+          onClick = { onValueChange(1f) },
+          modifier = Modifier.size(24.dp)
+        ) {
+          Icon(
+            imageVector = Icons.Default.Refresh,
+            contentDescription = resetDescription,
+            modifier = Modifier.size(16.dp)
+          )
+        }
+      }
+    }
+
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      FilledTonalIconButton(
+        onClick = { onValueChange((value - ADVANCED_ZOOM_STEP).coerceAtLeast(ADVANCED_ZOOM_MIN)) },
+        modifier = Modifier.size(36.dp),
+      ) {
+        Icon(Icons.Default.Remove, contentDescription = decreaseDescription, modifier = Modifier.size(18.dp))
+      }
+
+      Slider(
+        value = value,
+        onValueChange = onValueChange,
+        valueRange = ADVANCED_ZOOM_MIN..ADVANCED_ZOOM_MAX,
+        modifier = Modifier.weight(1f)
+      )
+
+      FilledTonalIconButton(
+        onClick = { onValueChange((value + ADVANCED_ZOOM_STEP).coerceAtMost(ADVANCED_ZOOM_MAX)) },
+        modifier = Modifier.size(36.dp),
+      ) {
+        Icon(Icons.Default.Add, contentDescription = increaseDescription, modifier = Modifier.size(18.dp))
+      }
+    }
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,7 @@
     <string name="player_sheets_aspect_ratio_zoom_value">Zoom: %1$.2fx</string>
     <string name="player_sheets_aspect_ratio_reset_zoom">Reset Zoom</string>
     <string name="player_sheets_aspect_ratio_horizontal_offset_value">Horizontal Offset: %1$.3f</string>
+    <string name="player_sheets_aspect_ratio_vertical_offset_value">Vertical Offset: %1$.3f</string>
     <string name="player_sheets_aspect_ratio_reset_pan">Reset Pan</string>
     <string name="player_sheets_aspect_ratio_add_custom_title">Add Custom Ratio (e.g. 16:9)</string>
     <string name="player_sheets_aspect_ratio_width">Width</string>
@@ -521,6 +522,17 @@
     <string name="player_sheets_aspect_ratio_custom_ratio_label" translatable="false">%1$s:%2$s</string>
     <string name="player_sheets_aspect_ratio_invalid">Invalid</string>
     <string name="player_sheets_aspect_ratio_add">Add</string>
+    <string name="player_sheets_aspect_ratio_advanced_zoom_toggle">Advanced Zoom</string>
+    <string name="player_sheets_aspect_ratio_advanced_zoom_description">Independently stretch or crop the horizontal and vertical axes, useful for removing black bars</string>
+    <string name="player_sheets_aspect_ratio_horizontal_zoom_value">Horizontal Zoom: %1$.2fx</string>
+    <string name="player_sheets_aspect_ratio_vertical_zoom_value">Vertical Zoom: %1$.2fx</string>
+    <string name="player_sheets_aspect_ratio_reset_horizontal_zoom">Reset horizontal zoom</string>
+    <string name="player_sheets_aspect_ratio_reset_vertical_zoom">Reset vertical zoom</string>
+    <string name="player_sheets_aspect_ratio_decrease_horizontal_zoom">Decrease horizontal zoom</string>
+    <string name="player_sheets_aspect_ratio_increase_horizontal_zoom">Increase horizontal zoom</string>
+    <string name="player_sheets_aspect_ratio_decrease_vertical_zoom">Decrease vertical zoom</string>
+    <string name="player_sheets_aspect_ratio_increase_vertical_zoom">Increase vertical zoom</string>
+    <string name="player_sheets_aspect_ratio_reset_advanced_zoom">Reset Advanced Zoom</string>
 
     <string name="player_sheets_frame_navigation_title">Frame Navigation</string>
     <string name="player_sheets_frame_navigation_timestamp_value" formatted="false" translatable="false">%1$02d:%2$02d:%3$02d</string>


### PR DESCRIPTION
Added

Advanced Zoom

- Independently stretch or crop the horizontal and vertical axes, useful for removing black bars.

Some videos have black bars that are built into the video itself, and they are not easy to remove using the current aspect ratio implementation and zoom system without losing some content beyond the screen.

Now users have the ability to adjust:

- Horizontal Zoom
- Vertical Zoom
- Vertical Offset

https://github.com/user-attachments/assets/b0b040bd-1b34-426f-8faf-62415b03c60e
