### PR TITLE
fix(network): fix first swipe swallowed and missing scrollbar in network browser

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserScreen.kt
@@ -207,7 +207,7 @@ private fun NetworkBrowserContent(
     else -> {
       val folders = files.filter { it.isDirectory }
       val videos = files.filter { !it.isDirectory && it.mimeType?.startsWith("video/") == true }
-      val networkListState = LazyListState()
+      val networkListState = remember { LazyListState() }
 
       // Check if at top of list to hide scrollbar during pull-to-refresh
       val isAtTop by remember {

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
@@ -35,10 +35,6 @@ class NetworkBrowserViewModel(
   private val _error = MutableStateFlow<String?>(null)
   val error: StateFlow<String?> = _error.asStateFlow()
 
-  init {
-    loadData()
-  }
-
   /**
    * Load files in the current directory
    */

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -102,7 +102,7 @@ object NetworkStreamingScreen : Screen {
     val navigationBarHeight = xyz.mpv.rex.ui.browser.LocalNavigationBarHeight.current
 
     // LazyList state for scroll tracking
-    val listState = LazyListState()
+    val listState = remember { LazyListState() }
 
     // Track scroll direction to show/hide FAB
     var previousFirstVisibleItemIndex by remember { mutableIntStateOf(0) }


### PR DESCRIPTION
## Summary

Fixes two issues in the network share browser:

- The folder/file list ignores the first drag gesture.
- The scrollbar never appears in directories with more than 20 items.

Local file browsing is unaffected.

## Root cause

`NetworkBrowserScreen` and `NetworkStreamingScreen` were creating
`LazyListState()` directly inside composition, so every recomposition
produced a new state instance.

During the first drag, scrolling changes `firstVisibleItemScrollOffset`,
which flips the `isAtTop` derived state and triggers a recomposition
mid-gesture. The new `LazyListState` replaces the `ScrollableState` and
cancels the in-flight drag (`DragGestureNode` resets), so the first swipe
appears to be swallowed.

The same stale-state issue keeps `isAtTop` observing the old state
forever, leaving the scrollbar alpha at 0.

`NetworkBrowserViewModel` also called `loadData()` from both `init` and
the screen's `LaunchedEffect`, causing duplicate concurrent SMB listings.

## Changes

- `NetworkBrowserScreen`: use `remember { LazyListState() }`
- `NetworkStreamingScreen`: use `remember { LazyListState() }`
- `NetworkBrowserViewModel`: remove duplicate `init { loadData() }`

## Verification

Tested on a device with a debug build:

- Network share folder list scrolls on the first touch.
- Scrollbar appears in directories with more than 20 items.
- Local file browser remains unaffected.
