### PR TITLE
fix(i18n): replace hardcoded UI strings and itemType with localized resources

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/DeleteConfirmationDialog.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/DeleteConfirmationDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import xyz.mpv.rex.R
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -30,13 +31,13 @@ fun DeleteConfirmationDialog(
   isOpen: Boolean,
   onDismiss: () -> Unit,
   onConfirm: () -> Unit,
-  itemType: String,
+  @androidx.annotation.PluralsRes itemTypePluralRes: Int,
   itemCount: Int,
   itemNames: List<String> = emptyList(),
 ) {
   if (!isOpen) return
 
-  val itemText = if (itemCount == 1) itemType else "${itemType}s"
+  val itemText = pluralStringResource(itemTypePluralRes, itemCount)
 
   AlertDialog(
     onDismissRequest = onDismiss,
@@ -60,7 +61,7 @@ fun DeleteConfirmationDialog(
           modifier = Modifier.fillMaxWidth(),
         ) {
           Text(
-            text = stringResource(R.string.delete_items_warning, if (itemCount == 1) "" else "s"),
+            text = pluralStringResource(R.plurals.delete_items_warning, itemCount),
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onErrorContainer,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/RenameDialog.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/RenameDialog.kt
@@ -34,7 +34,7 @@ fun RenameDialog(
   onDismiss: () -> Unit,
   onConfirm: (String) -> Unit,
   currentName: String,
-  itemType: String,
+  @androidx.annotation.StringRes itemTypeRes: Int,
   extension: String? = null,
 ) {
   if (!isOpen) return
@@ -75,7 +75,7 @@ fun RenameDialog(
     onDismissRequest = onDismiss,
     title = {
       Text(
-        text = stringResource(R.string.rename_item, itemType),
+        text = stringResource(R.string.rename_item, stringResource(itemTypeRes)),
         style = MaterialTheme.typography.headlineMedium,
         fontWeight = FontWeight.Bold,
       )

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -605,7 +605,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
             title = if (isAtRoot) {
               stringResource(xyz.mpv.rex.R.string.app_name)
             } else {
-              breadcrumbs.lastOrNull()?.name ?: "Tree View"
+              breadcrumbs.lastOrNull()?.name ?: stringResource(xyz.mpv.rex.R.string.tree_view)
             },
             isInSelectionMode = isInSelectionMode,
             selectedCount = selectedCount,
@@ -882,7 +882,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
                 filePicker.launch(arrayOf("video/*"))
               },
               icon = { Icon(Icons.Filled.FileOpen, contentDescription = null) },
-              text = { Text(text = "Open File") },
+              text = { Text(text = stringResource(R.string.open_file)) },
             )
 
             FloatingActionButtonMenuItem(
@@ -897,7 +897,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
                 }
               },
               icon = { Icon(Icons.Filled.History, contentDescription = null) },
-              text = { Text(text = "Recently Played") },
+              text = { Text(text = stringResource(R.string.recently_played)) },
             )
 
             FloatingActionButtonMenuItem(
@@ -906,7 +906,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
                 showLinkDialog.value = true
               },
               icon = { Icon(Icons.Filled.Link, contentDescription = null) },
-              text = { Text(text = "Open Link") },
+              text = { Text(text = stringResource(R.string.open_link)) },
             )
           }
         }
@@ -1109,10 +1109,10 @@ fun FileSystemBrowserScreen(path: String? = null) {
           videoSelectionManager.deleteSelected()
         }
       },
-      itemType = when {
-        folderSelectionManager.isInSelectionMode && videoSelectionManager.isInSelectionMode -> "item"
-        folderSelectionManager.isInSelectionMode -> "folder"
-        else -> "video"
+      itemTypePluralRes = when {
+        folderSelectionManager.isInSelectionMode && videoSelectionManager.isInSelectionMode -> R.plurals.item_type_item_plural
+        folderSelectionManager.isInSelectionMode -> R.plurals.item_type_folder_plural
+        else -> R.plurals.item_type_video_plural
       },
       itemCount = selectedCount,
       itemNames = (folderSelectionManager.getSelectedItems().map { it.name } +
@@ -1132,14 +1132,14 @@ fun FileSystemBrowserScreen(path: String? = null) {
               coroutineScope.launch {
                 val ok = viewModel.renameFolder(folder, newName)
                 if (!ok) {
-                  android.widget.Toast.makeText(context, "Rename failed", android.widget.Toast.LENGTH_SHORT).show()
+                  android.widget.Toast.makeText(context, context.getString(R.string.rename_failed), android.widget.Toast.LENGTH_SHORT).show()
                 }
                 folderSelectionManager.clear()
                 viewModel.refresh()
               }
             },
             currentName = folder.name,
-            itemType = "folder",
+            itemTypeRes = R.string.item_type_folder,
           )
         }
       } else if (videoSelectionManager.isSingleSelection) {
@@ -1152,7 +1152,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
             onDismiss = { renameDialogOpen.value = false },
             onConfirm = { newName -> videoSelectionManager.renameSelected(newName) },
             currentName = baseName,
-            itemType = "file",
+            itemTypeRes = R.string.item_type_file,
             extension = if (extension != ".") extension else null,
           )
         }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/folderlist/FolderListScreen.kt
@@ -950,14 +950,14 @@ object FolderListScreen : Screen {
               coroutineScope.launch {
                 val ok = viewModel.renameFolder(folder, newName)
                 if (!ok) {
-                  android.widget.Toast.makeText(context, "Rename failed", android.widget.Toast.LENGTH_SHORT).show()
+                  android.widget.Toast.makeText(context, context.getString(R.string.rename_failed), android.widget.Toast.LENGTH_SHORT).show()
                 }
                 selectionManager.clear()
                 viewModel.refresh()
               }
             },
             currentName = folder.name,
-            itemType = "folder",
+            itemTypeRes = R.string.item_type_folder,
           )
         }
       }
@@ -966,7 +966,7 @@ object FolderListScreen : Screen {
         isOpen = deleteDialogOpen.value,
         onDismiss = { deleteDialogOpen.value = false },
         onConfirm = { selectionManager.deleteSelected() },
-        itemType = "folder",
+        itemTypePluralRes = R.plurals.item_type_folder_plural,
         itemCount = selectionManager.selectedCount,
         itemNames = selectionManager.getSelectedItems().map { it.name },
       )

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -386,7 +386,7 @@ fun MediaLibraryContent() {
               filePicker.launch(arrayOf("video/*"))
             },
             icon = { Icon(Icons.Filled.FileOpen, contentDescription = null) },
-            text = { Text(text = "Open File") },
+            text = { Text(text = stringResource(R.string.open_file)) },
           )
 
           FloatingActionButtonMenuItem(
@@ -403,7 +403,7 @@ fun MediaLibraryContent() {
               }
             },
             icon = { Icon(Icons.Filled.History, contentDescription = null) },
-            text = { Text(text = "Recently Played") },
+            text = { Text(text = stringResource(R.string.recently_played)) },
           )
 
           FloatingActionButtonMenuItem(
@@ -412,7 +412,7 @@ fun MediaLibraryContent() {
               showLinkDialog.value = true
             },
             icon = { Icon(Icons.Filled.Link, contentDescription = null) },
-            text = { Text(text = "Open Link") },
+            text = { Text(text = stringResource(R.string.open_link)) },
           )
         }
       }
@@ -510,7 +510,7 @@ fun MediaLibraryContent() {
         },
         itemCount = selectionManager.selectedCount,
         isOpen = deleteDialogOpen.value,
-        itemType = "video"
+        itemTypePluralRes = R.plurals.item_type_video_plural
       )
     }
 
@@ -525,7 +525,7 @@ fun MediaLibraryContent() {
           },
           currentName = video.displayName,
           isOpen = renameDialogOpen.value,
-          itemType = "video"
+          itemTypeRes = R.string.item_type_video
         )
       }
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
@@ -434,4 +434,3 @@ object PlaylistScreen : Screen {
       gridState = gridState,
     )
   }
-}

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
@@ -395,6 +395,7 @@ object PlaylistScreen : Screen {
             showDeleteDialog = false
           },
           itemTypePluralRes = R.plurals.item_type_playlist_plural,
+          itemCount = selectionManager.selectedCount,
           itemNames = selectionManager.getSelectedItems().map { it.playlist.name },
         )
       }
@@ -433,3 +434,4 @@ object PlaylistScreen : Screen {
       gridState = gridState,
     )
   }
+}

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/playlist/PlaylistScreen.kt
@@ -394,8 +394,7 @@ object PlaylistScreen : Screen {
             selectionManager.deleteSelected()
             showDeleteDialog = false
           },
-          itemCount = selectionManager.selectedCount,
-          itemType = "playlist",
+          itemTypePluralRes = R.plurals.item_type_playlist_plural,
           itemNames = selectionManager.getSelectedItems().map { it.playlist.name },
         )
       }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/videolist/VideoListScreen.kt
@@ -554,7 +554,7 @@ data class VideoListScreen(
         isOpen = deleteDialogOpen.value,
         onDismiss = { deleteDialogOpen.value = false },
         onConfirm = { selectionManager.deleteSelected() },
-        itemType = "video",
+        itemTypePluralRes = R.plurals.item_type_video_plural,
         itemCount = selectionManager.selectedCount,
         itemNames = selectionManager.getSelectedItems().map { it.displayName },
       )
@@ -570,7 +570,7 @@ data class VideoListScreen(
             onDismiss = { renameDialogOpen.value = false },
             onConfirm = { newName -> selectionManager.renameSelected(newName) },
             currentName = baseName,
-            itemType = "file",
+            itemTypeRes = R.string.item_type_file,
             extension = if (extension != ".") extension else null,
           )
         }
@@ -762,12 +762,12 @@ fun VideoListContent(
     emptyTitle = if (searchQuery != null) {
       if (searchQuery.isBlank()) stringResource(R.string.search_empty_title) else stringResource(R.string.search_no_results_title)
     } else {
-      "No videos in this folder"
+      stringResource(R.string.no_videos_in_folder)
     },
     emptyMessage = if (searchQuery != null) {
       if (searchQuery.isBlank()) stringResource(R.string.search_empty_message) else stringResource(R.string.search_no_results_message)
     } else {
-      "Videos you add to this folder will appear here"
+      stringResource(R.string.no_videos_in_folder_desc)
     },
     emptyIcon = if (searchQuery != null) Icons.Filled.Search else Icons.Filled.VideoLibrary,
     isRefreshing = isRefreshing,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
@@ -74,9 +74,9 @@ object PlayerPreferencesScreen : Screen {
         ) {
           // General Section
           item {
-            PreferenceSectionHeader(title = "General")
+            PreferenceSectionHeader(title = stringResource(R.string.pref_player_general))
           }
-          
+
           item {
             PreferenceCard {
               val orientation by preferences.orientation.collectAsState()
@@ -93,45 +93,45 @@ object PlayerPreferencesScreen : Screen {
                   ) 
                 },
               )
-              
+
               PreferenceDivider()
-              
+
               val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
               SwitchPreference(
                 value = savePositionOnQuit,
                 onValueChange = preferences.savePositionOnQuit::set,
                 title = { Text(stringResource(R.string.pref_player_save_position_on_quit)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val closeAfterEndOfVideo by preferences.closeAfterReachingEndOfVideo.collectAsState()
               SwitchPreference(
                 value = closeAfterEndOfVideo,
                 onValueChange = preferences.closeAfterReachingEndOfVideo::set,
                 title = { Text(stringResource(id = R.string.pref_player_close_after_eof)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val autoplayNextVideo by preferences.autoplayNextVideo.collectAsState()
               SwitchPreference(
                 value = autoplayNextVideo,
                 onValueChange = preferences.autoplayNextVideo::set,
-                title = { Text(text = "Autoplay next video") },
+                title = { Text(text = stringResource(R.string.pref_player_autoplay_next_video)) },
                 summary = {
                   Text(
                     text = if (autoplayNextVideo)
-                      "Automatically play next video when current ends"
+                      stringResource(R.string.pref_player_autoplay_next_video_summary_on)
                     else
-                      "Stay on current video when it ends",
+                      stringResource(R.string.pref_player_autoplay_next_video_summary_off),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },
               )
-              
+
               PreferenceDivider()
-              
+
               val playlistMode by preferences.playlistMode.collectAsState()
               SwitchPreference(
                 value = playlistMode,
@@ -140,14 +140,14 @@ object PlayerPreferencesScreen : Screen {
                 summary = {
                   Text(
                     text = if (playlistMode)
-                      "Show next/previous buttons for all videos in folder"
+                      stringResource(R.string.pref_player_playlist_mode_summary_on)
                     else
-                      "Play videos individually (select multiple for playlist)",
+                      stringResource(R.string.pref_player_playlist_mode_summary_off),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },
               )
-              
+
               PreferenceDivider()
 
               val rememberBrightness by preferences.rememberBrightness.collectAsState()
@@ -163,10 +163,10 @@ object PlayerPreferencesScreen : Screen {
               SwitchPreference(
                 value = autoPiPOnNavigation,
                 onValueChange = preferences.autoPiPOnNavigation::set,
-                title = { Text("Auto Picture-in-Picture") },
+                title = { Text(stringResource(R.string.pref_player_auto_pip)) },
                 summary = {
                   Text(
-                    text = "Automatically enter PIP mode when pressing home or back",
+                    text = stringResource(R.string.pref_player_auto_pip_summary),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },
@@ -182,14 +182,14 @@ object PlayerPreferencesScreen : Screen {
                 summary = {
                   Text(
                     text = if (keepScreenOnWhenPaused)
-                      "Screen stays awake while video is paused"
+                      stringResource(R.string.pref_player_keep_screen_on_when_paused_summary_on)
                     else
-                      "Screen can turn off while video is paused",
+                      stringResource(R.string.pref_player_keep_screen_on_when_paused_summary_off),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },
               )
-              
+
               PreferenceDivider()
 
               val resumeOnUnlock by preferences.resumeOnUnlock.collectAsState()
@@ -213,7 +213,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceSectionHeader(title = stringResource(R.string.pref_player_seeking_title))
           }
-          
+
           item {
             PreferenceCard {
               val showDoubleTapOvals by preferences.showDoubleTapOvals.collectAsState()
@@ -222,9 +222,9 @@ object PlayerPreferencesScreen : Screen {
                 onValueChange = preferences.showDoubleTapOvals::set,
                 title = { Text(stringResource(R.string.show_splash_ovals_on_double_tap_to_seek)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val showCircularDoubleTapSeek by preferences.showCircularDoubleTapSeek.collectAsState()
               SwitchPreference(
                 value = showCircularDoubleTapSeek,
@@ -232,25 +232,25 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_show_circular_double_tap_seek_title)) },
                 summary = { Text(stringResource(R.string.pref_player_show_circular_double_tap_seek_summary)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val showSeekTimeWhileSeeking by preferences.showSeekTimeWhileSeeking.collectAsState()
               SwitchPreference(
                 value = showSeekTimeWhileSeeking,
                 onValueChange = preferences.showSeekTimeWhileSeeking::set,
                 title = { Text(stringResource(R.string.show_time_on_double_tap_to_seek)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val usePreciseSeeking by preferences.usePreciseSeeking.collectAsState()
               SwitchPreference(
                 value = usePreciseSeeking,
                 onValueChange = preferences.usePreciseSeeking::set,
                 title = { Text(stringResource(R.string.pref_player_use_precise_seeking)) },
               )
-              
+
               PreferenceDivider()
 
               val showSeekBarWhenSeeking by preferences.showSeekBarWhenSeeking.collectAsState()
@@ -260,7 +260,7 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_show_seekbar_when_seeking_title)) },
                 summary = { Text(stringResource(R.string.pref_player_show_seekbar_when_seeking_summary)) },
               )
-              
+
               PreferenceDivider()
 
               val hideOsdText by preferences.hideOsdText.collectAsState()
@@ -270,9 +270,9 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_hide_osd_text_title)) },
                 summary = { Text(stringResource(R.string.pref_player_hide_osd_text_summary)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val customSkipDuration by preferences.customSkipDuration.collectAsState()
               SliderPreference(
                 value = customSkipDuration.toFloat(),
@@ -295,7 +295,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceSectionHeader(title = stringResource(R.string.pref_player_gestures))
           }
-          
+
           item {
             PreferenceCard {
               val brightnessGesture by preferences.brightnessGesture.collectAsState()
@@ -304,27 +304,27 @@ object PlayerPreferencesScreen : Screen {
                 onValueChange = preferences.brightnessGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_brightness)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val volumeGesture by preferences.volumeGesture.collectAsState()
               SwitchPreference(
                 value = volumeGesture,
                 onValueChange = preferences.volumeGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_volume)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val pinchToZoomGesture by preferences.pinchToZoomGesture.collectAsState()
               SwitchPreference(
                 value = pinchToZoomGesture,
                 onValueChange = preferences.pinchToZoomGesture::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_pinch_to_zoom)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val panAndZoomEnabled by preferences.panAndZoomEnabled.collectAsState()
               SwitchPreference(
                 value = panAndZoomEnabled,
@@ -332,16 +332,16 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_gestures_pan_and_zoom)) },
                 summary = { Text(stringResource(R.string.pref_player_gestures_pan_and_zoom_summary)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val horizontalSwipeToSeek by preferences.horizontalSwipeToSeek.collectAsState()
               SwitchPreference(
                 value = horizontalSwipeToSeek,
                 onValueChange = preferences.horizontalSwipeToSeek::set,
                 title = { Text(stringResource(R.string.pref_player_gestures_horizontal_swipe_to_seek)) },
               )
-              
+
               PreferenceDivider()
 
               val swipeToSubtitleSeek by preferences.swipeToSubtitleSeek.collectAsState()
@@ -363,7 +363,7 @@ object PlayerPreferencesScreen : Screen {
               )
 
               PreferenceDivider()
-              
+
               val horizontalSwipeSensitivity by preferences.horizontalSwipeSensitivity.collectAsState()
               SliderPreference(
                 value = horizontalSwipeSensitivity,
@@ -371,6 +371,7 @@ object PlayerPreferencesScreen : Screen {
                 title = { Text(stringResource(R.string.pref_player_gestures_horizontal_swipe_sensitivity)) },
                 valueRange = 0.020f..0.1f,
                 summary = {
+                  // ملاحظة: هذا الجزء يحتوي على النص المركب المستثنى (Low/Medium/High) — لم يُلمس عمداً
                   val sensitivityPercent = (horizontalSwipeSensitivity * 1000).toInt()
                   Text(
                     "Current: ${sensitivityPercent}/100 (${if (sensitivityPercent < 30) "Low" else if (sensitivityPercent < 55) "Medium" else "High"})",
@@ -380,9 +381,9 @@ object PlayerPreferencesScreen : Screen {
                 onSliderValueChange = { preferences.horizontalSwipeSensitivity.set(it.toFixed(3)) },
                 sliderValue = horizontalSwipeSensitivity,
               )
-              
+
               PreferenceDivider()
-              
+
               val holdForMultipleSpeed by preferences.holdForMultipleSpeed.collectAsState()
               SliderPreference(
                 value = holdForMultipleSpeed,
@@ -402,17 +403,17 @@ object PlayerPreferencesScreen : Screen {
                 onSliderValueChange = { preferences.holdForMultipleSpeed.set(it.toFixed(2)) },
                 sliderValue = holdForMultipleSpeed,
               )
-              
+
               PreferenceDivider()
-              
+
               val showDynamicSpeedOverlay by preferences.showDynamicSpeedOverlay.collectAsState()
               SwitchPreference(
                 value = showDynamicSpeedOverlay,
                 onValueChange = preferences.showDynamicSpeedOverlay::set,
-                title = { Text("Dynamic Speed Overlay") },
+                title = { Text(stringResource(R.string.pref_player_dynamic_speed_overlay)) },
                 summary = {
                   Text(
-                    "Show advance overlay for speed control during long press and swipe",
+                    stringResource(R.string.pref_player_dynamic_speed_overlay_summary),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 }
@@ -438,9 +439,9 @@ object PlayerPreferencesScreen : Screen {
                   )
                 },
               )
-              
+
               PreferenceDivider()
-              
+
               val allowGesturesInPanels by preferences.allowGesturesInPanels.collectAsState()
               SwitchPreference(
                 value = allowGesturesInPanels,
@@ -451,18 +452,18 @@ object PlayerPreferencesScreen : Screen {
                   )
                 },
               )
-              
+
               PreferenceDivider()
-              
+
               val swapVolumeAndBrightness by preferences.swapVolumeAndBrightness.collectAsState()
               SwitchPreference(
                 value = swapVolumeAndBrightness,
                 onValueChange = preferences.swapVolumeAndBrightness::set,
                 title = { Text(stringResource(R.string.swap_the_volume_and_brightness_slider)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val showLoadingCircle by preferences.showLoadingCircle.collectAsState()
               SwitchPreference(
                 value = showLoadingCircle,
@@ -475,7 +476,7 @@ object PlayerPreferencesScreen : Screen {
           item {
             PreferenceSectionHeader(title = stringResource(R.string.pref_player_display))
           }
-          
+
           item {
             PreferenceCard {
               val showSystemStatusBar by preferences.showSystemStatusBar.collectAsState()
@@ -491,11 +492,11 @@ object PlayerPreferencesScreen : Screen {
               SwitchPreference(
                 value = showSystemNavigationBar,
                 onValueChange = preferences.showSystemNavigationBar::set,
-                title = { Text("Show navigation bar with controls") },
+                title = { Text(stringResource(R.string.pref_player_display_show_navigation_bar)) },
               )
-              
+
               PreferenceDivider()
-              
+
               val reduceMotion by preferences.reduceMotion.collectAsState()
               SwitchPreference(
                 value = reduceMotion,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1031,8 +1031,21 @@
 
     <string name="no_videos_in_folder">لا توجد فيديوهات في هذا المجلد</string>
     <string name="no_videos_in_folder_desc">الفيديوهات التي تضيفها لهذا المجلد ستظهر هنا</string>
-
     <string name="tree_view">العرض الشجري</string>
+
+    <string name="pref_player_general">عام</string>
+    <string name="pref_player_autoplay_next_video">تشغيل الفيديو التالي تلقائياً</string>
+    <string name="pref_player_autoplay_next_video_summary_on">تشغيل الفيديو التالي تلقائياً عند انتهاء الحالي</string>
+    <string name="pref_player_autoplay_next_video_summary_off">البقاء على الفيديو الحالي عند انتهائه</string>
+    <string name="pref_player_playlist_mode_summary_on">إظهار أزرار التالي/السابق لكل فيديوهات المجلد</string>
+    <string name="pref_player_playlist_mode_summary_off">تشغيل الفيديوهات بشكل منفرد (اختر عدة فيديوهات لقائمة تشغيل)</string>
+    <string name="pref_player_keep_screen_on_when_paused_summary_on">تبقى الشاشة مضاءة أثناء إيقاف الفيديو مؤقتاً</string>
+    <string name="pref_player_keep_screen_on_when_paused_summary_off">يمكن للشاشة أن تُطفأ أثناء إيقاف الفيديو مؤقتاً</string>
+    <string name="pref_player_auto_pip">صورة داخل صورة تلقائية</string>
+    <string name="pref_player_auto_pip_summary">الدخول تلقائياً لوضع الصورة داخل الصورة عند الضغط على الرئيسية أو الرجوع</string>
+    <string name="pref_player_dynamic_speed_overlay">عرض السرعة الديناميكي</string>
+    <string name="pref_player_dynamic_speed_overlay_summary">إظهار قيمة السرعة متغيرة أثناء الضغط المطوّل والسحب</string>
+    <string name="pref_player_display_show_navigation_bar">إظهار شريط التنقل مع عناصر التحكم</string>
 
     <plurals name="item_type_video_plural">
         <item quantity="zero">فيديو</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1023,4 +1023,11 @@
     <string name="pref_enable_glass_shorts_controls_summary">تطبيق نمط الزجاج Glass-morphism على أزرار التحكم في المقاطع القصيرة</string>
     <string name="pref_show_shorts_back_button">إظهار زر الرجوع</string>
     <string name="pref_show_shorts_back_button_summary">إظهار زر الرجوع في لوحة التحكم الجانبية للمقاطع القصيرة</string>
+
+    <string name="item_type_video">فيديو</string>
+    <string name="item_type_folder">مجلد</string>
+    <string name="item_type_file">ملف</string>
+    <string name="item_type_playlist">قائمة تشغيل</string>
+    <string name="item_type_item">عنصر</string>
+    
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1029,5 +1029,47 @@
     <string name="item_type_file">ملف</string>
     <string name="item_type_playlist">قائمة تشغيل</string>
     <string name="item_type_item">عنصر</string>
+
+    <plurals name="item_type_video_plural">
+        <item quantity="zero">فيديو</item>
+        <item quantity="one">فيديو</item>
+        <item quantity="two">فيديوهين</item>
+        <item quantity="few">فيديوهات</item>
+        <item quantity="many">فيديو</item>
+        <item quantity="other">فيديو</item>
+    </plurals>
+    <plurals name="item_type_folder_plural">
+        <item quantity="zero">مجلد</item>
+        <item quantity="one">مجلد</item>
+        <item quantity="two">مجلدين</item>
+        <item quantity="few">مجلدات</item>
+        <item quantity="many">مجلد</item>
+        <item quantity="other">مجلد</item>
+    </plurals>
+    <plurals name="item_type_file_plural">
+        <item quantity="zero">ملف</item>
+        <item quantity="one">ملف</item>
+        <item quantity="two">ملفين</item>
+        <item quantity="few">ملفات</item>
+        <item quantity="many">ملف</item>
+        <item quantity="other">ملف</item>
+    </plurals>
+    <plurals name="item_type_playlist_plural">
+        <item quantity="zero">قائمة تشغيل</item>
+        <item quantity="one">قائمة تشغيل</item>
+        <item quantity="two">قائمتي تشغيل</item>
+        <item quantity="few">قوائم تشغيل</item>
+        <item quantity="many">قائمة تشغيل</item>
+        <item quantity="other">قائمة تشغيل</item>
+    </plurals>
+    <plurals name="item_type_item_plural">
+        <item quantity="zero">عنصر</item>
+        <item quantity="one">عنصر</item>
+        <item quantity="two">عنصرين</item>
+        <item quantity="few">عناصر</item>
+        <item quantity="many">عنصر</item>
+        <item quantity="other">عنصر</item>
+    </plurals>
+    <string name="rename_failed">فشلت إعادة التسمية</string>
     
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1032,6 +1032,8 @@
     <string name="no_videos_in_folder">لا توجد فيديوهات في هذا المجلد</string>
     <string name="no_videos_in_folder_desc">الفيديوهات التي تضيفها لهذا المجلد ستظهر هنا</string>
 
+    <string name="tree_view">العرض الشجري</string>
+
     <plurals name="item_type_video_plural">
         <item quantity="zero">فيديو</item>
         <item quantity="one">فيديو</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1029,6 +1029,9 @@
     <string name="item_type_playlist">قائمة تشغيل</string>
     <string name="item_type_item">عنصر</string>
 
+    <string name="no_videos_in_folder">لا توجد فيديوهات في هذا المجلد</string>
+    <string name="no_videos_in_folder_desc">الفيديوهات التي تضيفها لهذا المجلد ستظهر هنا</string>
+
     <plurals name="item_type_video_plural">
         <item quantity="zero">فيديو</item>
         <item quantity="one">فيديو</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -765,7 +765,6 @@
     <string name="file_bytes_progress">%1$s من %2$s</string>
     <string name="files_processed">الملفات المعالَجة</string>
     <string name="total_size">الحجم الإجمالي</string>
-    <string name="delete_items_warning">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العنصر (أو العناصر) المحددة نهائياً.%1$s.</string>
     <string name="select_storage_location">اختر موقع التخزين</string>
     <string name="go_to_internal_storage">الانتقال إلى التخزين الداخلي</string>
     <string name="create_folder">إنشاء مجلد</string>
@@ -1071,5 +1070,14 @@
         <item quantity="other">عنصر</item>
     </plurals>
     <string name="rename_failed">فشلت إعادة التسمية</string>
+
+    <plurals name="delete_items_warning">
+        <item quantity="zero">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العناصر المحددة نهائياً.</item>
+        <item quantity="one">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العنصر المحدد نهائياً.</item>
+        <item quantity="two">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العنصرين المحددين نهائياً.</item>
+        <item quantity="few">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العناصر المحددة نهائياً.</item>
+        <item quantity="many">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العناصر المحددة نهائياً.</item>
+        <item quantity="other">لا يمكن التراجع عن هذا الإجراء. سيتم حذف العناصر المحددة نهائياً.</item>
+    </plurals>
     
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1099,4 +1099,26 @@
     <string name="item_type_playlist">playlist</string>
     <string name="item_type_item">item</string>
 
+    <plurals name="item_type_video_plural">
+        <item quantity="one">video</item>
+        <item quantity="other">videos</item>
+    </plurals>
+    <plurals name="item_type_folder_plural">
+        <item quantity="one">folder</item>
+        <item quantity="other">folders</item>
+    </plurals>
+    <plurals name="item_type_file_plural">
+        <item quantity="one">file</item>
+        <item quantity="other">files</item>
+    </plurals>
+    <plurals name="item_type_playlist_plural">
+        <item quantity="one">playlist</item>
+        <item quantity="other">playlists</item>
+    </plurals>
+    <plurals name="item_type_item_plural">
+        <item quantity="one">item</item>
+        <item quantity="other">items</item>
+    </plurals>
+    <string name="rename_failed">Rename failed</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1093,4 +1093,10 @@
     <string name="pref_gesture_double_tap_seek_area_width_title">Double Tap Seek Area Width</string>
     <string name="pref_gesture_custom_seek_dialog_hint">Enter custom seek duration in seconds (1-120)</string>
 
+    <string name="item_type_video">video</string>
+    <string name="item_type_folder">folder</string>
+    <string name="item_type_file">file</string>
+    <string name="item_type_playlist">playlist</string>
+    <string name="item_type_item">item</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1101,6 +1101,8 @@
     <string name="no_videos_in_folder">No videos in this folder</string>
     <string name="no_videos_in_folder_desc">Videos you add to this folder will appear here</string>
 
+    <string name="tree_view">Tree View</string>
+
     <plurals name="item_type_video_plural">
         <item quantity="one">video</item>
         <item quantity="other">videos</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1100,8 +1100,21 @@
 
     <string name="no_videos_in_folder">No videos in this folder</string>
     <string name="no_videos_in_folder_desc">Videos you add to this folder will appear here</string>
-
     <string name="tree_view">Tree View</string>
+
+    <string name="pref_player_general">General</string>
+    <string name="pref_player_autoplay_next_video">Autoplay next video</string>
+    <string name="pref_player_autoplay_next_video_summary_on">Automatically play next video when current ends</string>
+    <string name="pref_player_autoplay_next_video_summary_off">Stay on current video when it ends</string>
+    <string name="pref_player_playlist_mode_summary_on">Show next/previous buttons for all videos in folder</string>
+    <string name="pref_player_playlist_mode_summary_off">Play videos individually (select multiple for playlist)</string>
+    <string name="pref_player_keep_screen_on_when_paused_summary_on">Screen stays awake while video is paused</string>
+    <string name="pref_player_keep_screen_on_when_paused_summary_off">Screen can turn off while video is paused</string>
+    <string name="pref_player_auto_pip">Auto Picture-in-Picture</string>
+    <string name="pref_player_auto_pip_summary">Automatically enter PIP mode when pressing home or back</string>
+    <string name="pref_player_dynamic_speed_overlay">Dynamic Speed Overlay</string>
+    <string name="pref_player_dynamic_speed_overlay_summary">Show advance overlay for speed control during long press and swipe</string>
+    <string name="pref_player_display_show_navigation_bar">Show navigation bar with controls</string>
 
     <plurals name="item_type_video_plural">
         <item quantity="one">video</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -838,7 +838,6 @@
     <string name="file_bytes_progress">%1$s of %2$s</string>
     <string name="files_processed">Files processed</string>
     <string name="total_size">Total size</string>
-    <string name="delete_items_warning">This action cannot be undone. The selected item%1$s will be permanently deleted.</string>
 
     <!-- File Picker Dialog Strings -->
     <string name="select_storage_location">Select a storage location</string>
@@ -1120,5 +1119,10 @@
         <item quantity="other">items</item>
     </plurals>
     <string name="rename_failed">Rename failed</string>
+
+    <plurals name="delete_items_warning">
+        <item quantity="one">This action cannot be undone. The selected item will be permanently deleted.</item>
+        <item quantity="other">This action cannot be undone. The selected items will be permanently deleted.</item>
+    </plurals>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1098,6 +1098,9 @@
     <string name="item_type_playlist">playlist</string>
     <string name="item_type_item">item</string>
 
+    <string name="no_videos_in_folder">No videos in this folder</string>
+    <string name="no_videos_in_folder_desc">Videos you add to this folder will appear here</string>
+
     <plurals name="item_type_video_plural">
         <item quantity="one">video</item>
         <item quantity="other">videos</item>


### PR DESCRIPTION
## Problem
Several dialogs and screens injected raw English strings (`"video"`, `"folder"`, `"file"`, `"playlist"`, `"item"`, `"Open File"`, `"Recently Played"`, `"Open Link"`, `"Rename failed"`, `"Tree View"`) directly into Composables or as arguments to already-localized `stringResource()` calls. This bypassed localization entirely — non-English locales would see English words injected mid-sentence (e.g. "Delete video 1?" instead of a fully translated string), regardless of language.

Pluralization was also hardcoded to English rules (`"${itemType}s"`), which breaks for every locale with different plural rules (Arabic has 6 forms, not 2).

## Fix
- Replaced `itemType: String` params with `@StringRes`/`@PluralsRes` Int references in `RenameDialog` and `DeleteConfirmationDialog`
- Added proper Android `<plurals>` resources so each locale can supply grammatically correct plural forms
- Replaced all hardcoded UI strings with `stringResource()` calls
- Added missing string/plural resources in `values/strings.xml` and `values-ar/strings.xml` (English + Arabic provided; other locales can now translate via the existing localization workflow)
- Extracted remaining hardcoded strings in `PlayerPreferencesScreen.kt`