### PR TITLE
fix(i18n): extract hardcoded strings in player (ambient mode, zoom sheet)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.animateFloatingActionButton
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import xyz.mpv.rex.R
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -294,7 +295,7 @@ object RecentlyPlayedScreen : Screen {
       if (deleteDialogOpen.value && selectionManager.isInSelectionMode) {
         // Remove selected items from history
         val itemCount = selectionManager.selectedCount
-        val itemText = if (itemCount == 1) "item" else "items"
+        val itemText = pluralStringResource(R.plurals.item_type_item_plural, itemCount)
         val deleteFiles = deleteFilesCheckbox.value
 
         val title = if (deleteFiles) {

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/AmbientModeManager.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/AmbientModeManager.kt
@@ -20,7 +20,7 @@ class AmbientModeManager(
   private val playerPreferences: PlayerPreferences,
   private val cacheDir: File,
   private val scope: CoroutineScope,
-  private val onShowText: (String) -> Unit
+  private val onShowText: (Boolean) -> Unit
 ) {
   companion object {
     private const val TAG = "AmbientModeManager"
@@ -50,10 +50,10 @@ class AmbientModeManager(
     if (_isAmbientEnabled.value) {
       lastAmbientScaleX = -1.0 // Force rewrite
       updateAmbientStretch()
-      onShowText("Ambience Mode: ON")
+      onShowText(true)
     } else {
       disableAmbientShader()
-      onShowText("Ambience Mode: OFF")
+      onShowText(false)
     }
   }
 

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -327,7 +327,12 @@ class PlayerViewModel(
     playerPreferences = playerPreferences,
     cacheDir = host.context.cacheDir,
     scope = viewModelScope,
-    onShowText = { text -> playerUpdate.value = PlayerUpdates.ShowText(text) }
+    onShowText = { isOn ->
+      val text = host.context.getString(
+        if (isOn) R.string.ambient_mode_on else R.string.ambient_mode_off
+      )
+      playerUpdate.value = PlayerUpdates.ShowText(text)
+    }
   )
 
   // Expose ambient mode state through the manager

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/VideoZoomSheet.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/sheets/VideoZoomSheet.kt
@@ -134,7 +134,7 @@ private fun ZoomVideoSheet(
         },
         modifier = Modifier.size(36.dp),
       ) {
-        Icon(Icons.Default.Remove, contentDescription = "Decrease zoom", modifier = Modifier.size(18.dp))
+        Icon(Icons.Default.Remove, contentDescription = stringResource(R.string.player_sheets_zoom_decrease), modifier = Modifier.size(18.dp))
       }
 
       SliderItem(
@@ -154,7 +154,7 @@ private fun ZoomVideoSheet(
         },
         modifier = Modifier.size(36.dp),
       ) {
-        Icon(Icons.Default.Add, contentDescription = "Increase zoom", modifier = Modifier.size(18.dp))
+        Icon(Icons.Default.Add, contentDescription = stringResource(R.string.player_sheets_zoom_increase), modifier = Modifier.size(18.dp))
       }
     }
 
@@ -205,7 +205,7 @@ private fun ZoomVideoSheet(
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-          text = "Pan & Zoom",
+          text = stringResource(R.string.pref_player_gestures_pan_and_zoom),
           style = MaterialTheme.typography.bodyMedium,
           color = if (panAndZoomEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -710,8 +710,8 @@
     <string name="remove_from_history_title">إزالة %1$d %2$s من السجل ؟</string>
     <string name="remove_from_history_msg">سيؤدي هذا إلى إزالة %1$s المحدد من قائمة المُشغَّل مؤخراً. لن يتم حذف ملفات الفيديو الأصلية.</string>
     <string name="delete_files_title">حذف %1$d %2$s ؟</string>
-    <string name="delete_files_msg">سيؤدي هذا إلى حذف ملف(ملفات) الفيديو الأصلية نهائياً من تخزين جهازك.\n\nلا يمكن التراجع عن هذا الإجراء.</string>
-    <string name="also_delete_files">حذف الملف(الملفات) الأصلية أيضاً</string>
+    <string name="delete_files_msg">سيؤدي هذا إلى الحذف نهائيا من جهازك.\n\nلا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="also_delete_files">حذف الملف الأصلي أيضا</string>
     <string name="no_video_folders_found">لم يتم العثور على أي مجلد فيديو</string>
     <string name="no_video_folders_found_desc">أضف فيديوهات إلى جهازك لتظهر المجلدات هنا</string>
     <string name="search_in_all_storage_volumes">البحث في جميع وحدات التخزين...</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1191,5 +1191,8 @@
         <!-- Shorts Video Info Dialog -->
     <string name="shorts_video_info_title">معلومات الفيديو</string>
     <string name="shorts_video_info_resolution">الدقة: %1$dx%2$d</string>
+
+    <string name="player_sheets_zoom_decrease">تقليل التكبير</string>
+    <string name="player_sheets_zoom_increase">زيادة التكبير</string>
     
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -931,8 +931,10 @@
     <string name="ab_loop_short">AB</string>
     <string name="loop">تكرار</string>
     <string name="background_playback">التشغيل في الخلفية</string>
-    <string name="ambient">الوضع المحيطي</string>
-    <string name="ambience_mode">وضع الإضاءة المحيطية</string>
+    <string name="ambient">الوضع السينيمـائي</string>
+    <string name="ambience_mode">الوضع السـينيمائي</string>
+    <string name="ambient_mode_on">الوضع السينيمائي: مفعّل</string>
+    <string name="ambient_mode_off">الوضع السينيمائي: معطّل</string>
     <string name="sleep_timer">مؤقت النوم</string>
 
     

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1048,6 +1048,8 @@
     <string name="background_playback">Background</string>
     <string name="ambient">Ambient</string>
     <string name="ambience_mode">Ambience Mode</string>
+    <string name="ambient_mode_on">Ambience Mode: ON</string>
+    <string name="ambient_mode_off">Ambience Mode: OFF</string>
     <string name="sleep_timer">Sleep Timer</string>
 
     <!-- Preference section headers -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1222,4 +1222,7 @@
     <string name="shorts_video_info_title">Video Info</string>
     <string name="shorts_video_info_resolution">Resolution: %1$dx%2$d</string>
 
+    <string name="player_sheets_zoom_decrease">Decrease zoom</string>
+    <string name="player_sheets_zoom_increase">Increase zoom</string>
+
 </resources>


### PR DESCRIPTION
Three hardcoded string issues, all missing translations:

1. Ambient mode ON/OFF toast was hardcoded in English inside
   AmbientModeManager.kt, which has no Context access to use
   stringResource(). Changed onShowText callback to pass a Boolean state
   instead of a ready-made string, and built the translated text in
   PlayerViewModel.kt at the call site using the existing
   host.context.getString() pattern already used elsewhere in that file.

2. VideoZoomSheet.kt had hardcoded "Pan & Zoom" text and hardcoded
   contentDescription strings on the zoom +/- buttons (accessibility
   labels, not visible on screen but read by TalkBack). "Pan & Zoom"
   now reuses the existing pref_player_gestures_pan_and_zoom key since
   it's literally the same toggle duplicated in the player for quick
   access. The zoom button descriptions got two new keys since they're
   a distinct control from the aspect-ratio zoom buttons.

3. RecentlyPlayedScreen.kt was building the "item"/"items" word manually
   in English (if itemCount == 1) instead of using the existing
   item_type_item_plural resource, so it leaked into the middle of an
   otherwise correctly translated Arabic sentence (e.g. "Remove items 3
   from history?"). Swapped it for pluralStringResource(), no new keys
   needed since the plural resource already existed.

Added to both strings.xml and strings-ar.xml (items 1 and 2 only —
item 3 reused existing resources).