### PR TITLE
Fix Arabic/Spanish plural handling for horizontal video duration string

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/ShortsPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/ShortsPreferencesScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import xyz.mpv.rex.R
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -208,7 +209,7 @@ object ShortsPreferencesScreen : Screen {
                                 title = { Text(stringResource(R.string.pref_max_horizontal_video_duration)) },
                                 summary = { 
                                     Text(
-                                        text = stringResource(R.string.pref_max_horizontal_video_duration_desc, maxDuration, if (maxDuration > 1) "s" else ""),
+                                        text = pluralStringResource(R.plurals.pref_max_horizontal_video_duration_desc, maxDuration, maxDuration),
                                         color = MaterialTheme.colorScheme.outline
                                     ) 
                                 },

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -825,7 +825,14 @@
     <string name="pref_include_short_horizontal_videos">تضمين الفيديوهات القصيرة العادية</string>
     <string name="pref_include_short_horizontal_videos_summary">إظهار الفيديوهات الأفقية في التغذية إذا كانت قصيرة</string>
     <string name="pref_max_horizontal_video_duration">الحد الأقصى لمدة الفيديوهات الأفقية</string>
-    <string name="pref_max_horizontal_video_duration_desc">تقييد الفيديوهات الأفقية إلى%1$d دقيقة%2$s</string>
+    <plurals name="pref_max_horizontal_video_duration_desc">
+        <item quantity="zero">تقييد الفيديوهات الأفقية إلى %d دقيقة</item>
+        <item quantity="one">تقييد الفيديوهات الأفقية إلى دقيقة واحدة</item>
+        <item quantity="two">تقييد الفيديوهات الأفقية إلى دقيقتين</item>
+        <item quantity="few">تقييد الفيديوهات الأفقية إلى %d دقائق</item>
+        <item quantity="many">تقييد الفيديوهات الأفقية إلى %d دقيقة</item>
+        <item quantity="other">تقييد الفيديوهات الأفقية إلى %d دقيقة</item>
+    </plurals>
     <string name="pref_sourced_folders">المجلدات المصدرية</string>
     <string name="pref_sourced_folders_all">مصدرها جميع المجلدات المفحوصة</string>
     <string name="pref_sourced_folders_count">مصدرها %1$d مجلد(مجلدات)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -854,7 +854,10 @@ Next: NEXT</string>
     <string name="pref_include_short_horizontal_videos">Incluir videos normales en Shorts</string>
     <string name="pref_include_short_horizontal_videos_summary">Mostrar vídeos horizontales en el feed si son shorts</string>
     <string name="pref_max_horizontal_video_duration">Duración horizontal máxima</string>
-    <string name="pref_max_horizontal_video_duration_desc">Limitar vídeos horizontales a %1$d minutos%2$s</string>
+    <plurals name="pref_max_horizontal_video_duration_desc">
+        <item quantity="one">Limitar vídeos horizontales a %d minuto</item>
+        <item quantity="other">Limitar vídeos horizontales a %d minutos</item>
+    </plurals>
     <string name="pref_sourced_folders">Carpetas de origen</string>
     <string name="playlist_now_playing">Reproduciendo ahora</string>
     <string name="playlist_playing">Reproduciendo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -924,7 +924,10 @@
     <string name="pref_include_short_horizontal_videos">Include Short Normal Videos</string>
     <string name="pref_include_short_horizontal_videos_summary">Show horizontal videos in the feed if they are short</string>
     <string name="pref_max_horizontal_video_duration">Max Horizontal Duration</string>
-    <string name="pref_max_horizontal_video_duration_desc">Limit horizontal videos to %1$d minute%2$s</string>
+    <plurals name="pref_max_horizontal_video_duration_desc">
+        <item quantity="one">Limit horizontal videos to %d minute</item>
+        <item quantity="other">Limit horizontal videos to %d minutes</item>
+    </plurals>
     <string name="pref_sourced_folders">Sourced Folders</string>
     <string name="pref_sourced_folders_all">Sourced from all scanned directories</string>
     <string name="pref_sourced_folders_count">Sourced from %1$d folder(s)</string>


### PR DESCRIPTION
Found this bug while extracting hardcoded strings for i18n — the duration text was showing stuff like "8 دقيقةs" in Arabic (English "s" literally stuck onto Arabic text).

Turns out `pref_max_horizontal_video_duration_desc` was using a manual English pluralization trick (`%1$d minute%2$s` + `if (count > 1) "s" else ""` in the Kotlin code) instead of real Android `<plurals>`. That works fine for English (one/other), but Arabic has 6 plural forms, so it just broke.

Converted the string to `<plurals>` in `values`, `values-ar`, and `values-es` (Spanish had the same string, same issue, just less obvious with only one/other forms — figured I'd fix it too since it's the exact same problem). `bn-rBD` and `zh-rTW` don't have this key so they just fall back to English, no changes needed there.

Also updated `ShortsPreferencesScreen.kt` to use `pluralStringResource` instead of `stringResource` and dropped the manual "s" hack.