### PR TITLE
feat(player): implement universal video_list parser, robust smb resolution, and seekbar reset

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -119,6 +119,7 @@
                 <data android:scheme="mmsh" />
                 <data android:scheme="tcp" />
                 <data android:scheme="udp" />
+                <data android:scheme="smb" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/BrowserPreferences.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/BrowserPreferences.kt
@@ -18,6 +18,10 @@ class BrowserPreferences(
   val videoSortType = preferenceStore.getEnum("video_sort_type", VideoSortType.Title)
   val videoSortOrder = preferenceStore.getEnum("video_sort_order", SortOrder.Ascending)
 
+  // Network sorting preferences
+  val networkSortType = preferenceStore.getEnum("network_sort_type", FolderSortType.Title)
+  val networkSortOrder = preferenceStore.getEnum("network_sort_order", SortOrder.Ascending)
+
   val folderViewMode = preferenceStore.getEnum("folder_view_mode", FolderViewMode.AlbumView)
 
   private val isTablet = context.resources.configuration.smallestScreenWidthDp >= 600

--- a/app/src/main/kotlin/xyz/mpv/rex/repository/NetworkRepository.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/repository/NetworkRepository.kt
@@ -1,9 +1,12 @@
 package xyz.mpv.rex.repository
 
 import xyz.mpv.rex.database.dao.NetworkConnectionDao
+import java.util.concurrent.ConcurrentHashMap
+
 import xyz.mpv.rex.domain.network.ConnectionStatus
 import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.domain.network.NetworkFile
+import xyz.mpv.rex.domain.network.NetworkProtocol
 import xyz.mpv.rex.ui.browser.networkstreaming.clients.NetworkClient
 import xyz.mpv.rex.ui.browser.networkstreaming.clients.NetworkClientFactory
 import kotlinx.coroutines.flow.Flow
@@ -18,7 +21,7 @@ class NetworkRepository(
   private val dao: NetworkConnectionDao,
 ) {
   // Active network clients
-  private val activeClients = mutableMapOf<Long, NetworkClient>()
+  private val activeClients = ConcurrentHashMap<Long, NetworkClient>()
 
   // Connection statuses
   private val _connectionStatuses = MutableStateFlow<Map<Long, ConnectionStatus>>(emptyMap())
@@ -40,15 +43,63 @@ class NetworkRepository(
   suspend fun getConnectionById(id: Long): NetworkConnection? = dao.getConnectionById(id)
 
   /**
+   * Find the saved SMB connection that owns `smb://[host]/[share]/…`, or null if none is saved.
+   *
+   * There is no query for this, so the (short) list is matched in Kotlin. Host names and SMB share
+   * names are case-insensitive, and the saved share may or may not carry surrounding slashes.
+   */
+  suspend fun findSmbConnection(
+    host: String,
+    share: String,
+  ): NetworkConnection? {
+    fun normalizeHost(raw: String): String {
+      val trimmed = raw.trim().removePrefix("smb://").trimEnd('/')
+      return when {
+        trimmed.startsWith('[') && trimmed.contains(']') -> trimmed.substringAfter('[').substringBefore(']')
+        trimmed.count { it == ':' } > 1 -> trimmed
+        else -> trimmed.substringBefore(':')
+      }
+    }
+
+    val cleanHost = normalizeHost(host)
+    val cleanShare = share.trim('/')
+    val smbConnections = dao.getAllConnectionsList().filter {
+      it.protocol == NetworkProtocol.SMB &&
+        normalizeHost(it.host).equals(cleanHost, ignoreCase = true)
+    }
+
+    return smbConnections.firstOrNull {
+      it.path.trim('/').equals(cleanShare, ignoreCase = true)
+    } ?: smbConnections.firstOrNull {
+      it.path.trim('/').isEmpty()
+    }?.copy(path = cleanShare)
+  }
+
+  /**
+   * Strips stray whitespace from the fields that address the server.
+   *
+   * A pasted or fat-fingered space in the username authenticates as a different (non-existent)
+   * account, which surfaces as a confusing "share not found" rather than a login failure. The
+   * password is deliberately left alone — spaces can be part of a real one.
+   */
+  private fun NetworkConnection.trimmed(): NetworkConnection =
+    copy(
+      name = name.trim(),
+      host = host.trim(),
+      username = username.trim(),
+      path = path.trim(),
+    )
+
+  /**
    * Add a new connection
    */
-  suspend fun addConnection(connection: NetworkConnection): Long = dao.insert(connection)
+  suspend fun addConnection(connection: NetworkConnection): Long = dao.insert(connection.trimmed())
 
   /**
    * Update an existing connection
    */
   suspend fun updateConnection(connection: NetworkConnection) {
-    dao.update(connection)
+    dao.update(connection.trimmed())
     // Disconnect and remove cached client if it exists
     // This ensures the next connection uses the updated credentials
     activeClients[connection.id]?.let { client ->
@@ -194,25 +245,40 @@ class NetworkRepository(
     path: String,
   ): Result<List<NetworkFile>> =
     try {
-      // Always fetch the latest connection from database to ensure we have current credentials
-      val latestConnection = dao.getConnectionById(connection.id) ?: connection
-
-      // Check if we have an active client
-      val existingClient = activeClients[connection.id]
-
-      // If no client exists, or if connection details have changed, create a new one
-      val client = if (existingClient == null) {
-        // Create new client with latest connection settings
-        NetworkClientFactory.createClient(latestConnection).also { newClient ->
-          newClient.connect().getOrThrow()
-          activeClients[connection.id] = newClient
+      if (connection.id <= 0) {
+        val client = NetworkClientFactory.createClient(connection)
+        try {
+          client.connect().getOrThrow()
+          client.listFiles(path)
+        } finally {
+          client.disconnect()
         }
       } else {
-        existingClient
-      }
+        // Always fetch the latest connection from database to ensure we have current credentials
+        val dbConnection = dao.getConnectionById(connection.id)
+        val latestConnection = dbConnection?.copy(
+          path = connection.path.takeIf { it.isNotBlank() && it != "/" } ?: dbConnection.path,
+          port = connection.port.takeIf { it > 0 } ?: dbConnection.port,
+        ) ?: connection
 
-      // List files
-      client.listFiles(path)
+        // Check if we have an active client
+        val existingClient = activeClients[connection.id]
+
+        // If no client exists, or if connection details have changed, create a new one
+        val client = if (existingClient == null || !existingClient.isConnected() || existingClient.connection.path != latestConnection.path) {
+          existingClient?.disconnect()
+          // Create new client with latest connection settings
+          NetworkClientFactory.createClient(latestConnection).also { newClient ->
+            newClient.connect().getOrThrow()
+            activeClients[connection.id] = newClient
+          }
+        } else {
+          existingClient
+        }
+
+        // List files
+        client.listFiles(path)
+      }
     } catch (e: Exception) {
       Result.failure(e)
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/dialogs/SortDialog.kt
@@ -1522,3 +1522,58 @@ fun FileSystemSortDialog(
     )
   )
 }
+
+/**
+ * Sort options for a network share.
+ *
+ * Only title, date and size are offered: a folder listing over SMB carries name, timestamp and
+ * size, but not duration, and probing every remote file for it would mean opening each one.
+ */
+@Composable
+fun NetworkSortDialog(
+  isOpen: Boolean,
+  onDismiss: () -> Unit,
+) {
+  val browserPreferences = koinInject<BrowserPreferences>()
+  val sortType by browserPreferences.networkSortType.collectAsState()
+  val sortOrder by browserPreferences.networkSortOrder.collectAsState()
+
+  SortDialog(
+    isOpen = isOpen,
+    onDismiss = onDismiss,
+    title = stringResource(R.string.sort_and_view_options),
+    sortType = sortType.displayName,
+    onSortTypeChange = { typeName ->
+      FolderSortType.entries.find { it.displayName == typeName }?.let {
+        browserPreferences.networkSortType.set(it)
+      }
+    },
+    sortOrderAsc = sortOrder.isAscending,
+    onSortOrderChange = { isAsc ->
+      browserPreferences.networkSortOrder.set(
+        if (isAsc) SortOrder.Ascending else SortOrder.Descending,
+      )
+    },
+    types = listOf(
+      FolderSortType.Title.displayName,
+      FolderSortType.Date.displayName,
+      FolderSortType.Size.displayName,
+    ),
+    icons = listOf(
+      Icons.Filled.Title,
+      Icons.Filled.CalendarToday,
+      Icons.Filled.SwapVert,
+    ),
+    getLabelForType = { type, _ ->
+      when (type) {
+        FolderSortType.Title.displayName -> Pair("A-Z", "Z-A")
+        FolderSortType.Date.displayName -> Pair("Oldest", "Newest")
+        FolderSortType.Size.displayName -> Pair("Smallest", "Largest")
+        else -> Pair("Asc", "Desc")
+      }
+    },
+    showSortOptions = true,
+    enableViewModeOptions = false,
+    enableLayoutModeOptions = false,
+  )
+}

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,8 +44,11 @@ import xyz.mpv.rex.presentation.components.pullrefresh.PullRefreshBox
 import xyz.mpv.rex.ui.browser.cards.NetworkFolderCard
 import xyz.mpv.rex.ui.browser.cards.NetworkVideoCard
 import xyz.mpv.rex.ui.browser.components.BrowserTopBar
+import xyz.mpv.rex.ui.browser.dialogs.NetworkSortDialog
 import xyz.mpv.rex.ui.browser.states.EmptyState
 import xyz.mpv.rex.ui.utils.LocalBackStack
+import xyz.mpv.rex.utils.storage.FileTypeUtils
+import java.io.File
 import kotlinx.serialization.Serializable
 import androidx.compose.foundation.layout.fillMaxHeight
 import xyz.mpv.rex.ui.browser.components.FastScrollbar
@@ -72,13 +76,15 @@ data class NetworkBrowserScreen(
           ),
       )
 
-    val files by viewModel.items.collectAsState()
+    val filesState = viewModel.items.collectAsState()
+    val files = filesState.value
     val isLoading by viewModel.isLoading.collectAsState()
     val uiSettings by viewModel.uiSettings.collectAsState()
     val error by viewModel.error.collectAsState()
 
     // UI State
     val isRefreshing = remember { mutableStateOf(false) }
+    val sortDialogOpen = rememberSaveable { mutableStateOf(false) }
 
     // Load files when connectionId or currentPath changes
     LaunchedEffect(connectionId, currentPath) {
@@ -98,7 +104,7 @@ data class NetworkBrowserScreen(
           totalCount = 0,
           onBackClick = { backstack.removeLastOrNull() },
           onCancelSelection = {},
-          onSortClick = null,
+          onSortClick = { sortDialogOpen.value = true },
           onSearchClick = null,
           onSettingsClick = {
             backstack.add(xyz.mpv.rex.ui.preferences.PreferencesScreen)
@@ -115,7 +121,8 @@ data class NetworkBrowserScreen(
       },
     ) { padding ->
       NetworkBrowserContent(
-        files = files,
+        folders = remember { derivedStateOf { filesState.value.filter { it.isDirectory } } }.value,
+        videos = remember { derivedStateOf { filesState.value.filter { !it.isDirectory && FileTypeUtils.isMediaFile(File(it.name)) } } }.value,
         connectionId = connectionId,
         connectionName = connectionName,
         isLoading = isLoading && files.isEmpty(),
@@ -138,12 +145,18 @@ data class NetworkBrowserScreen(
         modifier = Modifier.padding(top = padding.calculateTopPadding()),
       )
     }
+
+    NetworkSortDialog(
+      isOpen = sortDialogOpen.value,
+      onDismiss = { sortDialogOpen.value = false },
+    )
   }
 }
 
 @Composable
 private fun NetworkBrowserContent(
-  files: List<NetworkFile>,
+  folders: List<NetworkFile>,
+  videos: List<NetworkFile>,
   connectionId: Long,
   connectionName: String,
   isLoading: Boolean,
@@ -191,7 +204,7 @@ private fun NetworkBrowserContent(
       }
     }
 
-    files.isEmpty() -> {
+    folders.isEmpty() && videos.isEmpty() -> {
       Box(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
@@ -205,8 +218,7 @@ private fun NetworkBrowserContent(
     }
 
     else -> {
-      val folders = files.filter { it.isDirectory }
-      val videos = files.filter { !it.isDirectory && it.mimeType?.startsWith("video/") == true }
+      
       val networkListState = remember { LazyListState() }
 
       // Check if at top of list to hide scrollbar during pull-to-refresh

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
@@ -11,12 +11,19 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.domain.network.NetworkFile
 import xyz.mpv.rex.domain.network.NetworkProtocol
+import xyz.mpv.rex.preferences.BrowserPreferences
 import xyz.mpv.rex.repository.NetworkRepository
 import xyz.mpv.rex.ui.browser.base.BaseBrowserViewModel
+import xyz.mpv.rex.utils.media.FolderPlaylistOps
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -35,6 +42,18 @@ class NetworkBrowserViewModel(
   private val _error = MutableStateFlow<String?>(null)
   val error: StateFlow<String?> = _error.asStateFlow()
 
+  init {
+    viewModelScope.launch(Dispatchers.Default) {
+      combine(
+        browserPreferences.networkSortType.changes(),
+        browserPreferences.networkSortOrder.changes(),
+      ) { _, _ -> }
+        .drop(1)
+        .collect {
+          _items.update { it.sortedWith(listComparator()) }
+        }
+    }
+  }
   /**
    * Load files in the current directory
    */
@@ -49,10 +68,7 @@ class NetworkBrowserViewModel(
 
         repository.listFiles(connection, currentPath)
           .onSuccess { fileList ->
-            _items.value = fileList.sortedWith(
-              compareBy<NetworkFile> { !it.isDirectory }
-                .thenBy { it.name.lowercase() },
-            )
+            _items.value = fileList.sortedWith(listComparator())
           }
           .onFailure { e ->
             _error.value = e.message ?: "Unknown error"
@@ -68,6 +84,10 @@ class NetworkBrowserViewModel(
   override fun refresh(silent: Boolean) {
     loadData()
   }
+
+  /** Directories first, then the network browser's sort preference. */
+  private fun listComparator(): Comparator<NetworkFile> =
+    compareBy<NetworkFile> { !it.isDirectory }.then(FolderPlaylistOps.networkFileComparator())
 
   /**
    * Play a video file

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/clients/BaseNetworkClient.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/clients/BaseNetworkClient.kt
@@ -1,6 +1,8 @@
 package xyz.mpv.rex.ui.browser.networkstreaming.clients
 
 import android.net.Uri
+import kotlinx.coroutines.NonCancellable
+
 import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.domain.network.NetworkFile
 import kotlinx.coroutines.Dispatchers
@@ -10,7 +12,7 @@ import java.io.InputStream
 /**
  * Base class for all network protocol clients to reduce duplication.
  */
-abstract class BaseNetworkClient(protected val connection: NetworkConnection) : NetworkClient {
+abstract class BaseNetworkClient(override val connection: NetworkConnection) : NetworkClient {
 
     protected abstract suspend fun performConnect(): Unit
     protected abstract suspend fun performDisconnect(): Unit
@@ -25,7 +27,7 @@ abstract class BaseNetworkClient(protected val connection: NetworkConnection) : 
         runCatching { performConnect() }
     }
 
-    override suspend fun disconnect() = withContext(Dispatchers.IO) {
+    override suspend fun disconnect() = withContext(NonCancellable + Dispatchers.IO) {
         runCatching { performDisconnect() }
         Unit
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/clients/NetworkClient.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/clients/NetworkClient.kt
@@ -1,6 +1,7 @@
 package xyz.mpv.rex.ui.browser.networkstreaming.clients
 
 import android.net.Uri
+import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.domain.network.NetworkFile
 import java.io.InputStream
 
@@ -8,6 +9,8 @@ import java.io.InputStream
  * Common interface for all network protocol clients
  */
 interface NetworkClient {
+  val connection: NetworkConnection
+
   /**
    * Connect to the server
    */

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/networkstreaming/proxy/NetworkStreamingProxy.kt
@@ -1,6 +1,7 @@
 package xyz.mpv.rex.ui.browser.networkstreaming.proxy
 
 import android.util.Log
+import java.net.URI
 import xyz.mpv.rex.domain.network.NetworkConnection
 import xyz.mpv.rex.ui.browser.networkstreaming.clients.NetworkClient
 import xyz.mpv.rex.ui.browser.networkstreaming.clients.NetworkClientFactory
@@ -106,6 +107,16 @@ class NetworkStreamingProxy private constructor() : NanoHTTPD("127.0.0.1", 0) {
         }
       }
     }
+  }
+
+  /**
+   * Extracts the stream ID from a local proxy URL (e.g. http://127.0.0.1:port/streamId)
+   */
+  fun extractStreamId(url: String?): String? {
+    if (url.isNullOrBlank()) return null
+    val uri = runCatching { URI(url) }.getOrNull() ?: return null
+    return uri.takeIf { it.host == "127.0.0.1" || it.host == "localhost" }
+      ?.path?.trim('/')?.substringBefore('/')?.takeIf { it.isNotEmpty() }
   }
 
   /**

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlaybackManager.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlaybackManager.kt
@@ -2,6 +2,7 @@ package xyz.mpv.rex.ui.player
 
 import xyz.mpv.rex.preferences.PlayerPreferences
 import `is`.xyz.mpv.MPVLib
+import android.os.SystemClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -16,10 +17,12 @@ class PlaybackManager(
 ) {
     companion object {
         private const val TAG = "PlaybackManager"
+        private const val SEEK_COALESCE_MS = 150L
     }
 
     private var seekJob: Job? = null
     private var resyncJob: Job? = null
+    @Volatile private var lastSeekAt = 0L
 
     /**
      * Performs an absolute seek to the specified position.
@@ -29,6 +32,11 @@ class PlaybackManager(
     fun seekTo(scope: CoroutineScope, position: Int, abLoopA: Double?, abLoopB: Double?) {
         seekJob?.cancel()
         seekJob = scope.launch(Dispatchers.IO) {
+            val isRemote = MPVLib.getPropertyString("path")?.startsWith("http", ignoreCase = true) == true
+            if (isRemote && SystemClock.elapsedRealtime() - lastSeekAt < SEEK_COALESCE_MS) {
+                delay(SEEK_COALESCE_MS)
+            }
+            lastSeekAt = SystemClock.elapsedRealtime()
             val maxDuration = MPVLib.getPropertyInt("duration") ?: 0
 
             var clampedPosition = position

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
@@ -35,12 +35,14 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.runBlocking
 import xyz.mpv.rex.MainActivity
 import xyz.mpv.rex.R
 import xyz.mpv.rex.database.entities.PlaybackStateEntity
 import xyz.mpv.rex.databinding.PlayerLayoutBinding
 import xyz.mpv.rex.domain.playbackstate.repository.PlaybackStateRepository
 import xyz.mpv.rex.ui.browser.miniplayer.MiniPlayerStateManager
+import xyz.mpv.rex.ui.browser.networkstreaming.proxy.NetworkStreamingProxy
 import xyz.mpv.rex.preferences.AdvancedPreferences
 import xyz.mpv.rex.preferences.DecoderPreferences
 import xyz.mpv.rex.domain.hdr.HdrToysManager
@@ -220,6 +222,8 @@ class PlayerActivity :
    */
   private var mediaIdentifier = ""
 
+  private var activeNetworkStreamId: String? = null
+
   /**
    * Helper for managing Picture-in-Picture mode.
    */
@@ -392,6 +396,10 @@ class PlayerActivity :
       }
     }
 
+    val externalPlaylist = if (intent.action == Intent.ACTION_VIEW || intent.action == null) {
+      FolderPlaylistOps.extractExternalPlaylist(intent)
+    } else null
+
     val playlistId = intent.getIntExtra("playlist_id", -1).takeIf { it != -1 }
     val playlistIndex = intent.getIntExtra("playlist_index", 0)
 
@@ -403,15 +411,26 @@ class PlayerActivity :
       intent.getParcelableArrayListExtra("playlist") ?: emptyList()
     }
 
-    if (playlistFromIntent.isNotEmpty() || playlistId != null) {
-      val titlesFromIntent = intent.getStringArrayListExtra("playlist_titles") ?: emptyList()
-      viewModel.playlistManager.setPlaylist(
-        items = playlistFromIntent,
-        index = playlistIndex,
-        id = playlistId,
-        titles = titlesFromIntent
-      )
-      updateMiniPlayerPlaylistState()
+    when {
+      externalPlaylist != null -> {
+        viewModel.playlistManager.setPlaylist(
+          items = externalPlaylist.items,
+          index = externalPlaylist.initialIndex,
+          titles = externalPlaylist.titles
+        )
+        Log.d(TAG, "Loaded external playlist: ${externalPlaylist.items.size} items at index ${externalPlaylist.initialIndex}")
+        updateMiniPlayerPlaylistState()
+      }
+      playlistFromIntent.isNotEmpty() || playlistId != null -> {
+        val titlesFromIntent = intent.getStringArrayListExtra("playlist_titles") ?: emptyList()
+        viewModel.playlistManager.setPlaylist(
+          items = playlistFromIntent,
+          index = playlistIndex,
+          id = playlistId,
+          titles = titlesFromIntent
+        )
+        updateMiniPlayerPlaylistState()
+      }
     }
 
     // If playlist is empty but playlist_id is provided, load asynchronously from database
@@ -457,24 +476,22 @@ class PlayerActivity :
 
     // Only auto-generate playlist from folder if playlist mode is enabled and no playlist_id
     if (viewModel.playlistManager.playlist.value.isEmpty() && playlistId == null && playerPreferences.playlistMode.get()) {
-      val launchSource = intent.getStringExtra("launch_source")
-      val path = parsePathFromIntent(intent)
-      if (path != null) {
-        if (launchSource == "media_library_list") {
-          generatePlaylistFromMediaLibrary(path)
-        } else {
-          generatePlaylistFromFolder(path)
-        }
-      }
+      autoGeneratePlaylist(intent)
     }
 
     // Extract fileName early so it's available when video loads
-    fileName = getFileName(intent)
+    fileName = if (externalPlaylist != null && !externalPlaylist.titles.getOrNull(externalPlaylist.initialIndex).isNullOrBlank()) {
+      externalPlaylist.titles[externalPlaylist.initialIndex]
+    } else {
+      getFileName(intent)
+    }
     if (fileName.isBlank()) {
       val mpvTitle = runCatching { MPVLib.getPropertyString("media-title") }.getOrNull()
       fileName = if (!mpvTitle.isNullOrBlank()) mpvTitle else (intent.data?.lastPathSegment ?: "Unknown Video")
     }
     mediaIdentifier = getMediaIdentifier(intent, fileName)
+    viewModel.setMediaTitle(fileName)
+    viewModel.setMediaIdentifier(mediaIdentifier)
 
     jellyfinExternalInfo = xyz.mpv.rex.jellyfin.JellyfinExternalHelper.detect(intent)
 
@@ -489,6 +506,7 @@ class PlayerActivity :
     val isAlreadyPlayingCurrent = !hasPlayableMediaInIntent && !currentMpvPath.isNullOrBlank() && currentMpvPath != "null"
 
     if (hasPlayableMediaInIntent) {
+      activeNetworkStreamId = NetworkStreamingProxy.getInstance().extractStreamId(playableUri)
       if (isManualBackgroundPlayback || isInBackgroundPlayback) {
         isManualBackgroundPlayback = false
         endBackgroundPlayback()
@@ -505,6 +523,7 @@ class PlayerActivity :
       }
     } else if (isAlreadyPlayingCurrent) {
       Log.d(TAG, "MPV is already playing media: $currentMpvPath. Re-attaching to active session.")
+      activeNetworkStreamId = NetworkStreamingProxy.getInstance().extractStreamId(currentMpvPath)
       isReady = true
       enableVideoAfterBackground()
     }
@@ -751,6 +770,15 @@ class PlayerActivity :
       cleanupAudio()
       cleanupReceivers()
       releaseMediaSession()
+
+      activeNetworkStreamId?.let { streamId ->
+        activeNetworkStreamId = null
+        if (!isManualBackgroundPlayback) {
+          kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
+            NetworkStreamingProxy.getInstance().unregisterStream(streamId)
+          }
+        }
+      }
     }.onFailure { e ->
       Log.e(TAG, "Error during onDestroy", e)
     }
@@ -1357,7 +1385,14 @@ class PlayerActivity :
    */
   private fun parsePathFromIntent(intent: Intent): String? =
     when (intent.action) {
-      Intent.ACTION_VIEW -> intent.data?.resolveUri(this)
+      Intent.ACTION_VIEW -> {
+        val data = intent.data
+        if (data?.scheme.equals("smb", ignoreCase = true)) {
+          intent.dataString ?: data.toString()
+        } else {
+          data?.resolveUri(this)
+        }
+      }
       Intent.ACTION_SEND -> parsePathFromSendIntent(intent)
       else -> intent.getStringExtra("uri")
     }
@@ -1525,11 +1560,28 @@ class PlayerActivity :
    * @return A playable URI string, or null if unable to resolve
    */
   private fun getPlayableUri(intent: Intent): String? {
-    val uri = parsePathFromIntent(intent) ?: return null
-    return if (uri.startsWith("content://")) {
-      uri.toUri().openContentFd(this)
-    } else {
-      uri
+    val uri = parsePathFromIntent(intent)
+      ?: (if (intent.action == Intent.ACTION_VIEW || intent.action == null) {
+        FolderPlaylistOps.extractExternalPlaylist(intent)?.let { playlist ->
+          playlist.items.getOrNull(playlist.initialIndex)?.let { firstUri ->
+            if (firstUri.scheme.equals("smb", ignoreCase = true)) {
+              firstUri.toString()
+            } else {
+              firstUri.resolveUri(this) ?: firstUri.toString()
+            }
+          }
+        }
+      } else null)
+      ?: return null
+
+    return when {
+      uri.startsWith("content://") -> uri.toUri().openContentFd(this)
+      uri.startsWith("smb://", ignoreCase = true) -> {
+        runBlocking(Dispatchers.IO) {
+          FolderPlaylistOps.resolveSmbUri(uri)?.url
+        } ?: uri
+      }
+      else -> uri
     }
   }
 
@@ -1891,8 +1943,8 @@ class PlayerActivity :
 
     // Update VM and services with exact loaded duration
     val loadedDurationSec = MPVLib.getPropertyDouble("duration") ?: 0.0
+    viewModel.onFileLoaded(loadedDurationSec)
     if (loadedDurationSec > 0.0) {
-      viewModel.onFileLoaded(loadedDurationSec)
       val loadedDurationMs = (loadedDurationSec * 1000).toLong()
       miniPlayerStateManager.updateState(durationMs = loadedDurationMs)
       updateMediaSessionMetadata(title = fileName, durationMs = loadedDurationMs)
@@ -2561,25 +2613,29 @@ class PlayerActivity :
     // Update the intent first so getFileName uses the new intent data
     setIntent(intent)
 
-    val incomingUri = getPlayableUri(intent)
+    val hasIntentMedia = intent.data != null || intent.hasExtra("video_list") || parsePathFromIntent(intent) != null
     val incomingFileName = getFileName(intent).ifBlank { intent.data?.lastPathSegment ?: "" }
     val incomingMediaIdentifier = if (incomingFileName.isNotBlank()) getMediaIdentifier(intent, incomingFileName) else ""
 
-    val isSameMedia = isReady && incomingUri != null &&
+    val isSameMedia = isReady && hasIntentMedia &&
       ((incomingMediaIdentifier.isNotBlank() && incomingMediaIdentifier == mediaIdentifier) ||
        (incomingFileName.isNotBlank() && incomingFileName == fileName))
 
     // If expanding active session without intent media, or if the exact same media is already active in foreground
-    if (isReady && (incomingUri == null || (isSameMedia && !isInBackgroundPlayback && !isManualBackgroundPlayback))) {
+    if (isReady && (!hasIntentMedia || (isSameMedia && !isInBackgroundPlayback && !isManualBackgroundPlayback))) {
       Log.d(TAG, "onNewIntent: current media already playing or expanding active session, restoring player without reload")
       enableVideoAfterBackground()
       @Suppress("DEPRECATION")
       overridePendingTransition(android.R.anim.fade_in, 0)
       return
     }
+    val externalPlaylist = if (intent.action == Intent.ACTION_VIEW || intent.action == null) {
+      FolderPlaylistOps.extractExternalPlaylist(intent)
+    } else null
     // Check if this intent has playlist information
     val hasPlaylistExtras = intent.hasExtra("playlist_id") ||
-      intent.hasExtra("playlist")
+      intent.hasExtra("playlist") ||
+      externalPlaylist != null
 
     // Clean up background playback state when loading a different video
     if (isManualBackgroundPlayback || isInBackgroundPlayback) {
@@ -2605,7 +2661,15 @@ class PlayerActivity :
 
     // Only update playlist state if we have new playlist information
     // This prevents losing the playlist when coming back from notification/PiP
-    if (hasPlaylistExtras || playlistFromIntent.isNotEmpty()) {
+    if (externalPlaylist != null) {
+      viewModel.playlistManager.setPlaylist(
+        items = externalPlaylist.items,
+        index = externalPlaylist.initialIndex,
+        titles = externalPlaylist.titles
+      )
+      Log.d(TAG, "onNewIntent: Loaded external playlist: ${externalPlaylist.items.size} items at index ${externalPlaylist.initialIndex}")
+      updateMiniPlayerPlaylistState()
+    } else if (hasPlaylistExtras || playlistFromIntent.isNotEmpty()) {
       val newPlaylistId = intent.getIntExtra("playlist_id", -1).takeIf { it != -1 }
       val newPlaylistIndex = intent.getIntExtra("playlist_index", 0)
       val titlesFromIntent = intent.getStringArrayListExtra("playlist_titles") ?: emptyList()
@@ -2653,23 +2717,21 @@ class PlayerActivity :
 
     // Auto-generate playlist from folder if playlist mode is enabled and no playlist_id
     if (viewModel.playlistManager.playlist.value.isEmpty() && viewModel.playlistManager.playlistId == null && playerPreferences.playlistMode.get()) {
-      val launchSource = intent.getStringExtra("launch_source")
-      val path = parsePathFromIntent(intent)
-      if (path != null) {
-        if (launchSource == "media_library_list") {
-          generatePlaylistFromMediaLibrary(path)
-        } else {
-          generatePlaylistFromFolder(path)
-        }
-      }
+      autoGeneratePlaylist(intent)
     }
 
     // Extract the new fileName before loading the file
-    fileName = getFileName(intent)
+    fileName = if (externalPlaylist != null && !externalPlaylist.titles.getOrNull(externalPlaylist.initialIndex).isNullOrBlank()) {
+      externalPlaylist.titles[externalPlaylist.initialIndex]
+    } else {
+      getFileName(intent)
+    }
     if (fileName.isBlank()) {
       fileName = intent.data?.lastPathSegment ?: "Unknown Video"
     }
     mediaIdentifier = getMediaIdentifier(intent, fileName)
+    viewModel.setMediaTitle(fileName)
+    viewModel.setMediaIdentifier(mediaIdentifier)
     jellyfinExternalInfo = xyz.mpv.rex.jellyfin.JellyfinExternalHelper.detect(intent)
 
     // Synchronously set orientation for the new file before displaying activity
@@ -2680,6 +2742,8 @@ class PlayerActivity :
 
     // Load the new file
     getPlayableUri(intent)?.let { uriStr ->
+      switchActiveNetworkStream(uriStr)
+
       val parsedUri = runCatching { Uri.parse(uriStr) }.getOrNull()
       val fastDurationMs = if (parsedUri != null) getFastDurationMsForUri(parsedUri) else 0L
       val fastDurationSec = if (fastDurationMs > 0L) fastDurationMs / 1000f else null
@@ -3613,6 +3677,12 @@ class PlayerActivity :
   }
 
   /**
+   * Bumped on every SMB playlist navigation so a resolve that finishes late, after the user has
+   * already pressed Next again, is discarded instead of loading on top of the newer one.
+   */
+  private var smbResolveToken = 0
+
+  /**
    * Internal method to load a playlist item
    */
   private fun loadPlaylistItemInternal(index: Int) {
@@ -3622,13 +3692,66 @@ class PlayerActivity :
       return
     }
 
+    val uri = playlist[index]
+    if (uri.scheme.equals("smb", ignoreCase = true)) {
+      val token = ++smbResolveToken
+      lifecycleScope.launch {
+        val stream = withContext(Dispatchers.IO) {
+          runCatching { FolderPlaylistOps.resolveSmbUri(uri.toString()) }
+            .onFailure { Log.w(TAG, "Could not resolve the next network playlist item", it) }
+            .getOrNull()
+        }
+        if (token != smbResolveToken) {
+          stream?.streamId?.takeIf { it.isNotEmpty() }?.let { streamId ->
+            lifecycleScope.launch(Dispatchers.IO) {
+              NetworkStreamingProxy.getInstance().unregisterStream(streamId)
+            }
+          }
+          return@launch
+        }
+        if (stream == null) {
+          viewModel.showToast(getString(R.string.network_share_unreachable))
+          return@launch
+        }
+        loadResolvedPlaylistItem(
+          index = index,
+          uri = uri,
+          playableUri = stream.url,
+          mediaIdentifierOverride = "network_${stream.connectionId}_${stream.filePath.hashCode()}",
+        )
+      }
+      return
+    }
+
+    loadResolvedPlaylistItem(index, uri, uri.resolveUri(this) ?: uri.toString())
+  }
+
+  private fun switchActiveNetworkStream(playableUri: String?) {
+    val newStreamId = NetworkStreamingProxy.getInstance().extractStreamId(playableUri)
+    val oldStreamId = activeNetworkStreamId
+    if (oldStreamId != null && oldStreamId != newStreamId) {
+      lifecycleScope.launch(Dispatchers.IO) {
+        NetworkStreamingProxy.getInstance().unregisterStream(oldStreamId)
+      }
+    }
+    activeNetworkStreamId = newStreamId
+  }
+
+  /**
+   * Loads a playlist item whose playable URI is already known.
+   */
+  private fun loadResolvedPlaylistItem(
+    index: Int,
+    uri: Uri,
+    playableUri: String,
+    mediaIdentifierOverride: String? = null,
+  ) {
     // Save current video's playback state before switching
     if (fileName.isNotBlank()) {
       saveVideoPlaybackState(fileName)
     }
 
-    val uri = playlist[index]
-    val playableUri = uri.resolveUri(this) ?: uri.toString()
+    switchActiveNetworkStream(playableUri)
 
     // Update index in manager
     viewModel.playlistManager.updateIndex(index)
@@ -3637,7 +3760,9 @@ class PlayerActivity :
     val customTitle = viewModel.playlistManager.getTitleAt(index)
     fileName = if (!customTitle.isNullOrBlank()) customTitle else getFileNameFromUri(uri)
     // Generate new media identifier for playback state
-    mediaIdentifier = getMediaIdentifierFromUri(uri, fileName)
+    mediaIdentifier = mediaIdentifierOverride ?: getMediaIdentifierFromUri(uri, fileName)
+    viewModel.setMediaTitle(fileName)
+    viewModel.setMediaIdentifier(mediaIdentifier)
 
     val cachedDurationMs = viewModel.playlistManager.getDurationAt(index)
     val fastDurationMs = if (cachedDurationMs > 0L) cachedDurationMs else getFastDurationMsForUri(uri)
@@ -3951,13 +4076,7 @@ class PlayerActivity :
     }
 
     val uri = extractUriFromIntent(intent)
-    return if (uri != null && (uri.scheme?.startsWith("http") == true || uri.scheme == "rtmp" || uri.scheme == "ftp" || uri.scheme == "rtsp" || uri.scheme == "mms")) {
-      // For remote protocols: hash the URI so position is per-episode or per-stream.
-      "${fileName}_${uri.toString().hashCode()}"
-    } else {
-      // For local/file uris and unknown: just use fileName.
-      fileName
-    }
+    return if (uri != null) getMediaIdentifierFromUri(uri, fileName) else fileName
   }
 
   /**
@@ -3967,7 +4086,7 @@ class PlayerActivity :
    * For network URIs (http/https/rtmp/etc.), uses a hash of the URI string to distinguish different streams.
    */
   private fun getMediaIdentifierFromUri(uri: Uri, fileName: String): String {
-    return if (uri.scheme?.startsWith("http") == true || uri.scheme == "rtmp" || uri.scheme == "ftp" || uri.scheme == "rtsp" || uri.scheme == "mms") {
+    return if (uri.scheme?.startsWith("http") == true || uri.scheme == "rtmp" || uri.scheme == "ftp" || uri.scheme == "rtsp" || uri.scheme == "mms" || uri.scheme.equals("smb", ignoreCase = true)) {
       "${fileName}_${uri.toString().hashCode()}"
     } else {
       fileName
@@ -3993,6 +4112,61 @@ class PlayerActivity :
         }
       }.onFailure { e ->
         Log.e(TAG, "Failed to auto-generate library playlist", e)
+      }
+    }
+  }
+
+  /**
+   * Picks the sibling source that matches how this file was launched.
+   *
+   * SMB is checked first because for those launches [parsePathFromIntent] yields a local proxy URL,
+   * which has no folder to scan: our own browser passes the share-relative path plus the connection
+   * it came from, and external file managers that proxy SMB themselves (MiXplorer) put the real
+   * location in a `real_path` extra. Without either, nothing changes for local/content launches.
+   */
+  private fun autoGeneratePlaylist(intent: Intent) {
+    val networkFilePath = intent.getStringExtra("network_file_path")
+    val networkConnectionId = intent.getLongExtra("network_connection_id", -1L)
+    val smbUri = intent.dataString?.takeIf { it.startsWith("smb://", ignoreCase = true) }
+      ?: intent.getStringExtra("real_path")?.takeIf { it.startsWith("smb://", ignoreCase = true) }
+
+    when {
+      networkFilePath != null && networkConnectionId != -1L ->
+        generatePlaylistFromNetworkFolder {
+          FolderPlaylistOps.generateNetworkFolderPlaylist(networkConnectionId, networkFilePath)
+        }
+
+      smbUri != null ->
+        generatePlaylistFromNetworkFolder { FolderPlaylistOps.generateNetworkFolderPlaylist(smbUri) }
+
+      else -> {
+        val path = parsePathFromIntent(intent) ?: return
+        if (intent.getStringExtra("launch_source") == "media_library_list") {
+          generatePlaylistFromMediaLibrary(path)
+        } else {
+          generatePlaylistFromFolder(path)
+        }
+      }
+    }
+  }
+
+  /**
+   * Builds a playlist by listing a remote folder. A share we cannot list means no playlist — the
+   * user asked to watch a file, not to build a playlist, so playback is left alone and it is only
+   * logged.
+   */
+  private fun generatePlaylistFromNetworkFolder(generate: suspend () -> Result<Pair<List<Uri>, Int>?>) {
+    lifecycleScope.launch(Dispatchers.IO) {
+      val (newPlaylist, newIndex) = generate()
+        .getOrElse { e ->
+          Log.w(TAG, "Could not list the remote folder for an auto-playlist", e)
+          return@launch
+        } ?: return@launch
+
+      withContext(Dispatchers.Main) {
+        viewModel.playlistManager.setPlaylist(items = newPlaylist, index = newIndex)
+        Log.d(TAG, "Auto-playlist generated from network folder: ${newPlaylist.size} items")
+        updateMiniPlayerPlaylistState()
       }
     }
   }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -186,7 +186,7 @@ class PlayerViewModel(
     get() = if (_externalAudioTracks.isNotEmpty() && (_primaryVideoDuration.value ?: 0.0) > 0.0) {
       _primaryVideoDuration.value?.toInt()
     } else {
-      _preciseDuration.value.takeIf { it > 0f }?.toInt() ?: _mpvDuration
+      _preciseDuration.value.takeIf { it > 0f }?.toInt() ?: _mpvDuration.takeIf { !_isLoadingFile.value }
     }
 
   // External audio state and duration tracking
@@ -203,6 +203,16 @@ class PlayerViewModel(
   // High-precision position and duration for smooth seekbar
   private val _precisePosition = MutableStateFlow(0f)
   val precisePosition = _precisePosition.asStateFlow()
+
+  /**
+   * True between asking mpv to load a file and mpv reporting it loaded.
+   *
+   * mpv keeps answering `time-pos`/`duration` for the *outgoing* file until the new one is open,
+   * which on a network stream is seconds rather than milliseconds. Without this gate the seek bar
+   * shows the previous video's position and length while the next one buffers.
+   */
+  private val _isLoadingFile = MutableStateFlow(false)
+  val isLoadingFile: StateFlow<Boolean> = _isLoadingFile.asStateFlow()
 
   private val _preciseDuration = MutableStateFlow(0f)
   val preciseDuration = _preciseDuration.asStateFlow()
@@ -343,7 +353,19 @@ class PlayerViewModel(
   val remainingTime: StateFlow<Int> = _remainingTime.asStateFlow()
 
   // Media title for subtitle association
-  var currentMediaTitle: String = ""
+  private val _mediaTitle = MutableStateFlow("")
+  val mediaTitle: StateFlow<String> = _mediaTitle.asStateFlow()
+
+  private val _mediaIdentifier = MutableStateFlow("")
+  val mediaIdentifier: StateFlow<String> = _mediaIdentifier.asStateFlow()
+
+  fun setMediaIdentifier(identifier: String) {
+    _mediaIdentifier.value = identifier
+  }
+
+  var currentMediaTitle: String
+    get() = _mediaTitle.value
+    set(value) { _mediaTitle.value = value }
   private var lastAutoSelectedMediaTitle: String? = null
 
   // External subtitle tracking
@@ -515,7 +537,7 @@ class PlayerViewModel(
       }.collectLatest { shouldPoll ->
         if (shouldPoll) {
           while (isActive) {
-            val time = MPVLib.getPropertyDouble("time-pos")
+            val time = if (_isLoadingFile.value) null else MPVLib.getPropertyDouble("time-pos")
             if (time != null) {
               val primaryDur = _primaryVideoDuration.value
               if (_externalAudioTracks.isNotEmpty() && primaryDur != null && primaryDur > 0) {
@@ -537,7 +559,7 @@ class PlayerViewModel(
     // Update precise position whenever integer time-pos changes in MPV (e.g. seeking while paused or controls hidden)
     viewModelScope.launch {
       MPVLib.propInt["time-pos"].collect { _ ->
-        val time = MPVLib.getPropertyDouble("time-pos")
+        val time = if (_isLoadingFile.value) null else MPVLib.getPropertyDouble("time-pos")
         if (time != null) {
           val primaryDur = _primaryVideoDuration.value
           if (_externalAudioTracks.isNotEmpty() && primaryDur != null && primaryDur > 0) {
@@ -705,6 +727,7 @@ class PlayerViewModel(
   }
 
   fun prepareForFileLoad(initialDurationSec: Float? = null) {
+    _isLoadingFile.value = true
     resetExternalAudioTracks()
     _precisePosition.value = 0f
     if (initialDurationSec != null && initialDurationSec > 0f) {
@@ -726,6 +749,7 @@ class PlayerViewModel(
   }
 
   fun onFileLoaded(durationSec: Double) {
+    _isLoadingFile.value = false
     if (durationSec > 0) {
       if (_externalAudioTracks.isEmpty()) {
         _primaryVideoDuration.value = durationSec

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/PlayerControls.kt
@@ -78,6 +78,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -205,11 +206,23 @@ fun PlayerControls(
   val showSeekTime by playerPreferences.showSeekTimeWhileSeeking.collectAsState()
   val showSpeedIndicatorOverlay by playerPreferences.showSpeedIndicatorOverlay.collectAsState()
   val hideOsdText by playerPreferences.hideOsdText.collectAsState()
+  val isLoadingFile by viewModel.isLoadingFile.collectAsState()
+  val mediaTitle by viewModel.mediaTitle.collectAsState()
+  val mediaIdentifier by viewModel.mediaIdentifier.collectAsState()
+  val playlistItems by viewModel.playlistManager.playlist.collectAsState()
+  val playlistIndex by viewModel.playlistManager.currentIndex.collectAsState()
   var isSeeking by remember { mutableStateOf(false) }
   var dragStartValue by remember { mutableStateOf(-1f) }
   var isCloseToStart by remember { mutableStateOf(false) }
   var changeCount by remember { mutableStateOf(0) }
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
+
+  LaunchedEffect(playlistIndex, mediaIdentifier.ifBlank { mediaTitle }) {
+    isSeeking = false
+    dragStartValue = -1f
+    isCloseToStart = false
+    changeCount = 0
+  }
   val seekText by viewModel.seekText.collectAsState()
   val currentChapter by MPVLib.propInt["chapter"].collectAsState()
   val mpvDecoder by MPVLib.propString["hwdec-current"].collectAsState()
@@ -1022,8 +1035,10 @@ fun PlayerControls(
                 else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
               )
 
-              if (viewModel.hasPlaylistSupport()) {
-                androidx.compose.foundation.layout.Row(
+              if (playlistItems.isNotEmpty() && playlistIndex >= 0 && viewModel.hasPlaylistSupport()) {
+                val canGoPrevious = viewModel.hasPrevious()
+                val canGoNext = viewModel.hasNext()
+                Row(
                   horizontalArrangement = Arrangement.spacedBy(24.dp),
                   verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -1033,6 +1048,7 @@ fun PlayerControls(
                         .size(48.dp)
                         .clip(CircleShape)
                         .clickable(
+                          enabled = canGoPrevious,
                           onClick = {
                             resetControlsTimestamp = System.currentTimeMillis()
                             viewModel.handleMediaPrevious()
@@ -1056,7 +1072,7 @@ fun PlayerControls(
                       imageVector = Icons.Default.SkipPrevious,
                       contentDescription = "Previous",
                       tint =
-                        if (viewModel.hasPrevious()) {
+                        if (canGoPrevious) {
                           contentColor
                         } else {
                           contentColor.copy(alpha = 0.38f)
@@ -1106,6 +1122,7 @@ fun PlayerControls(
                         .size(48.dp)
                         .clip(CircleShape)
                         .clickable(
+                          enabled = canGoNext,
                           onClick = {
                             resetControlsTimestamp = System.currentTimeMillis()
                             viewModel.handleMediaNext()
@@ -1129,7 +1146,7 @@ fun PlayerControls(
                       imageVector = Icons.Default.SkipNext,
                       contentDescription = "Next",
                       tint =
-                        if (viewModel.hasNext()) {
+                        if (canGoNext) {
                           contentColor
                         } else {
                           contentColor.copy(alpha = 0.38f)
@@ -1229,6 +1246,7 @@ fun PlayerControls(
         ) {
           val invertDuration by playerPreferences.invertDuration.collectAsState()
           val seekbarStyle by appearancePreferences.seekbarStyle.collectAsState()
+          val effectiveDuration = if (preciseDuration > 0f) preciseDuration else if (isLoadingFile) 0f else duration?.toFloat() ?: 0f
 
           // Calculate read-ahead position (current position + buffered cache time)
           // No keys for remember, derivedStateOf reactively tracks read dependencies
@@ -1236,7 +1254,7 @@ fun PlayerControls(
             derivedStateOf {
               val currentPos = position?.toFloat() ?: 0f
               val cacheDuration = demuxerCacheDuration ?: 0f
-              val totalDuration = if (preciseDuration > 0) preciseDuration else duration?.toFloat() ?: 0f
+              val totalDuration = effectiveDuration
               val isBuffering = cacheBufferingState ?: 0
 
               // If cache duration is available and valid, use it (up to 60 seconds)
@@ -1253,61 +1271,63 @@ fun PlayerControls(
             }
           }
 
-          SeekbarWithTimers(
-            position = { precisePosition },
-            duration = if (preciseDuration > 0) preciseDuration else duration?.toFloat() ?: 0f,
-            onValueChange = { newValue ->
-              if (dragStartValue == -1f) {
-                dragStartValue = precisePosition
-                changeCount = 0
-              }
-              changeCount++
-              isSeeking = true
-              resetControlsTimestamp = System.currentTimeMillis()
+          key(playlistIndex, mediaIdentifier.ifBlank { mediaTitle }) {
+            SeekbarWithTimers(
+              position = { precisePosition },
+              duration = effectiveDuration,
+              onValueChange = { newValue ->
+                if (dragStartValue == -1f) {
+                  dragStartValue = precisePosition
+                  changeCount = 0
+                }
+                changeCount++
+                isSeeking = true
+                resetControlsTimestamp = System.currentTimeMillis()
 
-              val durationFloat = if (preciseDuration > 0) preciseDuration else duration?.toFloat() ?: 0f
-              val threshold = (durationFloat * 0.08f).coerceIn(15f, 400f)
-              val close = enableReleaseToCancel && changeCount > 1 && abs(newValue - dragStartValue) < threshold
+                val durationFloat = effectiveDuration
+                val threshold = (durationFloat * 0.08f).coerceIn(15f, 400f)
+                val close = enableReleaseToCancel && changeCount > 1 && abs(newValue - dragStartValue) < threshold
 
-              if (close) {
-                isCloseToStart = true
-                viewModel.playerUpdate.value = PlayerUpdates.ShowText("Release to cancel")
-              } else {
+                if (close) {
+                  isCloseToStart = true
+                  viewModel.playerUpdate.value = PlayerUpdates.ShowText("Release to cancel")
+                } else {
+                  if (isCloseToStart) {
+                    isCloseToStart = false
+                    viewModel.playerUpdate.value = PlayerUpdates.None
+                  }
+                }
+                viewModel.seekTo(newValue.toInt())
+                viewModel.autoHideControls()
+              },
+              onValueChangeFinished = {
                 if (isCloseToStart) {
-                  isCloseToStart = false
+                  viewModel.seekTo(dragStartValue.toInt())
                   viewModel.playerUpdate.value = PlayerUpdates.None
                 }
-              }
-              viewModel.seekTo(newValue.toInt())
-              viewModel.autoHideControls()
-            },
-            onValueChangeFinished = {
-              if (isCloseToStart) {
-                viewModel.seekTo(dragStartValue.toInt())
-                viewModel.playerUpdate.value = PlayerUpdates.None
-              }
-              isSeeking = false
-              dragStartValue = -1f
-              isCloseToStart = false
-              changeCount = 0
-              resetControlsTimestamp = System.currentTimeMillis()
-              viewModel.showControls()
-            },
-            timersInverted = Pair(false, invertDuration),
-            durationTimerOnCLick = {
-              resetControlsTimestamp = System.currentTimeMillis()
-              playerPreferences.invertDuration.set(!invertDuration)
-            },
-            positionTimerOnClick = {},
-            chapters = chapters.toImmutableList(),
-            paused = paused ?: false,
-            readAheadValue = { readAheadPosition },
-            seekbarStyle = seekbarStyle,
-            loopStart = abLoopA?.toFloat(),
-            loopEnd = abLoopB?.toFloat(),
-            isGestureSeeking = isGestureSeeking,
-            isCancelActive = isCloseToStart
-          )
+                isSeeking = false
+                dragStartValue = -1f
+                isCloseToStart = false
+                changeCount = 0
+                resetControlsTimestamp = System.currentTimeMillis()
+                viewModel.showControls()
+              },
+              timersInverted = Pair(false, invertDuration),
+              durationTimerOnCLick = {
+                resetControlsTimestamp = System.currentTimeMillis()
+                playerPreferences.invertDuration.set(!invertDuration)
+              },
+              positionTimerOnClick = {},
+              chapters = chapters.toImmutableList(),
+              paused = paused ?: false,
+              readAheadValue = { readAheadPosition },
+              seekbarStyle = seekbarStyle,
+              loopStart = abLoopA?.toFloat(),
+              loopEnd = abLoopB?.toFloat(),
+              isGestureSeeking = isGestureSeeking,
+              isCancelActive = isCloseToStart
+            )
+          }
         }
 
         AnimatedVisibility(

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/controls/components/Seekbar.kt
@@ -153,6 +153,12 @@ fun SeekbarWithTimers(
   LaunchedEffect(Unit) {
     snapshotFlow { position() }.collect { currentPosVal ->
       if (!isUserInteracting && currentPosVal != animatedPosition.value) {
+        if (currentPosVal <= 0.05f) {
+          animatedPosition.snapTo(0f)
+          userPosition = 0f
+          return@collect
+        }
+
         // If we recently interacted (within 2s) and the position is significantly different from the seeked target (>10s),
         // assume it's the old position and ignore it to prevent "back and forth" glitches.
         val timeSinceInteraction = System.currentTimeMillis() - lastInteractionTime
@@ -883,11 +889,12 @@ fun StandardSeekbar(
                 }
             }
     ) {
+        val safeDuration = duration.coerceAtLeast(0.1f)
         Slider(
-            value = if (isUserInteracting) userPosition else position(),
+            value = (if (isUserInteracting) userPosition else position()).coerceIn(0f, safeDuration),
             onValueChange = { /* Handled by custom gestures */ },
             onValueChangeFinished = { /* Handled by custom gestures */ },
-            valueRange = 0f..duration.coerceAtLeast(0.1f),
+            valueRange = 0f..safeDuration,
             modifier = Modifier.fillMaxWidth(),
             interactionSource = interactionSource,
             enabled = false, // Disable built-in interaction
@@ -901,17 +908,17 @@ fun StandardSeekbar(
             val isGlassActive = enableGlassPlayerControls && enableGlassSeekbar
             val outerRadiusDp = trackHeightDp / 2
 
-            val trackModifier = if (isGlassActive) {
-                Modifier.background(Color.White.copy(alpha = 0.15f), RoundedCornerShape(outerRadiusDp))
-            } else {
-                Modifier
-            }
+            val trackModifier = Modifier
+                .fillMaxWidth()
+                .height(trackHeightDp)
+                .background(
+                    color = if (isGlassActive) Color.White.copy(alpha = 0.15f) 
+                            else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = disabledAlpha),
+                    shape = RoundedCornerShape(outerRadiusDp)
+                )
 
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(trackHeightDp)
-                    .then(trackModifier)
+                modifier = trackModifier
             ) {
                 Canvas(
                     modifier = Modifier.fillMaxSize(),
@@ -943,7 +950,7 @@ fun StandardSeekbar(
                     val thumbGapStart = (thumbPx - gapHalf).coerceIn(0f, size.width)
                     val thumbGapEnd = (thumbPx + gapHalf).coerceIn(0f, size.width)
                     
-                    val chapterGaps = if (showSeekbarChapters) {
+                    val chapterGaps = if (showSeekbarChapters && duration > 0f) {
                         chapters
                             .map { (it.start / duration).coerceIn(0f, 1f) * size.width }
                             .filter { it > 0f && it < size.width }

--- a/app/src/main/kotlin/xyz/mpv/rex/utils/media/FolderPlaylistOps.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/utils/media/FolderPlaylistOps.kt
@@ -1,11 +1,19 @@
 package xyz.mpv.rex.utils.media
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.Parcelable
 import androidx.core.net.toUri
+import xyz.mpv.rex.domain.network.NetworkConnection
+import xyz.mpv.rex.domain.network.NetworkFile
+import xyz.mpv.rex.domain.network.NetworkProtocol
 import xyz.mpv.rex.preferences.BrowserPreferences
 import xyz.mpv.rex.preferences.FolderSortType
 import xyz.mpv.rex.repository.MediaFileRepository
+import xyz.mpv.rex.repository.NetworkRepository
+import xyz.mpv.rex.ui.browser.networkstreaming.proxy.NetworkStreamingProxy
 import xyz.mpv.rex.utils.sort.SortUtils
 import xyz.mpv.rex.utils.storage.FileFilterUtils
 import xyz.mpv.rex.utils.storage.FileTypeUtils
@@ -21,6 +29,9 @@ import org.koin.core.component.inject
  */
 object FolderPlaylistOps : KoinComponent {
   private val browserPreferences: BrowserPreferences by inject()
+  private val networkRepository: NetworkRepository by inject()
+
+  private const val SMB_SCHEME = "smb://"
 
   /**
    * Generates a playlist of URIs in the same folder as [currentPath].
@@ -142,5 +153,325 @@ object FolderPlaylistOps : KoinComponent {
       }
     }
     return null
+  }
+
+  /**
+   * Generates a playlist of `smb://` URIs sitting beside [smbPath] in the same remote folder.
+   *
+   * [smbPath] comes from an external file manager (MiXplorer's `real_path` extra); the credentials
+   * come from a saved connection matched on host + share. Without one there is nothing we can list,
+   * which is a "no playlist" answer, not an error.
+   *
+   * @return `failure` when the share could not be listed, `success(null)` when there is no playlist
+   *   to build (not an SMB path, no saved connection, or no siblings).
+   */
+  /**
+   * Represents an external playlist parsed from an external file manager intent (MX Player API).
+   */
+  data class ExternalPlaylist(
+    val items: List<Uri>,
+    val titles: List<String>,
+    val initialIndex: Int,
+    val isExplicit: Boolean,
+  )
+
+  /**
+   * Extracts external playlist extras adhering to the MX Player intent API standard:
+   * `video_list`, `video_list.name`, and `video_list_is_explicit`.
+   */
+  fun extractExternalPlaylist(intent: Intent): ExternalPlaylist? {
+    val rawList: List<Uri> = run {
+      val parcelableList = runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          intent.getParcelableArrayListExtra("video_list", Uri::class.java)
+            ?: intent.getParcelableArrayListExtra("video_list", Parcelable::class.java)?.filterIsInstance<Uri>()
+        } else {
+          @Suppress("DEPRECATION")
+          intent.getParcelableArrayListExtra<Parcelable>("video_list")?.filterIsInstance<Uri>()
+        }
+      }.getOrNull()?.filterNotNull()
+      if (!parcelableList.isNullOrEmpty()) {
+        return@run parcelableList
+      }
+
+      val array = runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          intent.getParcelableArrayExtra("video_list", Uri::class.java)
+            ?: intent.getParcelableArrayExtra("video_list", Parcelable::class.java)
+        } else {
+          @Suppress("DEPRECATION")
+          intent.getParcelableArrayExtra("video_list")
+        }
+      }.getOrNull()
+      val filteredArray = array?.mapNotNull { it as? Uri }
+      if (!filteredArray.isNullOrEmpty()) {
+        return@run filteredArray
+      }
+
+      val stringUris = (runCatching { intent.getStringArrayExtra("video_list")?.toList() }.getOrNull()
+        ?: runCatching { intent.getStringArrayListExtra("video_list") }.getOrNull())
+        ?.takeIf { it.isNotEmpty() }
+        ?.mapNotNull { str -> str?.takeIf { it.isNotBlank() }?.let { runCatching { Uri.parse(it) }.getOrNull() } }
+      if (!stringUris.isNullOrEmpty()) {
+        return@run stringUris
+      }
+
+      emptyList()
+    }
+
+    if (rawList.isEmpty()) return null
+
+    val rawNames: List<String>? = runCatching {
+      intent.getStringArrayExtra("video_list.name")?.filterNotNull()?.takeIf { it.isNotEmpty() }
+        ?: intent.getStringArrayListExtra("video_list.name")?.filterNotNull()?.takeIf { it.isNotEmpty() }
+        ?: intent.getCharSequenceArrayExtra("video_list.name")?.mapNotNull { it?.toString() }?.takeIf { it.isNotEmpty() }
+        ?: intent.getCharSequenceArrayListExtra("video_list.name")?.mapNotNull { it?.toString() }?.takeIf { it.isNotEmpty() }
+    }.getOrNull()
+
+    val isExplicit = intent.getBooleanExtra("video_list_is_explicit", false)
+
+    val currentData = intent.data
+    val initialIndex = currentData?.let { dataUri ->
+      rawList.indexOfFirst { it == dataUri || it.toString().equals(dataUri.toString(), ignoreCase = true) }
+        .takeIf { it >= 0 }
+        ?: dataUri.path?.trimEnd('/')?.let { cleanDataPath ->
+          rawList.indexOfFirst { it.path?.trimEnd('/')?.equals(cleanDataPath, ignoreCase = true) == true }.takeIf { it >= 0 }
+        }
+    } ?: 0
+
+    val titles = rawList.mapIndexed { index, uri ->
+      rawNames?.getOrNull(index)?.takeIf { it.isNotBlank() }
+        ?: uri.lastPathSegment?.takeIf { it.isNotBlank() }
+        ?: "Video ${index + 1}"
+    }
+
+    return ExternalPlaylist(
+      items = rawList,
+      titles = titles,
+      initialIndex = initialIndex,
+      isExplicit = isExplicit,
+    )
+  }
+
+  /**
+   * Generates a playlist of `smb://` URIs sitting beside [smbPath] in the same remote folder.
+   *
+   * [smbPath] comes from an external file manager (MiXplorer's `real_path` extra or direct `smb://` intent);
+   * credentials come from the URI itself or from a saved connection matched on host + share.
+   * If neither exists, falls back to anonymous/guest enumeration.
+   *
+   * @return `failure` when the share could not be listed, `success(null)` when there is no playlist
+   *   to build (not an SMB path or no siblings).
+   */
+  suspend fun generateNetworkFolderPlaylist(smbPath: String): Result<Pair<List<Uri>, Int>?> {
+    val parsed = parseSmbPath(smbPath) ?: return Result.success(null)
+    val connection = resolveNetworkConnection(parsed)
+    return networkSiblings(connection, parsed.filePath, parsed)
+  }
+
+  /**
+   * Same as above for files launched from our own network browser, which already knows which
+   * connection it came from and passes a share-relative path.
+   */
+  suspend fun generateNetworkFolderPlaylist(
+    connectionId: Long,
+    filePath: String,
+  ): Result<Pair<List<Uri>, Int>?> {
+    val connection = networkRepository.getConnectionById(connectionId) ?: return Result.success(null)
+    if (connection.protocol != NetworkProtocol.SMB) return Result.success(null)
+    return networkSiblings(connection, filePath.trim('/'))
+  }
+
+  /**
+   * A playable local-proxy URL for one `smb://` playlist entry, plus the identity of the remote file
+   * behind it so playback state stays keyed the same way a direct launch keys it.
+   */
+  data class SmbStream(
+    val url: String,
+    val connectionId: Long,
+    val filePath: String,
+    val streamId: String = "",
+  )
+
+  /**
+   * Resolves a [NetworkConnection] for an SMB path:
+   * 1. If embedded credentials (username, password, port) exist in the URI, constructs a transient connection.
+   * 2. Otherwise checks saved connections in [NetworkRepository].
+   * 3. If no saved connection exists, falls back to an anonymous/guest connection.
+   */
+  internal suspend fun resolveNetworkConnection(
+    parsed: SmbPath,
+    netRepo: NetworkRepository? = null,
+  ): NetworkConnection {
+    val isGuest = parsed.username.isNullOrEmpty() && parsed.password.isNullOrEmpty()
+    if (isGuest) {
+      val repository = netRepo ?: runCatching { networkRepository }.getOrNull()
+      val saved = repository?.findSmbConnection(parsed.host, parsed.share)
+      if (saved != null) {
+        return parsed.port?.takeIf { it != saved.port }?.let { saved.copy(port = it) } ?: saved
+      }
+    }
+
+    return NetworkConnection(
+      id = -1L,
+      name = if (isGuest) "Guest SMB" else "Transient SMB",
+      protocol = NetworkProtocol.SMB,
+      host = parsed.host,
+      port = parsed.port ?: NetworkProtocol.SMB.defaultPort,
+      username = parsed.username ?: "",
+      password = parsed.password ?: "",
+      path = parsed.share,
+      isAnonymous = isGuest,
+    )
+  }
+
+  /**
+   * Mints a proxy URL for a single `smb://` playlist entry.
+   *
+   * Deliberately one at a time: [NetworkStreamingProxy.registerStream] builds a client per call.
+   * Previous streams are unregistered by PlayerActivity upon navigation or playback exit.
+   */
+  suspend fun resolveSmbUri(smbPath: String): SmbStream? {
+    val parsed = parseSmbPath(smbPath) ?: return null
+    val connection = resolveNetworkConnection(parsed)
+    val extension = File(parsed.filePath).extension
+    val streamId = "${if (connection.id != -1L) connection.id else "smb"}_${System.currentTimeMillis()}"
+    val url = NetworkStreamingProxy.getInstance().registerStream(
+      streamId = streamId,
+      connection = connection,
+      filePath = parsed.filePath,
+      mimeType = FileTypeUtils.getMimeTypeFromExtension(extension),
+    )
+    return SmbStream(url, connection.id, parsed.filePath, streamId)
+  }
+
+  /**
+   * Orders remote files the way the network browser is configured to show them, so an auto-generated
+   * playlist walks the folder in the order the user is looking at.
+   *
+   * Duration and video count cannot be known without opening every remote file, so both fall back to
+   * the filename. Name is also the tie-break, keeping the browser and the playlist in lockstep when
+   * sizes or timestamps collide.
+   */
+  fun networkFileComparator(): Comparator<NetworkFile> {
+    val byName = Comparator<NetworkFile> { a, b ->
+      SortUtils.NaturalOrderComparator.DEFAULT.compare(a.name, b.name)
+    }
+    val base = when (browserPreferences.networkSortType.get()) {
+      FolderSortType.Date -> compareBy<NetworkFile> { it.lastModified }.then(byName)
+      FolderSortType.Size -> compareBy<NetworkFile> { it.size }.then(byName)
+      else -> byName
+    }
+    return if (browserPreferences.networkSortOrder.get().isAscending) base else base.reversed()
+  }
+
+  /**
+   * Lists [filePath]'s remote folder and turns it into a playlist, mirroring the local rules:
+   * media extensions only, the browser's sort preference, and no playlist for a lone file.
+   */
+  private suspend fun networkSiblings(
+    connection: NetworkConnection,
+    filePath: String,
+    parsed: SmbPath? = null,
+  ): Result<Pair<List<Uri>, Int>?> {
+    val parentPath = filePath.substringBeforeLast('/', "")
+    val files = networkRepository.listFiles(connection, parentPath)
+      .getOrElse { return Result.failure(it) }
+
+    val siblings = files
+      .filter {
+        !it.isDirectory &&
+          FileTypeUtils.isMediaFile(File(it.name)) &&
+          !FileFilterUtils.shouldSkipFile(File(it.name))
+      }
+      .sortedWith(networkFileComparator())
+
+    if (siblings.size <= 1) return Result.success(null)
+
+    val index = siblings.indexOfFirst { it.path.equals(filePath, ignoreCase = true) }
+    if (index == -1) return Result.success(null)
+
+    val authPart = if (parsed != null && !parsed.username.isNullOrEmpty()) {
+      "${parsed.username}${if (!parsed.password.isNullOrEmpty()) ":${parsed.password}" else ""}@"
+    } else ""
+    val effectivePort = (parsed?.port?.takeIf { it > 0 } ?: connection.port).takeIf { it > 0 && it != 445 }
+    val portPart = if (effectivePort != null) ":$effectivePort" else ""
+    val base = "$SMB_SCHEME$authPart${connection.host}$portPart/${connection.path.trim('/')}/"
+    return Result.success(siblings.map { (base + it.path).toUri() } to index)
+  }
+
+  internal data class SmbPath(
+    val host: String,
+    val share: String,
+    val filePath: String,
+    val port: Int? = null,
+    val username: String? = null,
+    val password: String? = null,
+  )
+
+  /**
+   * Splits `smb://[[user[:pass]@]host[:port]]/share/dir/file.ext` by hand.
+   *
+   * String surgery on purpose: external file managers hand over raw, unencoded spaces and
+   * parentheses, which `Uri.parse` does not treat as a path. Percent escapes are left untouched for
+   * the same reason — the observed input is unencoded, so a literal `%` in a file name must survive.
+   * Extracts embedded username, password, and port when present.
+   */
+  internal fun parseSmbPath(raw: String): SmbPath? {
+    if (!raw.startsWith(SMB_SCHEME, ignoreCase = true)) return null
+    val rest = raw.substring(SMB_SCHEME.length)
+    val authority = rest.substringBefore('/')
+    if (authority.isEmpty()) return null
+    val onShare = rest.substringAfter('/', "")
+    val share = onShare.substringBefore('/')
+    if (share.isEmpty()) return null
+    val filePath = onShare.substringAfter('/', "")
+    if (filePath.isEmpty()) return null
+
+    var username: String? = null
+    var password: String? = null
+    val hostPort: String
+
+    if (authority.contains('@')) {
+      val userInfo = authority.substringBeforeLast('@')
+      hostPort = authority.substringAfterLast('@')
+      if (userInfo.isNotEmpty()) {
+        val parts = userInfo.split(':', limit = 2)
+        username = parts[0]
+        password = parts.getOrNull(1)
+      }
+    } else {
+      hostPort = authority
+    }
+
+    val host: String
+    var port: Int? = null
+
+    if (hostPort.startsWith('[') && hostPort.contains(']')) {
+      host = hostPort.substringAfter('[').substringBefore(']')
+      val afterBracket = hostPort.substringAfter(']')
+      if (afterBracket.startsWith(':')) {
+        port = afterBracket.removePrefix(":").toIntOrNull()
+      }
+    } else if (hostPort.count { it == ':' } > 1) {
+      host = hostPort
+      port = null
+    } else if (hostPort.contains(':')) {
+      host = hostPort.substringBefore(':')
+      port = hostPort.substringAfter(':').toIntOrNull()
+    } else {
+      host = hostPort
+    }
+
+    if (host.isEmpty()) return null
+
+    return SmbPath(
+      host = host,
+      share = share,
+      filePath = filePath,
+      port = port,
+      username = username,
+      password = password,
+    )
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1161,6 +1161,7 @@
     <!-- Network Streaming Screen -->
     <string name="network_recent_links">Recent Links</string>
     <string name="network_local_network">Local Network</string>
+    <string name="network_share_unreachable">Can\'t reach the network share.</string>
     <string name="network_empty_title">No network connections</string>
     <string name="network_empty_description">Add SMB, FTP, or WebDAV connections to browse network files</string>
     <string name="network_remove_link_action">Remove Link</string>

--- a/app/src/test/kotlin/xyz/mpv/rex/utils/media/ExternalPlaylistTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/utils/media/ExternalPlaylistTest.kt
@@ -1,0 +1,172 @@
+package xyz.mpv.rex.utils.media
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Parcelable
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.mpv.rex.database.dao.NetworkConnectionDao
+import xyz.mpv.rex.domain.network.NetworkConnection
+import xyz.mpv.rex.domain.network.NetworkProtocol
+import xyz.mpv.rex.repository.NetworkRepository
+
+class ExternalPlaylistTest {
+
+  @Test
+  fun `extractExternalPlaylist returns null when video_list is absent`() {
+    val intent = mockk<Intent>(relaxed = true)
+    every { intent.getParcelableArrayListExtra<Uri>(any(), any()) } returns null
+    every { intent.getParcelableArrayListExtra<Parcelable>(any()) } returns null
+    every { intent.getParcelableArrayExtra(any(), any<Class<Uri>>()) } returns null
+    every { intent.getParcelableArrayExtra(any()) } returns null
+    every { intent.getStringArrayExtra(any()) } returns null
+    every { intent.getStringArrayListExtra(any()) } returns null
+
+    val result = FolderPlaylistOps.extractExternalPlaylist(intent)
+    assertNull(result)
+  }
+
+  @Test
+  fun `extractExternalPlaylist extracts parcelable array of URIs and names`() {
+    val uri1 = mockk<Uri>()
+    val uri2 = mockk<Uri>()
+    val uri3 = mockk<Uri>()
+    every { uri1.lastPathSegment } returns "Ep01.mkv"
+    every { uri2.lastPathSegment } returns "Ep02.mkv"
+    every { uri3.lastPathSegment } returns "Ep03.mkv"
+    every { uri1.path } returns "/Videos/Ep01.mkv"
+    every { uri2.path } returns "/Videos/Ep02.mkv"
+    every { uri3.path } returns "/Videos/Ep03.mkv"
+
+    val intent = mockk<Intent>(relaxed = true)
+    every { intent.getParcelableArrayListExtra<Uri>(any(), any()) } returns null
+    every { intent.getParcelableArrayListExtra<Parcelable>(any()) } returns null
+    every { intent.getParcelableArrayExtra("video_list") } returns arrayOf(uri1, uri2, uri3)
+    every { intent.getParcelableArrayExtra("video_list", any<Class<Uri>>()) } returns arrayOf(uri1, uri2, uri3)
+    every { intent.getParcelableArrayExtra("video_list", any<Class<Parcelable>>()) } returns arrayOf(uri1, uri2, uri3)
+    every { intent.getStringArrayExtra("video_list") } returns null
+    every { intent.getStringArrayListExtra("video_list") } returns null
+    every { intent.getStringArrayExtra("video_list.name") } returns arrayOf("Episode 1", "Episode 2", "Episode 3")
+    every { intent.getStringArrayListExtra("video_list.name") } returns null
+    every { intent.getCharSequenceArrayExtra("video_list.name") } returns null
+    every { intent.getCharSequenceArrayListExtra("video_list.name") } returns null
+    every { intent.getBooleanExtra("video_list_is_explicit", false) } returns true
+    every { intent.data } returns uri2
+
+    val playlist = FolderPlaylistOps.extractExternalPlaylist(intent)
+    assertNotNull(playlist)
+    assertEquals(3, playlist!!.items.size)
+    assertEquals(listOf(uri1, uri2, uri3), playlist.items)
+    assertEquals(listOf("Episode 1", "Episode 2", "Episode 3"), playlist.titles)
+    assertEquals(1, playlist.initialIndex)
+    assertTrue(playlist.isExplicit)
+  }
+
+  @Test
+  fun `extractExternalPlaylist falls back to lastPathSegment when names are absent`() {
+    val uri1 = mockk<Uri>()
+    val uri2 = mockk<Uri>()
+    every { uri1.lastPathSegment } returns "video1.mp4"
+    every { uri2.lastPathSegment } returns "video2.mp4"
+    every { uri1.path } returns "/video1.mp4"
+    every { uri2.path } returns "/video2.mp4"
+
+    val intent = mockk<Intent>(relaxed = true)
+    every { intent.getParcelableArrayListExtra<Uri>("video_list", any()) } returns arrayListOf(uri1, uri2)
+    every { intent.getParcelableArrayListExtra<Parcelable>("video_list") } returns arrayListOf(uri1, uri2)
+    every { intent.getStringArrayExtra("video_list.name") } returns null
+    every { intent.getStringArrayListExtra("video_list.name") } returns null
+    every { intent.getCharSequenceArrayExtra("video_list.name") } returns null
+    every { intent.getCharSequenceArrayListExtra("video_list.name") } returns null
+    every { intent.getBooleanExtra("video_list_is_explicit", false) } returns false
+    every { intent.data } returns null
+
+    val playlist = FolderPlaylistOps.extractExternalPlaylist(intent)
+    assertNotNull(playlist)
+    assertEquals(listOf("video1.mp4", "video2.mp4"), playlist!!.titles)
+    assertEquals(0, playlist.initialIndex)
+  }
+
+  @Test
+  fun `resolveNetworkConnection creates transient connection with embedded credentials`() = runBlocking {
+    val smbPath = FolderPlaylistOps.parseSmbPath("smb://alice:secret123@192.168.1.50:4455/share/folder/file.mkv")
+    assertNotNull(smbPath)
+
+    val connection = FolderPlaylistOps.resolveNetworkConnection(smbPath!!)
+    assertEquals("192.168.1.50", connection.host)
+    assertEquals(4455, connection.port)
+    assertEquals("alice", connection.username)
+    assertEquals("secret123", connection.password)
+    assertEquals("share", connection.path)
+    assertEquals(false, connection.isAnonymous)
+  }
+
+  @Test
+  fun `resolveNetworkConnection creates guest connection when no credentials or saved connection`() = runBlocking {
+    val smbPath = FolderPlaylistOps.parseSmbPath("smb://192.168.1.99/public_share/video.mp4")
+    assertNotNull(smbPath)
+
+    val dao = mockk<NetworkConnectionDao>()
+    val repository = NetworkRepository(dao)
+    every { runBlocking { dao.getAllConnectionsList() } } returns emptyList()
+
+    val connection = FolderPlaylistOps.resolveNetworkConnection(smbPath!!, repository)
+    assertEquals("192.168.1.99", connection.host)
+    assertEquals(445, connection.port)
+    assertEquals(true, connection.isAnonymous)
+    assertEquals("public_share", connection.path)
+  }
+
+  @Test
+  fun `findSmbConnection matches case-insensitively and root connections to shares`() = runBlocking {
+    val dao = mockk<NetworkConnectionDao>()
+    val repository = NetworkRepository(dao)
+
+    val rootConnection = NetworkConnection(
+      id = 10,
+      name = "NAS Root",
+      protocol = NetworkProtocol.SMB,
+      host = "MYNAS.LOCAL",
+      port = 445,
+      username = "user",
+      password = "pwd",
+      path = "/",
+    )
+
+    every { runBlocking { dao.getAllConnectionsList() } } returns listOf(rootConnection)
+
+    val matched = repository.findSmbConnection("mynas.local", "movies")
+    assertNotNull(matched)
+    assertEquals(10L, matched!!.id)
+    assertEquals("movies", matched.path)
+  }
+
+  @Test
+  fun `findSmbConnection matches IPv6 bracketed hosts`() = runBlocking {
+    val dao = mockk<NetworkConnectionDao>()
+    val repository = NetworkRepository(dao)
+
+    val ipv6Connection = NetworkConnection(
+      id = 20,
+      name = "IPv6 Server",
+      protocol = NetworkProtocol.SMB,
+      host = "[fe80::1]:445",
+      port = 445,
+      username = "user",
+      password = "pwd",
+      path = "shared",
+    )
+
+    every { runBlocking { dao.getAllConnectionsList() } } returns listOf(ipv6Connection)
+
+    val matched = repository.findSmbConnection("fe80::1", "shared")
+    assertNotNull(matched)
+    assertEquals(20L, matched!!.id)
+  }
+}

--- a/app/src/test/kotlin/xyz/mpv/rex/utils/media/SmbPathParseTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/utils/media/SmbPathParseTest.kt
@@ -1,0 +1,115 @@
+package xyz.mpv.rex.utils.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import xyz.mpv.rex.ui.browser.networkstreaming.proxy.NetworkStreamingProxy
+
+/**
+ * The `real_path` extra external file managers hand us is not a valid URI string, so
+ * [FolderPlaylistOps.parseSmbPath] splits it by hand. These cases guard that.
+ */
+class SmbPathParseTest {
+  @Test
+  fun `parses the raw unencoded path MiXplorer sends`() {
+    val raw = "smb://192.168.0.2/useless/Videos/EXT/Sample.Movie.2026.Director." +
+      "(Dont Stop Go Deeper ...).Part.1.1080p.mp4"
+
+    val parsed = FolderPlaylistOps.parseSmbPath(raw)
+
+    assertEquals(
+      FolderPlaylistOps.SmbPath(
+        host = "192.168.0.2",
+        share = "useless",
+        filePath = "Videos/EXT/Sample.Movie.2026.Director.(Dont Stop Go Deeper ...).Part.1.1080p.mp4",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun `strips credentials and port from the authority`() {
+    val parsed = FolderPlaylistOps.parseSmbPath("smb://user:pass@nas.local:4450/media/a/b.mkv")
+
+    assertEquals("nas.local", parsed?.host)
+    assertEquals("media", parsed?.share)
+    assertEquals("a/b.mkv", parsed?.filePath)
+    assertEquals("user", parsed?.username)
+    assertEquals("pass", parsed?.password)
+    assertEquals(4450, parsed?.port)
+  }
+
+  @Test
+  fun `parses authority with username only and no password`() {
+    val parsed = FolderPlaylistOps.parseSmbPath("smb://admin@nas.local/media/video.mp4")
+
+    assertEquals("nas.local", parsed?.host)
+    assertEquals("media", parsed?.share)
+    assertEquals("video.mp4", parsed?.filePath)
+    assertEquals("admin", parsed?.username)
+    assertNull(parsed?.password)
+    assertNull(parsed?.port)
+  }
+
+  @Test
+  fun `parses authority with port only and no user`() {
+    val parsed = FolderPlaylistOps.parseSmbPath("smb://nas.local:1445/media/video.mp4")
+
+    assertEquals("nas.local", parsed?.host)
+    assertEquals("media", parsed?.share)
+    assertEquals("video.mp4", parsed?.filePath)
+    assertNull(parsed?.username)
+    assertNull(parsed?.password)
+    assertEquals(1445, parsed?.port)
+  }
+
+  @Test
+  fun `parses bracketed IPv6 host with port and credentials`() {
+    val parsed = FolderPlaylistOps.parseSmbPath("smb://user:pass@[fe80::1]:445/share/movie.mkv")
+
+    assertEquals("fe80::1", parsed?.host)
+    assertEquals("share", parsed?.share)
+    assertEquals("movie.mkv", parsed?.filePath)
+    assertEquals("user", parsed?.username)
+    assertEquals("pass", parsed?.password)
+    assertEquals(445, parsed?.port)
+  }
+
+  @Test
+  fun `keeps a file sitting directly in the share root`() {
+    val parsed = FolderPlaylistOps.parseSmbPath("smb://host/share/movie.mp4")
+
+    assertEquals("share", parsed?.share)
+    assertEquals("movie.mp4", parsed?.filePath)
+  }
+
+  @Test
+  fun `rejects anything that is not a full smb file path`() {
+    assertNull(FolderPlaylistOps.parseSmbPath("http://127.0.0.1:34858/924984514"))
+    assertNull(FolderPlaylistOps.parseSmbPath("/storage/emulated/0/Movies/a.mp4"))
+    assertNull(FolderPlaylistOps.parseSmbPath("smb://host"))
+    assertNull(FolderPlaylistOps.parseSmbPath("smb://host/share"))
+    assertNull(FolderPlaylistOps.parseSmbPath("smb:///share/a.mp4"))
+  }
+
+  @Test
+  fun `extracts streamId from local proxy URL`() {
+    assertEquals(
+      "123_456789",
+      NetworkStreamingProxy.getInstance().extractStreamId("http://127.0.0.1:8080/123_456789"),
+    )
+    assertEquals(
+      "smb_123456",
+      NetworkStreamingProxy.getInstance().extractStreamId("http://localhost:8080/smb_123456"),
+    )
+    assertNull(
+      NetworkStreamingProxy.getInstance().extractStreamId("http://192.168.1.10:8080/123_456"),
+    )
+    assertNull(
+      NetworkStreamingProxy.getInstance().extractStreamId(null),
+    )
+    assertNull(
+      NetworkStreamingProxy.getInstance().extractStreamId("content://media/external/video/1"),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

This pull request implements comprehensive support for external playlist intents (MX Player Intent API), robust SMB URI handling and connection matching, stream leak fixes, and visual seek bar reset improvements.

### Key Changes

1. **Universal External Playlist Parser (`video_list`)**:
   - Implements full support for the MX Player Intent API (`video_list`, `video_list.name`, `video_list_is_explicit`) used by Android file managers (Solid Explorer, CX File Explorer, Total Commander, MiXplorer, etc.).
   - Parses parcelable and string URI lists with Android 13+ type safety.
   - Accurately maps the initial track index against `intent.data` or falls back to index 0 per spec.

2. **Robust SMB Resolution & Connection Management**:
   - Parses `smb://` URIs supporting embedded credentials (`user:pass`), custom ports, bracketed IPv6 (`[fe80::1]:445`), and unbracketed IPv6.
   - Preserves targeted share names when matching saved root connections (`/`) in Room database.
   - Prevents client map collisions and socket leaks for ephemeral/guest connections (`id <= 0`) by disconnecting immediately after folder listing.
   - Wraps client disconnects in `NonCancellable` to ensure sockets close properly even upon coroutine cancellation.
   - Uses thread-safe `ConcurrentHashMap` for cached active network clients.

3. **Proxy Stream Lifecycle & Leak Prevention**:
   - Automatically unregisters previous proxy streams on playlist navigation, new intent loading, and activity destroy.
   - Cleans up orphaned proxy streams when rapid playlist navigation triggers token superseding.
   - Restores `activeNetworkStreamId` when re-attaching from background playback.

4. **Seek Bar Visual Reset**:
   - Keys `SeekbarWithTimers` on `(playlistIndex, mediaIdentifier)` so file transitions reliably remount state.
   - Bypasses the 2-second anti-glitch filter when position snaps to `0:00`.
   - Prioritizes fast duration metadata over loading state to prevent seek bar collapse during transitions.
   - Guards Compose `Slider` value bounds and chapter calculation against division by zero on live streams.

### Testing
- All 32 Gradle test suites passed (`testDebugUnitTest`).
- Unit tests added for external playlist parsing, SMB credential/path resolution, and IPv6 host normalization.
- Verified on physical device (`arm64-v8a`) with Solid Explorer and MiXplorer SMB playback.