### PR TITLE
Fix: Use dynamic app name in settings backup filename (#226)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/SettingsManager.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/SettingsManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Xml
 import xyz.mpv.rex.database.MpvExDatabase
+import xyz.mpv.rex.R
 import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.domain.network.NetworkProtocol
 import xyz.mpv.rex.preferences.preference.PreferenceStore
@@ -295,7 +296,8 @@ class SettingsManager(
 
   fun getDefaultExportFilename(): String {
     val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault())
-    return "mpvEx_settings_${dateFormat.format(Date())}.xml"
+    val appName = context.getString(R.string.app_name)
+    return "${appName}_settings_${dateFormat.format(Date())}.xml"
   }
 
   data class ImportStats(


### PR DESCRIPTION
Fixes #226

The backup filename was hardcoded as `mpvEx_settings_...`, a leftover from before the project was renamed to mpvRex.

**Changes:**
- `SettingsManager.getDefaultExportFilename()` now pulls the app name from `R.string.app_name` instead of the hardcoded string
- Added the missing `import xyz.mpv.rex.R`

Backup files now export as `mpvRex_settings_YYYYMMdd_HHmmss.xml`. Didn't touch `TAG_ROOT` ("mpvExSettings") since that's the internal XML root tag, not the filename — changing it would break restoring older backups.