### PR TITLE
feat(player): add option to prevent media autoplay on open (Closes #328)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/preferences/PlayerPreferences.kt
@@ -91,6 +91,7 @@ class PlayerPreferences(
 
   // New: autoplay next video when current file ends
   val autoplayNextVideo = preferenceStore.getBoolean("autoplay_next_video", true)
+  val autoplayOnOpen = preferenceStore.getBoolean("autoplay_on_open", true)
   val showControlsOnPlay = preferenceStore.getBoolean("show_controls_on_play", true)
 
   val autoPiPOnNavigation = preferenceStore.getBoolean("auto_pip_on_navigation", false)

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/MPVView.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/MPVView.kt
@@ -143,6 +143,9 @@ class MPVView(
 
     MPVLib.setPropertyBoolean("keep-open", true)
     MPVLib.setPropertyBoolean("input-default-bindings", true)
+    if (!playerPreferences.autoplayOnOpen.get()) {
+      MPVLib.setPropertyBoolean("pause", true)
+    }
 
     MPVLib.setOptionString("tls-verify", "yes")
     MPVLib.setOptionString("tls-ca-file", "${context.filesDir.path}/cacert.pem")

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerActivity.kt
@@ -244,6 +244,7 @@ class PlayerActivity :
 
   @Volatile private var needsAspectReapply = false // Track if aspect ratio needs to be reapplied after video is ready (for Video/Smart orientation modes)
   @Volatile private var isPlaybackStateLoaded = false // Track if saved playback state has finished loading from database
+  private var isAutoplayNextTriggered = false // Track if file load was initiated by autoplay next video
 
   // ==================== Background Playback ====================
 
@@ -517,7 +518,7 @@ class PlayerActivity :
       if (isUriM3U(playableUri)) {
         loadM3uPlaylistOrPlayDirectly(playableUri)
       } else {
-        if (playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
+        if (!playerPreferences.autoplayOnOpen.get() || playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
           runCatching { MPVLib.setPropertyBoolean("pause", true) }
         }
         player.playFile(playableUri)
@@ -691,7 +692,9 @@ class PlayerActivity :
           .setAcceptsDelayedFocusGain(true)
           .setWillPauseWhenDucked(true)
           .build()
-      requestAudioFocus()
+      if (playerPreferences.autoplayOnOpen.get()) {
+        requestAudioFocus()
+      }
     }
   }
 
@@ -1781,6 +1784,7 @@ class PlayerActivity :
 
         if (hasNextItem && (autoplayEnabled || viewModel.shouldRepeatPlaylist())) {
           // Play next item in playlist
+          isAutoplayNextTriggered = true
           playNext()
         } else {
           miniPlayerStateManager.clearState()
@@ -1977,6 +1981,9 @@ class PlayerActivity :
     needsAspectReapply = true
     isPlaybackStateLoaded = false
 
+    val shouldAutoplay = playerPreferences.autoplayOnOpen.get() || isAutoplayNextTriggered
+    isAutoplayNextTriggered = false
+
     lifecycleScope.launch(Dispatchers.IO) {
       val externalPosMs = jellyfinExternalInfo?.positionMs
       val isJellyfinExternal = jellyfinExternalInfo != null && externalPosMs != null
@@ -2008,9 +2015,18 @@ class PlayerActivity :
       }
 
       // Unpause playback after position and state restoration complete (unless asking user to resume)
-      if (viewModel.resumePrompt.value == null) {
+      if (shouldAutoplay && viewModel.resumePrompt.value == null) {
+        withContext(Dispatchers.Main) { requestAudioFocus() }
         runCatching {
           MPVLib.setPropertyBoolean("pause", false)
+        }
+      } else {
+        runCatching {
+          MPVLib.setPropertyBoolean("pause", true)
+        }
+        withContext(Dispatchers.Main) {
+          abandonAudioFocus()
+          updateMediaSessionPlaybackState(isPlaying = false)
         }
       }
 
@@ -2101,9 +2117,7 @@ class PlayerActivity :
       viewModel.setMediaTitle(fileName)
     }
 
-    viewModel.unpause()
-
-    if (playerPreferences.showControlsOnPlay.get()) {
+    if (!shouldAutoplay || playerPreferences.showControlsOnPlay.get()) {
       viewModel.showControls()
     }
 
@@ -2137,7 +2151,8 @@ class PlayerActivity :
       title = fileName,
       durationMs = (MPVLib.getPropertyDouble("duration")?.times(1000))?.toLong() ?: 0L,
     )
-    updateMediaSessionPlaybackState(isPlaying = true)
+    val isPlaying = shouldAutoplay && viewModel.resumePrompt.value == null
+    updateMediaSessionPlaybackState(isPlaying = isPlaying)
 
     // Update MiniPlayer state and media notification thumbnail for newly loaded track
     val currentUri = viewModel.playlistManager.getCurrentUri() ?: extractUriFromIntent(intent)
@@ -2168,6 +2183,7 @@ class PlayerActivity :
         mediaPlaybackService?.setMediaInfo(title = currentTitle, artist = artist, thumbnail = activeThumb)
         miniPlayerStateManager.updateState(
           isPlaybackActive = true,
+          isPaused = !isPlaying,
           title = currentTitle,
           artist = artist,
           thumbnail = activeThumb,
@@ -2673,6 +2689,7 @@ class PlayerActivity :
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
 
+    isAutoplayNextTriggered = false
     pendingIntentExtras = true
     // Update the intent first so getFileName uses the new intent data
     setIntent(intent)
@@ -2816,7 +2833,7 @@ class PlayerActivity :
       if (parsedUri != null && isUriM3U(parsedUri)) {
         loadM3uPlaylistOrPlayDirectly(uriStr)
       } else {
-        if (playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
+        if (!playerPreferences.autoplayOnOpen.get() || playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
           runCatching { MPVLib.setPropertyBoolean("pause", true) }
         }
         // Avoid blocking UI thread while mpv opens network streams (e.g., HLS).
@@ -3738,6 +3755,7 @@ class PlayerActivity :
       Log.e(TAG, "Invalid playlist index: $index (playlist size: ${playlist.size})")
       return
     }
+    isAutoplayNextTriggered = true
     loadPlaylistItemInternal(index)
   }
 
@@ -3895,7 +3913,7 @@ class PlayerActivity :
     if (mpvInitialized) {
       safeSetPropertyString("vid", "no")
       runCatching { MPVLib.setPropertyBoolean("pause", true) }
-    } else if (playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
+    } else if (!playerPreferences.autoplayOnOpen.get() || playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
       runCatching { MPVLib.setPropertyBoolean("pause", true) }
     }
     // Load the new video
@@ -4087,7 +4105,7 @@ class PlayerActivity :
           if (mpvInitialized) {
             safeSetPropertyString("vid", "no")
             runCatching { MPVLib.setPropertyBoolean("pause", true) }
-          } else if (playerPreferences.savePositionOnQuit.get()) {
+          } else if (!playerPreferences.autoplayOnOpen.get() || playerPreferences.savePositionOnQuit.get() || playerPreferences.resumePlaybackMode.get() != ResumePlaybackMode.Never) {
             runCatching { MPVLib.setPropertyBoolean("pause", true) }
           }
           if (mpvInitialized) {

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/PlayerViewModel.kt
@@ -275,18 +275,23 @@ class PlayerViewModel(
 
   fun dismissResumePrompt() {
     _resumePrompt.value = null
-    runCatching { MPVLib.setPropertyBoolean("pause", false) }
+    if (playerPreferences.autoplayOnOpen.get()) {
+      host.requestAudioFocus()
+      runCatching { MPVLib.setPropertyBoolean("pause", false) }
+    }
   }
 
   fun confirmResume(position: Int) {
     _resumePrompt.value = null
     seekTo(position)
+    host.requestAudioFocus()
     runCatching { MPVLib.setPropertyBoolean("pause", false) }
   }
 
   fun restartFromBeginning() {
     _resumePrompt.value = null
     seekTo(0)
+    host.requestAudioFocus()
     runCatching { MPVLib.setPropertyBoolean("pause", false) }
   }
 

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/PlayerPreferencesScreen.kt
@@ -94,6 +94,7 @@ object PlayerPreferencesScreen : Screen {
             val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
             val closeAfterEndOfVideo by preferences.closeAfterReachingEndOfVideo.collectAsState()
             val autoplayNextVideo by preferences.autoplayNextVideo.collectAsState()
+            val autoplayOnOpen by preferences.autoplayOnOpen.collectAsState()
             val playlistMode by preferences.playlistMode.collectAsState()
             val rememberBrightness by preferences.rememberBrightness.collectAsState()
             val autoPiPOnNavigation by preferences.autoPiPOnNavigation.collectAsState()
@@ -220,6 +221,26 @@ object PlayerPreferencesScreen : Screen {
                         stringResource(R.string.pref_player_autoplay_next_video_summary_on)
                       else
                         stringResource(R.string.pref_player_autoplay_next_video_summary_off),
+                      color = MaterialTheme.colorScheme.outline,
+                    )
+                  },
+                )
+              }
+
+              GroupedPreferenceCard(
+                position = GroupPosition.MIDDLE,
+                highlightKey = listOf(R.string.pref_player_autoplay_on_open, R.string.pref_autoplay_on_open_title),
+              ) {
+                SwitchPreference(
+                  value = autoplayOnOpen,
+                  onValueChange = preferences.autoplayOnOpen::set,
+                  title = { Text(text = stringResource(R.string.pref_player_autoplay_on_open)) },
+                  summary = {
+                    Text(
+                      text = if (autoplayOnOpen)
+                        stringResource(R.string.pref_player_autoplay_on_open_summary_on)
+                      else
+                        stringResource(R.string.pref_player_autoplay_on_open_summary_off),
                       color = MaterialTheme.colorScheme.outline,
                     )
                   },

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/preferences/SearchablePreference.kt
@@ -244,6 +244,14 @@ object SearchablePreferences {
                 targetIndex = 1,
             ))
             add(SearchablePreference(
+                titleRes = R.string.pref_autoplay_on_open_title,
+                summaryRes = R.string.pref_autoplay_on_open_summary,
+                keywords = listOf("autoplay", "open", "start", "pause", "playback"),
+                category = "Player",
+                screen = PlayerPreferencesScreen,
+                targetIndex = 1,
+            ))
+            add(SearchablePreference(
                 titleRes = R.string.pref_auto_pip_title,
                 summaryRes = R.string.pref_auto_pip_summary,
                 keywords = listOf("pip", "picture", "auto", "navigation", "home", "back"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="pref_autoplay_summary">Show next/previous buttons for all videos in folder</string>
     <string name="pref_autoplay_next_video_title">Autoplay next video</string>
     <string name="pref_autoplay_next_video_summary">Automatically play next video when current ends</string>
+    <string name="pref_autoplay_on_open_title">Autoplay on open</string>
+    <string name="pref_autoplay_on_open_summary">Automatically begin playback when media is opened</string>
     <string name="pref_auto_pip_title">Auto Picture-in-Picture</string>
     <string name="pref_auto_pip_summary">Automatically enter PIP mode when pressing home or back</string>
     <string name="pref_player_resume_on_unlock_title">Resume on unlock</string>
@@ -1228,6 +1230,10 @@
     <string name="pref_player_autoplay_next_video">Autoplay next video</string>
     <string name="pref_player_autoplay_next_video_summary_on">Automatically play next video when current ends</string>
     <string name="pref_player_autoplay_next_video_summary_off">Stay on current video when it ends</string>
+    <string name="pref_player_autoplay_on_open">Autoplay on open</string>
+    <string name="pref_player_autoplay_on_open_summary">Automatically begin playback when media is opened</string>
+    <string name="pref_player_autoplay_on_open_summary_on">Automatically begin playback when media is opened</string>
+    <string name="pref_player_autoplay_on_open_summary_off">Open media in a paused state</string>
     <string name="pref_player_playlist_mode_summary_on">Show next/previous buttons for all videos in folder</string>
     <string name="pref_player_playlist_mode_summary_off">Play videos individually (select multiple for playlist)</string>
     <string name="pref_player_keep_screen_on_when_paused_summary_on">Screen stays awake while video is paused</string>

--- a/app/src/test/kotlin/xyz/mpv/rex/preferences/PlayerPreferencesTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/preferences/PlayerPreferencesTest.kt
@@ -1,0 +1,115 @@
+package xyz.mpv.rex.preferences
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.mpv.rex.preferences.preference.Preference
+import xyz.mpv.rex.preferences.preference.PreferenceStore
+
+class PlayerPreferencesTest {
+
+  private class InMemoryPreference<T>(
+    private val key: String,
+    private val defaultValue: T,
+  ) : Preference<T> {
+    private val flow = MutableStateFlow(defaultValue)
+
+    override fun key(): String = key
+    override fun get(): T = flow.value
+    override fun set(value: T) { flow.value = value }
+    override fun isSet(): Boolean = true
+    override fun delete() { flow.value = defaultValue }
+    override fun defaultValue(): T = defaultValue
+    override fun changes(): Flow<T> = flow.asStateFlow()
+    override fun stateIn(scope: CoroutineScope) = flow.asStateFlow()
+  }
+
+  private class InMemoryPreferenceStore : PreferenceStore {
+    override fun getString(key: String, defaultValue: String): Preference<String> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun getLong(key: String, defaultValue: Long): Preference<Long> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun getInt(key: String, defaultValue: Int): Preference<Int> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun getFloat(key: String, defaultValue: Float): Preference<Float> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun getBoolean(key: String, defaultValue: Boolean): Preference<Boolean> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> =
+      InMemoryPreference(key, defaultValue)
+
+    override fun <T> getObject(
+      key: String,
+      defaultValue: T,
+      serializer: (T) -> String,
+      deserializer: (String) -> T,
+    ): Preference<T> = InMemoryPreference(key, defaultValue)
+
+    override fun getAll(): Map<String, *> = emptyMap<String, Any>()
+  }
+
+  @Test
+  fun autoplayOnOpen_defaultsToTrue_andPersistsChanges() {
+    val store = InMemoryPreferenceStore()
+    val preferences = PlayerPreferences(store)
+
+    assertEquals("autoplay_on_open", preferences.autoplayOnOpen.key())
+    assertTrue(preferences.autoplayOnOpen.defaultValue())
+    assertTrue(preferences.autoplayOnOpen.get())
+
+    preferences.autoplayOnOpen.set(false)
+    assertFalse(preferences.autoplayOnOpen.get())
+
+    preferences.autoplayOnOpen.set(true)
+    assertTrue(preferences.autoplayOnOpen.get())
+
+    preferences.autoplayOnOpen.set(false)
+    assertFalse(preferences.autoplayOnOpen.get())
+    preferences.autoplayOnOpen.delete()
+    assertTrue(preferences.autoplayOnOpen.get())
+  }
+
+  @Test
+  fun autoplayOnOpen_and_autoplayNextVideo_operateIndependently() {
+    val store = InMemoryPreferenceStore()
+    val preferences = PlayerPreferences(store)
+
+    assertTrue(preferences.autoplayOnOpen.get())
+    assertTrue(preferences.autoplayNextVideo.get())
+
+    preferences.autoplayOnOpen.set(false)
+    assertFalse(preferences.autoplayOnOpen.get())
+    assertTrue(preferences.autoplayNextVideo.get())
+
+    preferences.autoplayNextVideo.set(false)
+    assertFalse(preferences.autoplayOnOpen.get())
+    assertFalse(preferences.autoplayNextVideo.get())
+
+    preferences.autoplayOnOpen.set(true)
+    assertTrue(preferences.autoplayOnOpen.get())
+    assertFalse(preferences.autoplayNextVideo.get())
+  }
+
+  @Test
+  fun searchablePreferences_indexesAutoplayOnOpen() {
+    val autoplayOnOpenEntry = xyz.mpv.rex.ui.preferences.SearchablePreferences.allPreferences.find {
+      it.titleRes == xyz.mpv.rex.R.string.pref_autoplay_on_open_title
+    }
+
+    org.junit.Assert.assertNotNull(autoplayOnOpenEntry)
+    assertEquals(xyz.mpv.rex.R.string.pref_autoplay_on_open_summary, autoplayOnOpenEntry?.summaryRes)
+    assertEquals("Player", autoplayOnOpenEntry?.category)
+    assertTrue(autoplayOnOpenEntry?.keywords?.contains("autoplay") == true)
+    assertTrue(autoplayOnOpenEntry?.keywords?.contains("open") == true)
+  }
+}


### PR DESCRIPTION
### Summary

Closes #328 by adding a user-configurable preference to prevent media from autoplaying upon being opened, allowing users to open videos in a paused state to adjust subtitles, audio tracks, or volume without sudden visual/audio noise.

### Why

Users requested an option to open media in a paused state. Previously, `PlayerActivity` unconditionally unpaused playback once position restoration completed (`MPVLib.setPropertyBoolean("pause", false)`), resulting in immediate audio and video playback as soon as media loaded.

### What

- **Preference Storage (`PlayerPreferences.kt`)**: Added `autoplayOnOpen` boolean preference backed by `"autoplay_on_open"`, defaulting to `true` to maintain standard playback behavior for existing users.
- **Settings UI (`PlayerPreferencesScreen.kt`, `strings.xml`)**: Exposed a `SwitchPreference` under **Settings > Player** in the General card section with dynamic summary state:
  - ON: *"Automatically begin playback when media is opened"*
  - OFF: *"Open media in a paused state"*
- **Search Integration (`SearchablePreference.kt`)**: Indexed `pref_autoplay_on_open_title` in settings search under category *Player* with relevant keywords (`autoplay`, `open`, `start`, `pause`, `playback`).
- **Playback Initialization (`PlayerActivity.kt`, `MPVView.kt`)**:
  - Sets initial pause state in `MPVView` when `autoplayOnOpen` is disabled.
  - When opening media with autoplay disabled, keeps playback paused after position and state restoration, suppresses initial audio focus request, keeps controls visible, and synchronizes `MediaSession` and `MiniPlayer` states to `STATE_PAUSED`.
  - Continuous playlist playback is preserved: auto-advancing (`autoplayNextVideo`) or clicking Next/Previous in the player controls sets `isAutoplayNextTriggered = true` so ongoing playlist sessions continue playing seamlessly.
- **Resume Prompt Handling (`PlayerViewModel.kt`)**: If a resume prompt is dismissed, audio focus is not stolen and the player remains paused if `autoplayOnOpen` is disabled; confirming "Resume" or "Restart" unpauses and requests audio focus as expected.
- **Unit Tests (`PlayerPreferencesTest.kt`)**: Added comprehensive tests covering default value, persistence, reset behavior, and search indexing.