### PR TITLE
fix(player): persist aspect ratio per-video in PlaybackStateEntity (Closes #352)

### DIFF
--- a/app/schemas/xyz.mpv.rex.database.MpvExDatabase/16.json
+++ b/app/schemas/xyz.mpv.rex.database.MpvExDatabase/16.json
@@ -1,0 +1,785 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "e2b4cfdb20e0ae91de0e6dc4cd87a1c3",
+    "entities": [
+      {
+        "tableName": "PlaybackStateEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaTitle` TEXT NOT NULL, `lastPosition` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `videoZoom` REAL NOT NULL, `sid` INTEGER NOT NULL, `secondarySid` INTEGER NOT NULL, `subDelay` INTEGER NOT NULL, `subSpeed` REAL NOT NULL, `aid` INTEGER NOT NULL, `audioDelay` INTEGER NOT NULL, `timeRemaining` INTEGER NOT NULL, `savedOrientation` INTEGER, `externalSubtitles` TEXT NOT NULL, `externalAudioTracks` TEXT NOT NULL, `hasBeenWatched` INTEGER NOT NULL, `videoAspect` TEXT, `customAspectRatio` REAL NOT NULL, PRIMARY KEY(`mediaTitle`))",
+        "fields": [
+          {
+            "fieldPath": "mediaTitle",
+            "columnName": "mediaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPosition",
+            "columnName": "lastPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoZoom",
+            "columnName": "videoZoom",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sid",
+            "columnName": "sid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondarySid",
+            "columnName": "secondarySid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subDelay",
+            "columnName": "subDelay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subSpeed",
+            "columnName": "subSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aid",
+            "columnName": "aid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDelay",
+            "columnName": "audioDelay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRemaining",
+            "columnName": "timeRemaining",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedOrientation",
+            "columnName": "savedOrientation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalSubtitles",
+            "columnName": "externalSubtitles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalAudioTracks",
+            "columnName": "externalAudioTracks",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasBeenWatched",
+            "columnName": "hasBeenWatched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoAspect",
+            "columnName": "videoAspect",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customAspectRatio",
+            "columnName": "customAspectRatio",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mediaTitle"
+          ]
+        }
+      },
+      {
+        "tableName": "RecentlyPlayedEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `videoTitle` TEXT, `duration` INTEGER NOT NULL, `fileSize` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `launchSource` TEXT, `playlistId` INTEGER, `isAudio` INTEGER NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoTitle",
+            "columnName": "videoTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchSource",
+            "columnName": "launchSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isAudio",
+            "columnName": "isAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `size` INTEGER NOT NULL, `dateModified` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `rotation` INTEGER NOT NULL, `fps` REAL NOT NULL, `hasEmbeddedSubtitles` INTEGER NOT NULL, `subtitleCodec` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `lastScanned` INTEGER NOT NULL, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rotation",
+            "columnName": "rotation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fps",
+            "columnName": "fps",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasEmbeddedSubtitles",
+            "columnName": "hasEmbeddedSubtitles",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleCodec",
+            "columnName": "subtitleCodec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanned",
+            "columnName": "lastScanned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "path"
+          ]
+        }
+      },
+      {
+        "tableName": "network_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `protocol` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `path` TEXT NOT NULL, `isAnonymous` INTEGER NOT NULL, `lastConnected` INTEGER NOT NULL, `autoConnect` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnonymous",
+            "columnName": "isAnonymous",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoConnect",
+            "columnName": "autoConnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaylistEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `m3uSourceUrl` TEXT, `isM3uPlaylist` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "m3uSourceUrl",
+            "columnName": "m3uSourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isM3uPlaylist",
+            "columnName": "isM3uPlaylist",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaylistItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `position` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, `playCount` INTEGER NOT NULL, `lastPosition` INTEGER NOT NULL, FOREIGN KEY(`playlistId`) REFERENCES `PlaylistEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "playCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPosition",
+            "columnName": "lastPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PlaylistItemEntity_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PlaylistEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "shorts_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `isLoved` INTEGER NOT NULL, `isBlocked` INTEGER NOT NULL, `isManuallyAdded` INTEGER NOT NULL, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLoved",
+            "columnName": "isLoved",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlocked",
+            "columnName": "isBlocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isManuallyAdded",
+            "columnName": "isManuallyAdded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "path"
+          ]
+        }
+      },
+      {
+        "tableName": "hybrid_media_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `sourceRoot` TEXT NOT NULL, `location` TEXT NOT NULL, `parentIdentity` TEXT NOT NULL, `parentDisplayName` TEXT NOT NULL, `displayName` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `size` INTEGER NOT NULL, `dateModified` INTEGER NOT NULL, `isAudio` INTEGER NOT NULL, `isNoMedia` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `rotation` INTEGER NOT NULL, `metadataState` TEXT NOT NULL, `available` INTEGER NOT NULL, `lastSeenGeneration` INTEGER NOT NULL, PRIMARY KEY(`identity`))",
+        "fields": [
+          {
+            "fieldPath": "identity",
+            "columnName": "identity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRoot",
+            "columnName": "sourceRoot",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentIdentity",
+            "columnName": "parentIdentity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentDisplayName",
+            "columnName": "parentDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAudio",
+            "columnName": "isAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNoMedia",
+            "columnName": "isNoMedia",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rotation",
+            "columnName": "rotation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataState",
+            "columnName": "metadataState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenGeneration",
+            "columnName": "lastSeenGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hybrid_media_index_parentIdentity",
+            "unique": false,
+            "columnNames": [
+              "parentIdentity"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hybrid_media_index_parentIdentity` ON `${TABLE_NAME}` (`parentIdentity`)"
+          },
+          {
+            "name": "index_hybrid_media_index_sourceRoot",
+            "unique": false,
+            "columnNames": [
+              "sourceRoot"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hybrid_media_index_sourceRoot` ON `${TABLE_NAME}` (`sourceRoot`)"
+          },
+          {
+            "name": "index_hybrid_media_index_available",
+            "unique": false,
+            "columnNames": [
+              "available"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_hybrid_media_index_available` ON `${TABLE_NAME}` (`available`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hybrid_media_roots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity` TEXT NOT NULL, `sourceType` TEXT NOT NULL, `location` TEXT NOT NULL, `displayName` TEXT NOT NULL, `available` INTEGER NOT NULL, `lastGeneration` INTEGER NOT NULL, `lastCompletedAt` INTEGER NOT NULL, `lastError` TEXT, PRIMARY KEY(`identity`))",
+        "fields": [
+          {
+            "fieldPath": "identity",
+            "columnName": "identity",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "sourceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "available",
+            "columnName": "available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastGeneration",
+            "columnName": "lastGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCompletedAt",
+            "columnName": "lastCompletedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "lastError",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e2b4cfdb20e0ae91de0e6dc4cd87a1c3')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/xyz/mpv/rex/database/MpvExDatabase.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/database/MpvExDatabase.kt
@@ -33,7 +33,7 @@ import xyz.mpv.rex.domain.network.NetworkConnection
     HybridMediaEntity::class,
     HybridMediaRootEntity::class,
   ],
-  version = 15,
+  version = 16,
   exportSchema = true,
 )
 @TypeConverters(NetworkProtocolConverter::class)

--- a/app/src/main/kotlin/xyz/mpv/rex/database/entities/PlaybackStateEntity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/database/entities/PlaybackStateEntity.kt
@@ -20,4 +20,6 @@ data class PlaybackStateEntity(
   val externalSubtitles: String = "", // Pipe-separated list of external subtitle URIs
   val externalAudioTracks: String = "", // Pipe-separated list of external audio URIs
   val hasBeenWatched: Boolean = false, // Persistent flag: true if video has ever reached the watched threshold
+  val videoAspect: String? = null, // Persisted aspect ratio mode name (e.g. Fit, Crop, Stretch)
+  val customAspectRatio: Double = -1.0, // Persisted custom aspect ratio value
 )

--- a/app/src/main/kotlin/xyz/mpv/rex/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/di/DatabaseModule.kt
@@ -547,6 +547,13 @@ val MIGRATION_14_15 = object : Migration(14, 15) {
   }
 }
 
+val MIGRATION_15_16 = object : Migration(15, 16) {
+  override fun migrate(db: SupportSQLiteDatabase) {
+    db.execSQL("ALTER TABLE `PlaybackStateEntity` ADD COLUMN `videoAspect` TEXT")
+    db.execSQL("ALTER TABLE `PlaybackStateEntity` ADD COLUMN `customAspectRatio` REAL NOT NULL DEFAULT -1.0")
+  }
+}
+
 val DatabaseModule =
   module {
     single<Json> {
@@ -561,7 +568,7 @@ val DatabaseModule =
       Room
         .databaseBuilder(context, MpvExDatabase::class.java, "mpvex.db")
         .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16)
         .fallbackToDestructiveMigration(false) // This is now safe
         .build()
     }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
@@ -242,7 +242,9 @@ class PlayerActivity :
   private var isInBackgroundPlayback = false // Track if we are currently in background playback mode
   private var inheritedNativeSession = false // MPV ownership came from HeadlessPlaybackController
 
-  @Volatile private var needsAspectReapply = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
+  @Volatile private var needsAspectReapply = false
+  @Volatile
+  private var isPlaybackStateLoaded = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
 
   // ==================== Background Playback ====================
 
@@ -1664,7 +1666,7 @@ class PlayerActivity :
   private fun handleConfigurationChange() {
     if (!isInPictureInPictureMode) {
       if (viewModel.videoAspect.value == VideoAspect.Stretch && viewModel.currentAspectRatio.value <= 0) {
-        viewModel.changeVideoAspect(VideoAspect.Stretch, showUpdate = false, resetZoomAndPan = false)
+        viewModel.changeVideoAspect(VideoAspect.Stretch, showUpdate = false, resetZoomAndPan = false, persistToPreferences = false)
       }
     } else {
       viewModel.hideControls()
@@ -1970,6 +1972,7 @@ class PlayerActivity :
     viewModel.resetVisualPreferences()
     viewModel.clearResumePrompt()
     needsAspectReapply = true
+    isPlaybackStateLoaded = false
 
     lifecycleScope.launch(Dispatchers.IO) {
       val externalPosMs = jellyfinExternalInfo?.positionMs
@@ -2391,7 +2394,10 @@ class PlayerActivity :
     val currentPos = viewModel.pos ?: 0
     val currentDuration = viewModel.duration ?: 0
     val currentSpeed = MPVLib.getPropertyDouble("speed") ?: DEFAULT_PLAYBACK_SPEED
+    val isStateLoaded = isPlaybackStateLoaded
     val currentZoom = viewModel.videoZoom.value
+    val currentAspect = viewModel.videoAspect.value.name
+    val currentCustomRatio = viewModel.currentAspectRatio.value
     val currentSid = player.sid
     val currentSecondarySid = player.secondarySid
     val currentAid = player.aid
@@ -2410,6 +2416,18 @@ class PlayerActivity :
       runCatching {
         val oldState = playbackStateRepository.getVideoDataByTitle(identifier)
         Log.d(TAG, "Saving playback state for: $mediaTitle (identifier: $identifier) at position: $currentPos")
+
+        val currentZoomToSave = if (isStateLoaded) currentZoom else (oldState?.videoZoom ?: currentZoom)
+        val currentAspectToSave = if (isStateLoaded) {
+          currentAspect
+        } else {
+          oldState?.videoAspect ?: currentAspect
+        }
+        val currentCustomRatioToSave = if (isStateLoaded) {
+          currentCustomRatio
+        } else {
+          oldState?.customAspectRatio ?: currentCustomRatio
+        }
 
         val watchedThreshold = browserPreferences.watchedThreshold.get()
         val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
@@ -2435,7 +2453,7 @@ class PlayerActivity :
             mediaTitle = identifier,
             lastPosition = savePos,
             playbackSpeed = currentSpeed,
-            videoZoom = currentZoom,
+            videoZoom = currentZoomToSave,
             sid = currentSid,
             secondarySid = currentSecondarySid,
             subDelay = (currentSubDelay * MILLISECONDS_TO_SECONDS).toInt(),
@@ -2446,6 +2464,8 @@ class PlayerActivity :
             savedOrientation = currentOrientation,
             externalSubtitles = currentExternalSubs.joinToString("|"),
             externalAudioTracks = currentExternalAudio.joinToString("|"),
+            videoAspect = currentAspectToSave,
+            customAspectRatio = currentCustomRatioToSave,
             hasBeenWatched = run {
               // Check if we are at the end (effectively watched) or reached watched threshold
               val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
@@ -2497,6 +2517,8 @@ class PlayerActivity :
       MPVLib.setPropertyInt("time-pos", 0)
       return
     }
+
+    needsAspectReapply = false
 
     val subDelay = state.subDelay / DELAY_DIVISOR
     val audioDelay = state.audioDelay / DELAY_DIVISOR
@@ -2558,6 +2580,30 @@ class PlayerActivity :
     MPVLib.setPropertyDouble("video-zoom", state.videoZoom.toDouble())
     viewModel.setVideoZoom(state.videoZoom)
 
+    // Restore video aspect ratio from saved state
+    if (state.videoAspect != null) {
+      val aspect = runCatching { VideoAspect.valueOf(state.videoAspect) }.getOrDefault(VideoAspect.Fit)
+      withContext(Dispatchers.Main) {
+        if (state.customAspectRatio > 0.0) {
+          viewModel.setCustomAspectRatio(
+            state.customAspectRatio,
+            resetZoomAndPan = false,
+            showUpdate = false,
+            persistToPreferences = false,
+          )
+        } else {
+          viewModel.changeVideoAspect(
+            aspect,
+            showUpdate = false,
+            resetZoomAndPan = false,
+            persistToPreferences = false,
+          )
+        }
+      }
+    }
+
+    isPlaybackStateLoaded = true
+
     val resumeMode = playerPreferences.resumePlaybackMode.get()
     val hasValidSavedPosition = state.lastPosition > 3
 
@@ -2588,6 +2634,7 @@ class PlayerActivity :
    * @param state The saved playback state entity (null if no saved state)
    */
   private fun applyDefaultSettings(state: PlaybackStateEntity?) {
+    isPlaybackStateLoaded = true
     if (state == null) {
       val defaultSubSpeed = subtitlesPreferences.defaultSubSpeed.get().toDouble()
       MPVLib.setPropertyDouble("sub-speed", defaultSubSpeed)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
@@ -242,9 +242,8 @@ class PlayerActivity :
   private var isInBackgroundPlayback = false // Track if we are currently in background playback mode
   private var inheritedNativeSession = false // MPV ownership came from HeadlessPlaybackController
 
-  @Volatile private var needsAspectReapply = false
-  @Volatile
-  private var isPlaybackStateLoaded = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
+  @Volatile private var needsAspectReapply = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
+  @Volatile private var isPlaybackStateLoaded = false // Track if saved playback state has finished loading from database
 
   // ==================== Background Playback ====================
 
@@ -1904,7 +1903,11 @@ class PlayerActivity :
         if (needsAspectReapply) {
           needsAspectReapply = false
           runOnUiThread {
-            viewModel.resetVisualPreferences()
+            if (isPlaybackStateLoaded) {
+              viewModel.reapplyCurrentVisualPreferences()
+            } else {
+              viewModel.resetVisualPreferences()
+            }
           }
         }
       }
@@ -2517,8 +2520,6 @@ class PlayerActivity :
       MPVLib.setPropertyInt("time-pos", 0)
       return
     }
-
-    needsAspectReapply = false
 
     val subDelay = state.subDelay / DELAY_DIVISOR
     val audioDelay = state.audioDelay / DELAY_DIVISOR

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -1200,9 +1200,9 @@ class PlayerViewModel(
     }
 
     if (savedCustomRatio > 0) {
-      setCustomAspectRatio(savedCustomRatio, resetZoomAndPan = false)
+      setCustomAspectRatio(savedCustomRatio, resetZoomAndPan = false, showUpdate = false, persistToPreferences = false)
     } else {
-      changeVideoAspect(savedAspect, showUpdate = false, resetZoomAndPan = false)
+      changeVideoAspect(savedAspect, showUpdate = false, resetZoomAndPan = false, persistToPreferences = false)
     }
 
     // 2. Load zoom and pan preferences or sync from mpv.conf/engine defaults
@@ -1251,6 +1251,7 @@ class PlayerViewModel(
     aspect: VideoAspect,
     showUpdate: Boolean = true,
     resetZoomAndPan: Boolean = true,
+    persistToPreferences: Boolean = true,
   ) {
     if (resetZoomAndPan) {
       setVideoZoom(0f)
@@ -1295,7 +1296,7 @@ class PlayerViewModel(
     // Update the state and persist to preferences
     _videoAspect.value = aspect
     _currentAspectRatio.value = -1.0 // Reset custom ratio when using standard modes
-    if (playerPreferences.rememberVideoAspect.get()) {
+    if (persistToPreferences && playerPreferences.rememberVideoAspect.get()) {
       playerPreferences.defaultVideoAspect.set(aspect)
       playerPreferences.defaultCustomAspectRatio.set(-1.0)
     }
@@ -1309,6 +1310,8 @@ class PlayerViewModel(
   fun setCustomAspectRatio(
     ratio: Double,
     resetZoomAndPan: Boolean = true,
+    showUpdate: Boolean = true,
+    persistToPreferences: Boolean = true,
   ) {
     if (resetZoomAndPan) {
       setVideoZoom(0f)
@@ -1317,10 +1320,12 @@ class PlayerViewModel(
     MPVLib.setPropertyDouble("panscan", 0.0)
     MPVLib.setPropertyDouble("video-aspect-override", ratio)
     _currentAspectRatio.value = ratio
-    if (playerPreferences.rememberVideoAspect.get()) {
+    if (persistToPreferences && playerPreferences.rememberVideoAspect.get()) {
       playerPreferences.defaultCustomAspectRatio.set(ratio)
     }
-    playerUpdate.value = PlayerUpdates.AspectRatio
+    if (showUpdate) {
+      playerUpdate.value = PlayerUpdates.AspectRatio
+    }
   }
 
   // ==================== Screen Rotation ====================

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -341,7 +341,13 @@ class PlayerViewModel(
   val videoZoom: StateFlow<Float> = _videoZoom.asStateFlow()
 
  // Video aspect ratio (now persisted via preferences)
-  private val _videoAspect = MutableStateFlow(playerPreferences.defaultVideoAspect.get())
+  private val _videoAspect = MutableStateFlow(
+    if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultVideoAspect.get()
+    } else {
+      VideoAspect.Fit
+    }
+  )
   val videoAspect: StateFlow<VideoAspect> = _videoAspect.asStateFlow()
 
   // Current aspect ratio value (for custom ratios and tracking)
@@ -1192,7 +1198,11 @@ class PlayerViewModel(
     _cachedVideoRotation = MPVLib.getPropertyInt("video-params/rotate") ?: 0
     
     // 1. Apply saved aspect ratio preference without overriding active zoom and pan
-    val savedAspect = playerPreferences.defaultVideoAspect.get()
+    val savedAspect = if (playerPreferences.rememberVideoAspect.get()) {
+      playerPreferences.defaultVideoAspect.get()
+    } else {
+      VideoAspect.Fit
+    }
     val savedCustomRatio = if (playerPreferences.rememberVideoAspect.get()) {
       playerPreferences.defaultCustomAspectRatio.get()
     } else {
@@ -1244,6 +1254,17 @@ class PlayerViewModel(
       MPVLib.setPropertyDouble("video-scale-y", 1.0)
       _videoScaleX.value = 1f
       _videoScaleY.value = 1f
+    }
+  }
+
+  // Re-applies the currently active aspect ratio without resetting to defaults
+  fun reapplyCurrentVisualPreferences() {
+    _cachedVideoRotation = MPVLib.getPropertyInt("video-params/rotate") ?: 0
+    val currentRatio = _currentAspectRatio.value
+    if (currentRatio > 0) {
+      setCustomAspectRatio(currentRatio, resetZoomAndPan = false, showUpdate = false, persistToPreferences = false)
+    } else {
+      changeVideoAspect(_videoAspect.value, showUpdate = false, resetZoomAndPan = false, persistToPreferences = false)
     }
   }
 

--- a/app/src/main/kotlin/xyz/mpv/rex/utils/history/HistoryManager.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/utils/history/HistoryManager.kt
@@ -229,6 +229,8 @@ class HistoryManager(
                         audioDelay = existing?.audioDelay ?: 0,
                         timeRemaining = -1,
                         hasBeenWatched = false,
+                        videoAspect = null,
+                        customAspectRatio = -1.0,
                     )
                 )
                 recentlyPlayedRepository.deleteByFilePath(filePath)
@@ -249,8 +251,13 @@ class HistoryManager(
                         subSpeed = existing?.subSpeed ?: 1.0,
                         aid = existing?.aid ?: -1,
                         audioDelay = existing?.audioDelay ?: 0,
-                        timeRemaining = durationSeconds,
+                        timeRemaining = existing?.timeRemaining ?: durationSeconds,
+                        savedOrientation = existing?.savedOrientation,
+                        externalSubtitles = existing?.externalSubtitles ?: "",
+                        externalAudioTracks = existing?.externalAudioTracks ?: "",
                         hasBeenWatched = false,
+                        videoAspect = existing?.videoAspect,
+                        customAspectRatio = existing?.customAspectRatio ?: -1.0,
                     )
                 )
                 // Upsert a RecentlyPlayed entry with timestamp = now so the file surfaces
@@ -278,7 +285,12 @@ class HistoryManager(
                         aid = existing?.aid ?: -1,
                         audioDelay = existing?.audioDelay ?: 0,
                         timeRemaining = 0,
+                        savedOrientation = existing?.savedOrientation,
+                        externalSubtitles = existing?.externalSubtitles ?: "",
+                        externalAudioTracks = existing?.externalAudioTracks ?: "",
                         hasBeenWatched = true,
+                        videoAspect = existing?.videoAspect,
+                        customAspectRatio = existing?.customAspectRatio ?: -1.0,
                     )
                 )
                 // Also add/bump in recently played history
@@ -306,7 +318,12 @@ class HistoryManager(
                         aid = existing?.aid ?: -1,
                         audioDelay = existing?.audioDelay ?: 0,
                         timeRemaining = durationSeconds,
+                        savedOrientation = existing?.savedOrientation,
+                        externalSubtitles = existing?.externalSubtitles ?: "",
+                        externalAudioTracks = existing?.externalAudioTracks ?: "",
                         hasBeenWatched = false,
+                        videoAspect = existing?.videoAspect,
+                        customAspectRatio = existing?.customAspectRatio ?: -1.0,
                     )
                 )
                 // Also clear from recently played history


### PR DESCRIPTION
### What & Why
- Fixes #352 where setting one video to crop and another to fit forced the selected aspect ratio across videos even when remember aspect ratio is off.
- Makes aspect ratio persistence consistent with `videoZoom` by storing `videoAspect` and `customAspectRatio` per-video in `PlaybackStateEntity` (Room DB v16).
- Restores per-video aspect ratio on media load without mutating global `defaultVideoAspect` preferences.
- Updates `HistoryManager` to preserve per-video aspect ratio across state transitions (resetting to default on Mark as New).