### PR TITLE
feat(player): add 'Seek while dragging' preference

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
@@ -21,6 +21,7 @@ class PlayerPreferences(
   val showCircularDoubleTapSeek = preferenceStore.getBoolean("show_circular_double_tap_seek", true)
   val showSeekTimeWhileSeeking = preferenceStore.getBoolean("show_seek_time_while_seeking", true)
   val usePreciseSeeking = preferenceStore.getBoolean("use_precise_seeking", false)
+  val seekWhileDragging = preferenceStore.getBoolean("seek_while_dragging", true)
 
   val brightnessGesture = preferenceStore.getBoolean("gestures_brightness", true)
   val volumeGesture = preferenceStore.getBoolean("volume_brightness", true)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/GestureHandler.kt
@@ -995,6 +995,7 @@ fun GestureHandler(
           var hasStartedSeeking = false
           var hasTriggeredSubSeek = false
           var initialVideoPosition = 0f
+          var lastSeekPosition = -1f
           // Use the sensitivity preference instead of hardcoded value
           val seekSensitivity = horizontalSwipeSensitivity
           
@@ -1052,9 +1053,13 @@ fun GestureHandler(
                     val maxDuration = if (preciseDuration > 0f) preciseDuration else duration?.toFloat() ?: 0f
                     val clampedPosition = targetPosition.coerceAtMost(maxDuration)
                     
-                    // Use the same seeking mechanism as seekbar scrubbing
-                    // This will update the seekbar position and provide live preview
-                    viewModel.seekTo(clampedPosition.toInt())
+                    // Use the same seeking mechanism as seekbar scrubbing.
+                    // Live preview only when the preference is enabled;
+                    // otherwise the final position is applied on release.
+                    lastSeekPosition = clampedPosition
+                    if (playerPreferences.seekWhileDragging.get()) {
+                      viewModel.seekTo(clampedPosition.toInt())
+                    }
                     
                     // Format and display time position updates
                     val currentPos = clampedPosition.toInt()
@@ -1097,6 +1102,7 @@ fun GestureHandler(
               // Multi-finger detected, cancel horizontal seek
               if (hasStartedSeeking) {
                 hasStartedSeeking = false
+                lastSeekPosition = -1f
                 viewModel.setGestureSeeking(false)
                 // Clean up seeking state without showing controls
                 viewModel.playerUpdate.update { PlayerUpdates.None }
@@ -1108,6 +1114,10 @@ fun GestureHandler(
 
           // Apply the final seek when gesture ends
           if (hasStartedSeeking) {
+            // Seek-on-release: jump to the final swipe position now.
+            if (!playerPreferences.seekWhileDragging.get() && lastSeekPosition >= 0f) {
+              viewModel.seekTo(lastSeekPosition.toInt())
+            }
             // Clear the horizontal seek update and hide seekbar after a short delay
             coroutineScope.launch {
               delay(300)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
@@ -207,6 +207,7 @@ fun PlayerControls(
   var dragStartValue by remember { mutableStateOf(-1f) }
   var isCloseToStart by remember { mutableStateOf(false) }
   var changeCount by remember { mutableStateOf(0) }
+  var lastDragValue by remember { mutableStateOf(0f) }
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
   val seekText by viewModel.seekText.collectAsState()
   val currentChapter by MPVLib.propInt["chapter"].collectAsState()
@@ -1258,13 +1259,19 @@ fun PlayerControls(
                   viewModel.playerUpdate.value = PlayerUpdates.None
                 }
               }
-              viewModel.seekTo(newValue.toInt())
+              lastDragValue = newValue
+              if (playerPreferences.seekWhileDragging.get()) {
+                viewModel.seekTo(newValue.toInt())
+              }
               viewModel.autoHideControls()
             },
             onValueChangeFinished = {
               if (isCloseToStart) {
                 viewModel.seekTo(dragStartValue.toInt())
                 viewModel.playerUpdate.value = PlayerUpdates.None
+              } else if (!playerPreferences.seekWhileDragging.get()) {
+                // Seek only on release: jump to the final drag position.
+                viewModel.seekTo(lastDragValue.toInt())
               }
               isSeeking = false
               dragStartValue = -1f

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
@@ -207,7 +207,7 @@ fun PlayerControls(
   var dragStartValue by remember { mutableStateOf(-1f) }
   var isCloseToStart by remember { mutableStateOf(false) }
   var changeCount by remember { mutableStateOf(0) }
-  var lastDragValue by remember { mutableStateOf(0f) }
+  var lastDragValue by remember { mutableStateOf(-1f) }
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
   val seekText by viewModel.seekText.collectAsState()
   val currentChapter by MPVLib.propInt["chapter"].collectAsState()
@@ -1269,14 +1269,18 @@ fun PlayerControls(
               if (isCloseToStart) {
                 viewModel.seekTo(dragStartValue.toInt())
                 viewModel.playerUpdate.value = PlayerUpdates.None
-              } else if (!playerPreferences.seekWhileDragging.get()) {
+              } else if (!playerPreferences.seekWhileDragging.get() && lastDragValue >= 0f) {
                 // Seek only on release: jump to the final drag position.
+                // Guard against cancel-drag (onDragCancel never fires onSeek),
+                // where lastDragValue would still be -1f and seeking to it
+                // would rewind to the start.
                 viewModel.seekTo(lastDragValue.toInt())
               }
               isSeeking = false
               dragStartValue = -1f
               isCloseToStart = false
               changeCount = 0
+              lastDragValue = -1f
               resetControlsTimestamp = System.currentTimeMillis()
               viewModel.showControls()
             },

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
@@ -299,6 +299,16 @@ object PlayerPreferencesScreen : Screen {
 
               PreferenceDivider()
 
+              val seekWhileDragging by preferences.seekWhileDragging.collectAsState()
+              SwitchPreference(
+                value = seekWhileDragging,
+                onValueChange = preferences.seekWhileDragging::set,
+                title = { Text(stringResource(R.string.pref_player_seek_while_dragging_title)) },
+                summary = { Text(stringResource(R.string.pref_player_seek_while_dragging_summary)) },
+              )
+
+              PreferenceDivider()
+
               val showSeekBarWhenSeeking by preferences.showSeekBarWhenSeeking.collectAsState()
               SwitchPreference(
                 value = showSeekBarWhenSeeking,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,8 @@
 
     <!-- Media Info Activity -->
     <string name="pref_player_use_precise_seeking">Use precise seeking</string>
+    <string name="pref_player_seek_while_dragging_title">Seek while dragging</string>
+    <string name="pref_player_seek_while_dragging_summary">Preview frames continuously while dragging the progress bar. Turn off to jump only when you release</string>
     <string name="pref_player_show_seekbar_when_seeking_title">Show seekbar when seeking</string>
     <string name="pref_player_show_seekbar_when_seeking_summary">Display the video progress bar during gesture seeking</string>
     <string name="pref_player_white_seekbar_title">White video progress bar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -604,7 +604,7 @@
     <!-- Media Info Activity -->
     <string name="pref_player_use_precise_seeking">Use precise seeking</string>
     <string name="pref_player_seek_while_dragging_title">Seek while dragging</string>
-    <string name="pref_player_seek_while_dragging_summary">Preview frames continuously while dragging the progress bar. Turn off to jump only when you release</string>
+    <string name="pref_player_seek_while_dragging_summary">Preview frames continuously while dragging the progress bar or swiping to seek. Turn off to jump only when you release</string>
     <string name="pref_player_show_seekbar_when_seeking_title">Show seekbar when seeking</string>
     <string name="pref_player_show_seekbar_when_seeking_summary">Display the video progress bar during gesture seeking</string>
     <string name="pref_player_white_seekbar_title">White video progress bar</string>


### PR DESCRIPTION
## Problem

Dragging the progress bar (and swipe-to-seek) issues a seek on every
position change, decoding and displaying the target frame each time. On
large / high-bitrate files this makes scrubbing feel janky because the
video flashes through frames while dragging. Other players (mpvRx, VLC)
only jump when the finger is released.

## Fix

New optional preference **"Seek while dragging"** (default **on**,
preserving current behavior) under Player settings. When turned off:

- Dragging the progress bar only updates the UI position; the seek
  happens when the finger is released
- Swipe-to-seek behaves the same way: OSD time/seekbar follow the
  finger, the final position is applied when the gesture ends
- Existing interactions are preserved:
  - Drag-cancel (drag back near the start and release) still seeks back
    to the original position ("Release to cancel")
  - Multi-finger cancel of swipe-seek still aborts without seeking
  - Tap-to-seek on the progress bar still works
  - Subtitle swipe / vertical gestures / double-tap are unaffected

Edge case handled: `onDragCancel` in the seekbar fires
`onSeekFinished` without `onSeek`, so the stored position could stay at
its initial -1f and seeking to it would rewind to the start — guarded
with `>= 0f` and reset on finish.

## Implementation notes

- One preference controls both entry points (progress bar + swipe),
  keeping the settings surface minimal
- `preferenceStore` key: `seek_while_dragging`, default `true`
- English strings only for now; localized strings can follow in a
  separate PR

## Tested

- Progress bar: live preview (default) and seek-on-release
- Swipe-to-seek: seek-on-release, multi-finger cancel
- Drag-cancel ("Release to cancel") in both modes
- Subtitle swipe / vertical gestures unaffected
