### PR TITLE
i18n: extract hardcoded strings in CustomButtonScreen

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/CustomButtonScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/CustomButtonScreen.kt
@@ -81,6 +81,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
+import xyz.mpv.rex.R
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import android.content.Intent
@@ -155,9 +158,9 @@ object CustomButtonScreen : Screen {
                     context.contentResolver.openOutputStream(it)?.use { output ->
                         output.write(xmlContent.toByteArray())
                     }
-                    Toast.makeText(context, "Buttons exported successfully", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, context.getString(R.string.custom_buttons_export_success), Toast.LENGTH_SHORT).show()
                 }.onFailure { e ->
-                    Toast.makeText(context, "Export failed: ${e.message}", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, context.getString(R.string.export_failed, e.message), Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -180,7 +183,7 @@ object CustomButtonScreen : Screen {
                     
                     showImportDialog = true
                 }.onFailure { e ->
-                    Toast.makeText(context, "Failed to read file: ${e.message}", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, context.getString(R.string.custom_button_read_failed, e.message), Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -228,13 +231,13 @@ object CustomButtonScreen : Screen {
                     title = {
                         Column {
                             Text(
-                                text = "Custom Buttons",
+                                text = stringResource(id = R.string.custom_buttons_title),
                                 style = MaterialTheme.typography.headlineSmall,
                                 fontWeight = FontWeight.ExtraBold,
                                 color = MaterialTheme.colorScheme.primary,
                             )
                             Text(
-                                text = "Drag to reorder • Tap any slot to expand & edit",
+                                text = stringResource(id = R.string.custom_buttons_subtitle),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -244,7 +247,7 @@ object CustomButtonScreen : Screen {
                         IconButton(onClick = backstack::removeLastOrNull) {
                             Icon(
                                 Icons.AutoMirrored.Outlined.ArrowBack,
-                                contentDescription = "Back",
+                                contentDescription = stringResource(id = R.string.back),
                                 tint = MaterialTheme.colorScheme.secondary,
                             )
                         }
@@ -288,7 +291,7 @@ object CustomButtonScreen : Screen {
                             dragHandle = { interceptModifier ->
                                 Icon(
                                     Icons.Default.DragHandle,
-                                    contentDescription = "Drag to reorder",
+                                    contentDescription = stringResource(id = R.string.drag_to_reorder),
                                     modifier = interceptModifier
                                         .draggableHandle()
                                         .padding(horizontal = 8.dp, vertical = 12.dp),
@@ -325,14 +328,14 @@ object CustomButtonScreen : Screen {
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Text(
-                                text = "Import / Export",
+                                text = stringResource(id = R.string.custom_buttons_import_export_title),
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onSurface,
                             )
                             
                             Text(
-                                text = "Backup or share all your custom buttons with their Lua code as an XML file",
+                                text = stringResource(id = R.string.custom_buttons_import_export_desc),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -352,7 +355,7 @@ object CustomButtonScreen : Screen {
                                         modifier = Modifier.size(18.dp)
                                     )
                                     Spacer(Modifier.width(8.dp))
-                                    Text("Import")
+                                    Text(stringResource(id = R.string.generic_import))
                                 }
                                 
                                 Button(
@@ -366,7 +369,7 @@ object CustomButtonScreen : Screen {
                                         modifier = Modifier.size(18.dp)
                                     )
                                     Spacer(Modifier.width(8.dp))
-                                    Text("Export")
+                                    Text(stringResource(id = R.string.generic_export))
                                 }
                             }
                         }
@@ -396,7 +399,12 @@ object CustomButtonScreen : Screen {
                             buttonSlots[slotIndex] = importedSlots[slotIndex]
                         }
                     }
-                    Toast.makeText(context, "Imported ${selectedImportSlots.size} button(s)", Toast.LENGTH_SHORT).show()
+                    val importedCountText = context.resources.getQuantityString(
+                        R.plurals.custom_buttons_imported_count,
+                        selectedImportSlots.size,
+                        selectedImportSlots.size
+                    )
+                    Toast.makeText(context, importedCountText, Toast.LENGTH_SHORT).show()
                     showImportDialog = false
                     selectedImportSlots = emptySet()
                 },
@@ -488,7 +496,7 @@ fun ButtonSlotCard(
                 Column(Modifier.weight(1f)) {
                     val titleAlpha = if (isPopulated && !draftEnabled) 0.4f else 1f
                     Text(
-                        text = draftTitle.ifBlank { if (isPopulated) button!!.title else "Empty slot" },
+                        text = draftTitle.ifBlank { if (isPopulated) button!!.title else stringResource(id = R.string.custom_button_empty_slot) },
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = if (isPopulated) FontWeight.SemiBold else FontWeight.Normal,
                         color = if (isPopulated)
@@ -520,7 +528,7 @@ fun ButtonSlotCard(
                             contentColor   = MaterialTheme.colorScheme.onErrorContainer,
                         ),
                     ) {
-                        Icon(Icons.Default.Delete, contentDescription = "Delete", modifier = Modifier.size(18.dp))
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(id = R.string.delete), modifier = Modifier.size(18.dp))
                     }
                     Spacer(Modifier.width(4.dp))
                 }
@@ -541,7 +549,7 @@ fun ButtonSlotCard(
                     // Disabled drag handle for empty slots
                     Icon(
                         Icons.Default.DragHandle,
-                        contentDescription = "Drag disabled",
+                        contentDescription = stringResource(id = R.string.custom_button_drag_disabled),
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f),
                     )
@@ -589,9 +597,9 @@ fun ButtonSlotCard(
     if (activeLuaField != null) {
         val fieldKey = activeLuaField!!
         val fieldLabel = when (fieldKey) {
-            "content"   -> "Tap action  ·  $slotLabel"
-            "longPress" -> "Long press  ·  $slotLabel"
-            "startup"   -> "On startup  ·  $slotLabel"
+            "content"   -> stringResource(id = R.string.custom_button_field_label_with_slot, stringResource(id = R.string.custom_button_tap_action), slotLabel)
+            "longPress" -> stringResource(id = R.string.custom_button_field_label_with_slot, stringResource(id = R.string.custom_button_long_press_action), slotLabel)
+            "startup"   -> stringResource(id = R.string.custom_button_field_label_with_slot, stringResource(id = R.string.custom_button_on_startup), slotLabel)
             else        -> fieldKey
         }
         val fieldValue = when (fieldKey) {
@@ -640,14 +648,14 @@ fun ButtonSlotCard(
                         },
                         navigationIcon = {
                             IconButton(onClick = { dismissAndSave() }) {
-                                Icon(Icons.AutoMirrored.Outlined.ArrowBack, "Back")
+                                Icon(Icons.AutoMirrored.Outlined.ArrowBack, stringResource(id = R.string.back))
                             }
                         },
                         actions = {
                             IconButton(onClick = { dismissAndSave() }) {
                                 Icon(
                                     Icons.Default.Check,
-                                    contentDescription = "Done",
+                                    contentDescription = stringResource(id = R.string.done),
                                     tint = MaterialTheme.colorScheme.primary,
                                 )
                             }
@@ -715,23 +723,23 @@ fun ButtonExpandedContent(
             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        HorizontalDividerWithLabel("Button")
+        HorizontalDividerWithLabel(stringResource(id = R.string.custom_button_field_label))
 
         // Title
         OutlinedTextField(
             value         = draftTitle,
             onValueChange = onTitleChange,
-            label         = { Text("Button title *") },
+            label         = { Text(stringResource(id = R.string.custom_button_title_field)) },
             modifier      = Modifier.fillMaxWidth(),
             singleLine    = true,
             shape         = RoundedCornerShape(12.dp),
         )
 
-        HorizontalDividerWithLabel("Lua scripts")
+        HorizontalDividerWithLabel(stringResource(id = R.string.custom_button_lua_scripts_label))
 
         // Tap action — required
         LuaEditorEntryCard(
-            label      = "Tap action *",
+            label      = stringResource(id = R.string.custom_button_tap_action_required),
             code       = draftContent,
             isRequired = true,
             onClick    = { onOpenLuaEditor("content") },
@@ -739,19 +747,19 @@ fun ButtonExpandedContent(
 
         // Long press
         LuaEditorEntryCard(
-            label   = "Long press action",
+            label   = stringResource(id = R.string.custom_button_long_press_action),
             code    = draftLongPress,
             onClick = { onOpenLuaEditor("longPress") },
         )
 
         // On startup
         LuaEditorEntryCard(
-            label   = "On startup",
+            label   = stringResource(id = R.string.custom_button_on_startup),
             code    = draftStartup,
             onClick = { onOpenLuaEditor("startup") },
         )
 
-        HorizontalDividerWithLabel("Settings")
+        HorizontalDividerWithLabel(stringResource(id = R.string.custom_button_settings_label))
 
         // Enable / Disable row
         Row(
@@ -761,13 +769,13 @@ fun ButtonExpandedContent(
         ) {
             Column(Modifier.weight(1f)) {
                 Text(
-                    text  = "Button enabled",
+                    text  = stringResource(id = R.string.custom_button_enabled_label),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    text  = if (draftEnabled) "Button is active in the player" else "Button is saved but hidden",
+                    text  = stringResource(id = if (draftEnabled) R.string.custom_button_enabled_desc else R.string.custom_button_disabled_desc),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -783,13 +791,13 @@ fun ButtonExpandedContent(
             horizontalArrangement = Arrangement.End,
             modifier              = Modifier.fillMaxWidth(),
         ) {
-            TextButton(onClick = onCollapse) { Text("Cancel") }
+            TextButton(onClick = onCollapse) { Text(stringResource(id = R.string.generic_cancel)) }
             Spacer(Modifier.width(8.dp))
             TextButton(
                 onClick = onSave,
                 enabled = draftTitle.isNotBlank(),
             ) {
-                Text(if (isPopulated) "Save" else "Add button")
+                Text(stringResource(id = if (isPopulated) R.string.save else R.string.custom_button_add))
             }
         }
     }
@@ -893,7 +901,7 @@ fun LuaEditorEntryCard(
                     )
                 } else {
                     Text(
-                        text = "Tap to write Lua code…",
+                        text = stringResource(id = R.string.custom_button_lua_editor_hint),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                     )
@@ -931,13 +939,13 @@ fun ImportSelectionScreen(
                 title = {
                     Column {
                         Text(
-                            text = "Select Buttons to Import",
+                            text = stringResource(id = R.string.custom_button_select_import_title),
                             style = MaterialTheme.typography.titleLarge,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.primary,
                         )
                         Text(
-                            text = "Choose which buttons to import",
+                            text = stringResource(id = R.string.custom_button_select_import_subtitle),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -947,7 +955,7 @@ fun ImportSelectionScreen(
                     IconButton(onClick = onDismiss) {
                         Icon(
                             Icons.AutoMirrored.Outlined.ArrowBack,
-                            contentDescription = "Cancel",
+                            contentDescription = stringResource(id = R.string.generic_cancel),
                             tint = MaterialTheme.colorScheme.secondary,
                         )
                     }
@@ -967,7 +975,7 @@ fun ImportSelectionScreen(
                     ) {
                         Icon(
                             Icons.Default.FileDownload,
-                            contentDescription = "Import",
+                            contentDescription = stringResource(id = R.string.generic_import),
                         )
                     }
                 },
@@ -1078,7 +1086,7 @@ fun ImportSelectionScreen(
                                     )
                                     Spacer(Modifier.width(4.dp))
                                     Text(
-                                        text = "Will overwrite existing button",
+                                        text = stringResource(id = R.string.custom_button_will_overwrite),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.error,
                                     )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1194,5 +1194,42 @@
 
     <string name="player_sheets_zoom_decrease">تقليل التكبير</string>
     <string name="player_sheets_zoom_increase">زيادة التكبير</string>
+
+    <string name="custom_buttons_title">الأزرار المخصصة</string>
+    <string name="custom_buttons_subtitle">اسحب لإعادة الترتيب • اضغط على أي مكان للتوسيع والتعديل</string>
+    <string name="custom_buttons_export_success">تم تصدير الأزرار بنجاح</string>
+    <string name="custom_buttons_import_export_title">استيراد / تصدير</string>
+    <string name="custom_buttons_import_export_desc">احفظ نسخة احتياطية أو شارك جميع أزرارك المخصصة مع أكواد Lua كملف XML</string>
+    <string name="generic_import">استيراد</string>
+    <string name="generic_export">تصدير</string>
+    <string name="custom_button_empty_slot">مكان فارغ</string>
+    <string name="custom_button_drag_disabled">السحب معطل</string>
+    <string name="custom_button_field_label">الزر</string>
+    <string name="custom_button_lua_scripts_label">أكواد Lua</string>
+    <string name="custom_button_title_field">اسم الزر *</string>
+    <string name="custom_button_tap_action">إجراء الضغط</string>
+    <string name="custom_button_tap_action_required">إجراء الضغط *</string>
+    <string name="custom_button_long_press_action">إجراء الضغط المطول</string>
+    <string name="custom_button_on_startup">عند بدء التشغيل</string>
+    <string name="custom_button_settings_label">الإعدادات</string>
+    <string name="custom_button_enabled_label">تفعيل الزر</string>
+    <string name="custom_button_enabled_desc">الزر مفعّل في المشغل</string>
+    <string name="custom_button_disabled_desc">الزر محفوظ لكنه مخفي</string>
+    <string name="custom_button_add">إضافة زر</string>
+    <string name="custom_button_lua_editor_hint">اضغط لكتابة كود Lua…</string>
+    <string name="custom_button_select_import_title">اختر الأزرار للاستيراد</string>
+    <string name="custom_button_select_import_subtitle">اختر الأزرار التي تريد استيرادها</string>
+    <string name="custom_button_will_overwrite">سيتم استبدال الزر الموجود</string>
+    <string name="custom_button_read_failed">فشل في قراءة الملف: %1$s</string>
+    <string name="custom_button_field_label_with_slot">%1$s  ·  %2$s</string>
+
+    <plurals name="custom_buttons_imported_count">
+        <item quantity="zero">لم يتم استيراد أي زر</item>
+        <item quantity="one">تم استيراد زر واحد</item>
+        <item quantity="two">تم استيراد زرين</item>
+        <item quantity="few">تم استيراد %1$d أزرار</item>
+        <item quantity="many">تم استيراد %1$d زرًا</item>
+        <item quantity="other">تم استيراد %1$d زر</item>
+    </plurals>
     
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1225,4 +1225,37 @@
     <string name="player_sheets_zoom_decrease">Decrease zoom</string>
     <string name="player_sheets_zoom_increase">Increase zoom</string>
 
+    <string name="custom_buttons_title">Custom Buttons</string>
+    <string name="custom_buttons_subtitle">Drag to reorder • Tap any slot to expand &amp; edit</string>
+    <string name="custom_buttons_export_success">Buttons exported successfully</string>
+    <string name="custom_buttons_import_export_title">Import / Export</string>
+    <string name="custom_buttons_import_export_desc">Backup or share all your custom buttons with their Lua code as an XML file</string>
+    <string name="generic_import">Import</string>
+    <string name="generic_export">Export</string>
+    <string name="custom_button_empty_slot">Empty slot</string>
+    <string name="custom_button_drag_disabled">Drag disabled</string>
+    <string name="custom_button_field_label">Button</string>
+    <string name="custom_button_lua_scripts_label">Lua scripts</string>
+    <string name="custom_button_title_field">Button title *</string>
+    <string name="custom_button_tap_action">Tap action</string>
+    <string name="custom_button_tap_action_required">Tap action *</string>
+    <string name="custom_button_long_press_action">Long press action</string>
+    <string name="custom_button_on_startup">On startup</string>
+    <string name="custom_button_settings_label">Settings</string>
+    <string name="custom_button_enabled_label">Button enabled</string>
+    <string name="custom_button_enabled_desc">Button is active in the player</string>
+    <string name="custom_button_disabled_desc">Button is saved but hidden</string>
+    <string name="custom_button_add">Add button</string>
+    <string name="custom_button_lua_editor_hint">Tap to write Lua code…</string>
+    <string name="custom_button_select_import_title">Select Buttons to Import</string>
+    <string name="custom_button_select_import_subtitle">Choose which buttons to import</string>
+    <string name="custom_button_will_overwrite">Will overwrite existing button</string>
+    <string name="custom_button_read_failed">Failed to read file: %1$s</string>
+    <string name="custom_button_field_label_with_slot">%1$s  ·  %2$s</string>
+
+    <plurals name="custom_buttons_imported_count">
+        <item quantity="one">Imported %1$d button</item>
+        <item quantity="other">Imported %1$d buttons</item>
+    </plurals>
+
 </resources>


### PR DESCRIPTION
Extracts the remaining hardcoded UI strings in `CustomButtonScreen.kt` into `strings.xml`, with Arabic translations included.

- Added 25 new strings + 1 plural (for the "Imported N button(s)" toast, since Arabic pluralization needs separate forms)
- Reused 8 existing strings instead of duplicating (`back`, `delete`, `done`, `settings`, `save`, `generic_cancel`, `drag_to_reorder`, `export_failed`)
- Left internal Compose keys/slot labels (`slot_$index`, `L1`/`R2`, `import_button_$index`) untouched — not user-facing text