### PR TITLE
feat(player): add default aspect ratio setting and persistence toggle (Closes #338)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
@@ -98,7 +98,9 @@ class PlayerPreferences(
   val keepScreenOnWhenPaused = preferenceStore.getBoolean("keep_screen_on_when_paused", false)
   val resumeOnUnlock = preferenceStore.getBoolean("resume_on_unlock", false)
 
-  // Persist aspect ratio setting (default to Fit)
+  /**
+   * Baseline default aspect ratio used when opening videos (Fit, Crop, Stretch).
+   */
   val defaultVideoAspect = preferenceStore.getEnum("default_video_aspect", VideoAspect.Fit)
   val defaultCustomAspectRatio = preferenceStore.getObject(
     key = "default_custom_aspect_ratio",
@@ -106,6 +108,12 @@ class PlayerPreferences(
     serializer = { it.toString() },
     deserializer = { it.toDoubleOrNull() ?: -1.0 }
   )
+
+  /**
+   * Whether aspect ratio adjustments made during video playback should persist across videos
+   * or remain session-only.
+   */
+  val rememberVideoAspect = preferenceStore.getBoolean("remember_video_aspect", false)
 
   // Custom Buttons - JSON List
   val customButtons = preferenceStore.getString("custom_buttons_json", "[]")

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
@@ -1663,7 +1663,9 @@ class PlayerActivity :
    */
   private fun handleConfigurationChange() {
     if (!isInPictureInPictureMode) {
-      // Configuration changes don't affect aspect ratio
+      if (viewModel.videoAspect.value == VideoAspect.Stretch && viewModel.currentAspectRatio.value <= 0) {
+        viewModel.changeVideoAspect(VideoAspect.Stretch, showUpdate = false, resetZoomAndPan = false)
+      }
     } else {
       viewModel.hideControls()
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -345,7 +345,13 @@ class PlayerViewModel(
   val videoAspect: StateFlow<VideoAspect> = _videoAspect.asStateFlow()
 
   // Current aspect ratio value (for custom ratios and tracking)
-  private val _currentAspectRatio = MutableStateFlow(playerPreferences.defaultCustomAspectRatio.get())
+  private val _currentAspectRatio = MutableStateFlow(
+    if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultCustomAspectRatio.get()
+    } else {
+      -1.0
+    }
+  )
   val currentAspectRatio: StateFlow<Double> = _currentAspectRatio.asStateFlow()
 
   // Timer
@@ -1187,7 +1193,11 @@ class PlayerViewModel(
     
     // 1. Apply saved aspect ratio preference without overriding active zoom and pan
     val savedAspect = playerPreferences.defaultVideoAspect.get()
-    val savedCustomRatio = playerPreferences.defaultCustomAspectRatio.get()
+    val savedCustomRatio = if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultCustomAspectRatio.get()
+    } else {
+      -1.0
+    }
 
     if (savedCustomRatio > 0) {
       setCustomAspectRatio(savedCustomRatio, resetZoomAndPan = false)
@@ -1285,8 +1295,10 @@ class PlayerViewModel(
     // Update the state and persist to preferences
     _videoAspect.value = aspect
     _currentAspectRatio.value = -1.0 // Reset custom ratio when using standard modes
-    playerPreferences.defaultVideoAspect.set(aspect)
-    playerPreferences.defaultCustomAspectRatio.set(-1.0)
+    if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultVideoAspect.set(aspect)
+      playerPreferences.defaultCustomAspectRatio.set(-1.0)
+    }
 
     // Notify the UI
     if (showUpdate) {
@@ -1305,7 +1317,9 @@ class PlayerViewModel(
     MPVLib.setPropertyDouble("panscan", 0.0)
     MPVLib.setPropertyDouble("video-aspect-override", ratio)
     _currentAspectRatio.value = ratio
-    playerPreferences.defaultCustomAspectRatio.set(ratio)
+    if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultCustomAspectRatio.set(ratio)
+    }
     playerUpdate.value = PlayerUpdates.AspectRatio
   }
 

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
@@ -29,6 +29,7 @@ import xyz.mpv.rex.presentation.components.GroupedListColumn
 import xyz.mpv.rex.ui.player.BackgroundPlaybackMode
 import xyz.mpv.rex.ui.player.PlayerOrientation
 import xyz.mpv.rex.ui.player.ResumePlaybackMode
+import xyz.mpv.rex.ui.player.VideoAspect
 import xyz.mpv.rex.ui.player.controls.components.sheets.toFixed
 import xyz.mpv.rex.ui.utils.LocalBackStack
 import kotlinx.serialization.Serializable
@@ -87,6 +88,8 @@ object PlayerPreferencesScreen : Screen {
 
           item {
             val orientation by preferences.orientation.collectAsState()
+            val defaultVideoAspect by preferences.defaultVideoAspect.collectAsState()
+            val rememberVideoAspect by preferences.rememberVideoAspect.collectAsState()
             val resumePlaybackMode by preferences.resumePlaybackMode.collectAsState()
             val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
             val closeAfterEndOfVideo by preferences.closeAfterReachingEndOfVideo.collectAsState()
@@ -113,6 +116,45 @@ object PlayerPreferencesScreen : Screen {
                       text = stringResource(id = orientation.titleRes),
                       color = MaterialTheme.colorScheme.outline,
                     ) 
+                  },
+                )
+              }
+
+              GroupedPreferenceCard(
+                position = GroupPosition.MIDDLE,
+                highlightKey = R.string.pref_player_default_aspect_ratio,
+              ) {
+                ListPreference(
+                  value = defaultVideoAspect,
+                  onValueChange = { aspect ->
+                    preferences.defaultVideoAspect.set(aspect)
+                    preferences.defaultCustomAspectRatio.set(-1.0)
+                  },
+                  values = VideoAspect.entries,
+                  valueToText = { AnnotatedString(context.getString(it.titleRes)) },
+                  title = { Text(text = stringResource(id = R.string.pref_player_default_aspect_ratio)) },
+                  summary = {
+                    Text(
+                      text = stringResource(id = defaultVideoAspect.titleRes),
+                      color = MaterialTheme.colorScheme.outline,
+                    )
+                  },
+                )
+              }
+
+              GroupedPreferenceCard(
+                position = GroupPosition.MIDDLE,
+                highlightKey = R.string.pref_player_remember_aspect_ratio,
+              ) {
+                SwitchPreference(
+                  value = rememberVideoAspect,
+                  onValueChange = preferences.rememberVideoAspect::set,
+                  title = { Text(text = stringResource(R.string.pref_player_remember_aspect_ratio)) },
+                  summary = {
+                    Text(
+                      text = stringResource(R.string.pref_player_remember_aspect_ratio_summary),
+                      color = MaterialTheme.colorScheme.outline,
+                    )
                   },
                 )
               }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/SearchablePreference.kt
@@ -192,6 +192,21 @@ object SearchablePreferences {
                 targetIndex = 1,
             ))
             add(SearchablePreference(
+                titleRes = R.string.pref_player_default_aspect_ratio,
+                keywords = listOf("aspect", "ratio", "fit", "crop", "stretch", "screen", "default", "scale"),
+                category = "Player",
+                screen = PlayerPreferencesScreen,
+                targetIndex = 1,
+            ))
+            add(SearchablePreference(
+                titleRes = R.string.pref_player_remember_aspect_ratio,
+                summaryRes = R.string.pref_player_remember_aspect_ratio_summary,
+                keywords = listOf("aspect", "ratio", "remember", "persist", "save", "session"),
+                category = "Player",
+                screen = PlayerPreferencesScreen,
+                targetIndex = 1,
+            ))
+            add(SearchablePreference(
                 titleRes = R.string.pref_player_save_position_on_quit,
                 keywords = listOf("save", "position", "resume", "remember", "progress"),
                 category = "Player",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">REX Player</string>
     <string name="author_name" translatable="false">Sakhawat</string>
 
@@ -199,6 +199,9 @@
     <string name="pref_player_seeking_title">Seeking</string>
     <string name="pref_player_close_after_eof">Close after the end of playback</string>
     <string name="pref_player_remember_brightness">Remember display brightness</string>
+    <string name="pref_player_default_aspect_ratio" tools:ignore="MissingTranslation">Default aspect ratio</string>
+    <string name="pref_player_remember_aspect_ratio" tools:ignore="MissingTranslation">Remember aspect ratio across videos</string>
+    <string name="pref_player_remember_aspect_ratio_summary" tools:ignore="MissingTranslation">Save the aspect ratio used in the player for subsequent videos</string>
 
     <string name="pref_player_gestures">Gestures</string>
     <string name="pref_player_gestures_brightness">Brightness gestures</string>


### PR DESCRIPTION
### Summary

Resolves #338 by exposing a global default aspect ratio in settings and decoupling in-player aspect adjustments so they do not silently overwrite the baseline preference.

### Why

Previously, `defaultVideoAspect` was defined in preferences but never exposed in the UI. In addition, manual aspect ratio tweaks during playback silently overwrote `defaultVideoAspect` globally for all future videos.

### What

- **Settings UI**: Expose **Default aspect ratio** (`Fit Screen`, `Crop`, `Stretch`) in `PlayerPreferencesScreen` under General.
- **Persistence Toggle**: Add **Remember aspect ratio across videos** toggle (default: `false`).
  - When disabled (`false`): In-player adjustments are session-only; new videos open with the configured default aspect ratio.
  - When enabled (`true`): In-player adjustments persist across videos.
- **Search Integration**: Index both preferences in `SearchablePreferences` with corresponding `highlightKey`s for settings search.
- **Stretch Recalculation**: Update `handleConfigurationChange` so `VideoAspect.Stretch` dynamically recalculates display ratios on device rotation without distortion.