### PR TITLE
fix(i18n): move FilterPreset display text to string resources

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerEnums.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerEnums.kt
@@ -166,8 +166,8 @@ sealed class PlayerUpdates {
  * Sharpness uses MPV's 'sharpen' property which ranges from -5 (blur) to 5 (sharp).
  */
 enum class FilterPreset(
-  val displayName: String,
-  val description: String,
+  @StringRes val displayNameRes: Int,
+  @StringRes val descriptionRes: Int,
   val brightness: Int,
   val saturation: Int,
   val contrast: Int,
@@ -176,8 +176,8 @@ enum class FilterPreset(
   val sharpness: Int,
 ) {
   NONE(
-    displayName = "None",
-    description = "Default settings with no adjustments",
+    displayNameRes = R.string.filter_preset_none,
+    descriptionRes = R.string.filter_preset_none_desc,
     brightness = 0,
     saturation = 0,
     contrast = 0,
@@ -186,8 +186,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   VIVID(
-    displayName = "Vivid",
-    description = "Enhanced colors with crisp details",
+    displayNameRes = R.string.filter_preset_vivid,
+    descriptionRes = R.string.filter_preset_vivid_desc,
     brightness = 5,
     saturation = 25,
     contrast = 15,
@@ -196,8 +196,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   WARM_TONE(
-    displayName = "Warm Tone",
-    description = "Warmer colors with golden tint",
+    displayNameRes = R.string.filter_preset_warm_tone,
+    descriptionRes = R.string.filter_preset_warm_tone_desc,
     brightness = 5,
     saturation = 10,
     contrast = 5,
@@ -206,8 +206,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   COOL_TONE(
-    displayName = "Cool Tone",
-    description = "Cooler colors with blue tint",
+    displayNameRes = R.string.filter_preset_cool_tone,
+    descriptionRes = R.string.filter_preset_cool_tone_desc,
     brightness = 0,
     saturation = 5,
     contrast = 10,
@@ -216,8 +216,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   SOFT_PASTEL(
-    displayName = "Soft Pastel",
-    description = "Soft, muted colors with gentle look",
+    displayNameRes = R.string.filter_preset_soft_pastel,
+    descriptionRes = R.string.filter_preset_soft_pastel_desc,
     brightness = 10,
     saturation = -15,
     contrast = -10,
@@ -226,8 +226,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   CINEMATIC(
-    displayName = "Cinematic",
-    description = "Film-like color grading with depth",
+    displayNameRes = R.string.filter_preset_cinematic,
+    descriptionRes = R.string.filter_preset_cinematic_desc,
     brightness = -5,
     saturation = -10,
     contrast = 20,
@@ -236,8 +236,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   DRAMATIC(
-    displayName = "Dramatic",
-    description = "High contrast dramatic look",
+    displayNameRes = R.string.filter_preset_dramatic,
+    descriptionRes = R.string.filter_preset_dramatic_desc,
     brightness = -10,
     saturation = 15,
     contrast = 30,
@@ -246,8 +246,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   NIGHT_MODE(
-    displayName = "Night Mode",
-    description = "Reduced brightness for dark environments",
+    displayNameRes = R.string.filter_preset_night_mode,
+    descriptionRes = R.string.filter_preset_night_mode_desc,
     brightness = -20,
     saturation = -5,
     contrast = 5,
@@ -256,8 +256,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   NOSTALGIC(
-    displayName = "Nostalgic",
-    description = "Vintage film look with soft focus",
+    displayNameRes = R.string.filter_preset_nostalgic,
+    descriptionRes = R.string.filter_preset_nostalgic_desc,
     brightness = 5,
     saturation = -20,
     contrast = 10,
@@ -266,8 +266,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   GHIBLI_STYLE(
-    displayName = "Ghibli Style",
-    description = "Soft, dreamy anime colors",
+    displayNameRes = R.string.filter_preset_ghibli_style,
+    descriptionRes = R.string.filter_preset_ghibli_style_desc,
     brightness = 8,
     saturation = 15,
     contrast = -5,
@@ -276,8 +276,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   NEON_POP(
-    displayName = "Neon Pop",
-    description = "Vibrant neon-like colors with edge",
+    displayNameRes = R.string.filter_preset_neon_pop,
+    descriptionRes = R.string.filter_preset_neon_pop_desc,
     brightness = 5,
     saturation = 40,
     contrast = 20,
@@ -286,8 +286,8 @@ enum class FilterPreset(
     sharpness = 0,
   ),
   DEEP_BLACK(
-    displayName = "Deep Black",
-    description = "Enhanced blacks for OLED displays",
+    displayNameRes = R.string.filter_preset_deep_black,
+    descriptionRes = R.string.filter_preset_deep_black_desc,
     brightness = -15,
     saturation = 5,
     contrast = 25,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/panels/VideoSettingsFilterPresetsCard.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/panels/VideoSettingsFilterPresetsCard.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import xyz.mpv.rex.R
 import xyz.mpv.rex.preferences.DecoderPreferences
 import xyz.mpv.rex.preferences.preference.collectAsState
 import xyz.mpv.rex.presentation.components.ExpandableCard
@@ -65,7 +67,7 @@ fun VideoSettingsFilterPresetsCard(modifier: Modifier = Modifier) {
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.medium),
       ) {
         Icon(Icons.Default.AutoAwesome, null)
-        Text("Filter Presets")
+        Text(stringResource(R.string.video_settings_filter_presets_title))
       }
     },
     colors = panelCardsColors(),
@@ -100,7 +102,7 @@ fun VideoSettingsFilterPresetsCard(modifier: Modifier = Modifier) {
               MPVLib.setPropertyInt("hue", preset.hue)
               MPVLib.setPropertyInt("sharpen", preset.sharpness)
             },
-            label = { Text(preset.displayName) },
+            label = { Text(stringResource(preset.displayNameRes)) },
             leadingIcon = null,
           )
         }
@@ -108,14 +110,12 @@ fun VideoSettingsFilterPresetsCard(modifier: Modifier = Modifier) {
 
       // Show description for selected preset
       currentPreset?.let { preset ->
-        if (preset.description.isNotEmpty()) {
-          Text(
-            text = preset.description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 4.dp),
-          )
-        }
+        Text(
+          text = stringResource(preset.descriptionRes),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.padding(top = 4.dp),
+        )
       }
     }
   }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1231,5 +1231,32 @@
         <item quantity="many">تم استيراد %1$d زرًا</item>
         <item quantity="other">تم استيراد %1$d زر</item>
     </plurals>
+
+        <!-- Video Settings Filter Presets Card -->
+    <string name="video_settings_filter_presets_title">أنماط الفلاتر الجاهزة</string>
+    <string name="filter_preset_none">عادي</string>
+    <string name="filter_preset_none_desc">الإعدادات الافتراضية بدون تعديلات</string>
+    <string name="filter_preset_vivid">حيوي</string>
+    <string name="filter_preset_vivid_desc">ألوان معززة بتفاصيل واضحة</string>
+    <string name="filter_preset_warm_tone">درجة دافئة</string>
+    <string name="filter_preset_warm_tone_desc">ألوان أكثر دفئاً بلمسة ذهبية</string>
+    <string name="filter_preset_cool_tone">درجة بارِدة</string>
+    <string name="filter_preset_cool_tone_desc">ألوان أكثر برودة بلمسة زرقاء</string>
+    <string name="filter_preset_soft_pastel">باستيل ناعم</string>
+    <string name="filter_preset_soft_pastel_desc">ألوان ناعمة وهادئة بمظهر رقيق</string>
+    <string name="filter_preset_cinematic">سينمائي</string>
+    <string name="filter_preset_cinematic_desc">تدرج ألوان يشبه الأفلام بعمق أكبر</string>
+    <string name="filter_preset_dramatic">دراماتيكي</string>
+    <string name="filter_preset_dramatic_desc">تباين عالٍ بمظهر دراماتيكي</string>
+    <string name="filter_preset_night_mode">وضع الليلي</string>
+    <string name="filter_preset_night_mode_desc">سطوع مخفّض للبيئات المعتمة</string>
+    <string name="filter_preset_nostalgic">حنين</string>
+    <string name="filter_preset_nostalgic_desc">مظهر أفلام قديمة وبتركيز ناعم</string>
+    <string name="filter_preset_ghibli_style">أسلوب غيبلي</string>
+    <string name="filter_preset_ghibli_style_desc">ألوان أنيميشن ناعمة وحالمة</string>
+    <string name="filter_preset_neon_pop">نيون زاهي</string>
+    <string name="filter_preset_neon_pop_desc">ألوان نيون نابضة بحيوية لافتة</string>
+    <string name="filter_preset_deep_black">أسود غامق</string>
+    <string name="filter_preset_deep_black_desc">أسود عميق معزز لشاشات الأوليد</string>
     
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1258,4 +1258,31 @@
         <item quantity="other">Imported %1$d buttons</item>
     </plurals>
 
+        <!-- Video Settings Filter Presets Card -->
+    <string name="video_settings_filter_presets_title">Filter Presets</string>
+    <string name="filter_preset_none">None</string>
+    <string name="filter_preset_none_desc">Default settings with no adjustments</string>
+    <string name="filter_preset_vivid">Vivid</string>
+    <string name="filter_preset_vivid_desc">Enhanced colors with crisp details</string>
+    <string name="filter_preset_warm_tone">Warm Tone</string>
+    <string name="filter_preset_warm_tone_desc">Warmer colors with golden tint</string>
+    <string name="filter_preset_cool_tone">Cool Tone</string>
+    <string name="filter_preset_cool_tone_desc">Cooler colors with blue tint</string>
+    <string name="filter_preset_soft_pastel">Soft Pastel</string>
+    <string name="filter_preset_soft_pastel_desc">Soft, muted colors with gentle look</string>
+    <string name="filter_preset_cinematic">Cinematic</string>
+    <string name="filter_preset_cinematic_desc">Film-like color grading with depth</string>
+    <string name="filter_preset_dramatic">Dramatic</string>
+    <string name="filter_preset_dramatic_desc">High contrast dramatic look</string>
+    <string name="filter_preset_night_mode">Night Mode</string>
+    <string name="filter_preset_night_mode_desc">Reduced brightness for dark environments</string>
+    <string name="filter_preset_nostalgic">Nostalgic</string>
+    <string name="filter_preset_nostalgic_desc">Vintage film look with soft focus</string>
+    <string name="filter_preset_ghibli_style">Ghibli Style</string>
+    <string name="filter_preset_ghibli_style_desc">Soft, dreamy anime colors</string>
+    <string name="filter_preset_neon_pop">Neon Pop</string>
+    <string name="filter_preset_neon_pop_desc">Vibrant neon-like colors with edge</string>
+    <string name="filter_preset_deep_black">Deep Black</string>
+    <string name="filter_preset_deep_black_desc">Enhanced blacks for OLED displays</string>
+
 </resources>


### PR DESCRIPTION
FilterPreset enum had displayName and description hardcoded as plain
English strings, with no `@StringRes` at all — the odd one out compared
to every other enum in PlayerEnums.kt, which all use `@StringRes` properly.

Checked how it's actually used first: VideoSettingsFilterPresetsCard.kt
matches presets by comparing 6 int values (brightness, saturation, etc),
never by the string itself, so converting to `@StringRes` was safe with
zero risk to stored preferences.

Renamed the properties to `displayNameRes`/`descriptionRes` (Int) and updated
the card to pull them through `stringResource()`. Also caught a hardcoded
"Filter Presets" card title and a missing R import while I was in there.

11 presets x 2 strings + the card title = 23 new keys, added to both
strings.xml and strings-ar.xml.