### PR TITLE
fix(browser): dim completed videos immediately and unstick watch status on rewatch (Closes #343)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/BaseMediaCard.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/BaseMediaCard.kt
@@ -79,7 +79,6 @@ fun BaseMediaCard(
     onThumbClick: (() -> Unit)? = null,
     isSelected: Boolean = false,
     isRecentlyPlayed: Boolean = false,
-    isNeverPlayed: Boolean = false,
     isWatched: Boolean = false,
     isGridMode: Boolean = false,
     gridColumns: Int = 1,
@@ -230,7 +229,7 @@ fun BaseMediaCard(
 
                 Spacer(modifier = Modifier.height(4.dp))
 
-                val shouldHighlight = isRecentlyPlayed && !(isWatched && isNeverPlayed)
+                val shouldHighlight = isRecentlyPlayed && !isWatched
                 // Title
                 Text(
                     text = title,
@@ -370,7 +369,7 @@ fun BaseMediaCard(
                 Spacer(modifier = Modifier.width(16.dp))
 
                 Column(modifier = Modifier.weight(1f)) {
-                    val shouldHighlight = isRecentlyPlayed && !(isWatched && isNeverPlayed)
+                    val shouldHighlight = isRecentlyPlayed && !isWatched
                     Text(
                         text = title,
                         style = listTitleStyle ?: MaterialTheme.typography.titleMedium,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/FolderCard.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/FolderCard.kt
@@ -104,7 +104,6 @@ fun FolderCard(
     onThumbClick = onThumbClick,
     isSelected = isSelected,
     isRecentlyPlayed = isRecentlyPlayed,
-    isNeverPlayed = isNeverPlayed,
     isWatched = isWatched,
     isGridMode = isGridMode,
     gridColumns = gridColumns,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/cards/VideoCard.kt
@@ -137,7 +137,6 @@ fun VideoCard(
     onThumbClick = onThumbClick,
     isSelected = isSelected,
     isRecentlyPlayed = isRecentlyPlayed,
-    isNeverPlayed = isNeverPlayed,
     isWatched = isWatched,
     isGridMode = isGridMode,
     gridColumns = gridColumns,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/delegates/PlayerPlaybackStateController.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/delegates/PlayerPlaybackStateController.kt
@@ -115,15 +115,7 @@ class PlayerPlaybackStateController(
             externalAudioTracks = currentExternalAudio.joinToString("|"),
             videoAspect = currentAspectToSave,
             customAspectRatio = currentCustomRatioToSave,
-            hasBeenWatched = run {
-              // Check if we are at the end (effectively watched) or reached watched threshold
-              val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
-
-              val oldProgress = if (currentDuration > 0) (oldState?.lastPosition?.toFloat() ?: 0f) / currentDuration.toFloat() else 0f
-              val wasWatchedThisSession = oldProgress >= (watchedThreshold / 100f)
-
-              isCurrentlyWatched || isFinished || wasWatchedThisSession || (oldState?.hasBeenWatched == true)
-            },
+            hasBeenWatched = isFinished || progress >= (watchedThreshold / 100f),
           ),
         )
       }.onFailure { e ->

--- a/app/src/test/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepositoryTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepositoryTest.kt
@@ -69,6 +69,138 @@ class HybridMediaIndexRepositoryTest {
   }
 
   @Test
+  fun flatFolders_rewatchedVideoWithHasBeenWatchedFalse_countsAsUnwatched() = runTest {
+    val clip = media(
+      identity = "file:/storage/A/clip.mp4",
+      location = "/storage/A/clip.mp4",
+      parent = "/storage/A",
+    ).copy(duration = 100_000L)
+    coEvery { dao.getAvailableMedia(true) } returns listOf(clip)
+
+    val rewatchedPlaybackState = PlaybackStateEntity(
+      mediaTitle = clip.location,
+      lastPosition = 20,
+      timeRemaining = 80,
+      playbackSpeed = 1.0,
+      sid = -1,
+      subDelay = 0,
+      subSpeed = 1.0,
+      aid = -1,
+      audioDelay = 0,
+      hasBeenWatched = false,
+    )
+
+    val folders = repository.getFlatFolders(
+      playbackStates = listOf(rewatchedPlaybackState),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertEquals(1, folders.size)
+    assertEquals(1, folders.first().unwatchedVideoCount)
+  }
+
+  @Test
+  fun flatFolders_finishedVideoResetToZeroPosWithHasBeenWatchedTrue_countsAsWatched() = runTest {
+    val clip = media(
+      identity = "file:/storage/A/clip.mp4",
+      location = "/storage/A/clip.mp4",
+      parent = "/storage/A",
+    ).copy(duration = 100_000L)
+    coEvery { dao.getAvailableMedia(true) } returns listOf(clip)
+
+    val finishedPlaybackState = PlaybackStateEntity(
+      mediaTitle = clip.location,
+      lastPosition = 0,
+      timeRemaining = 0,
+      playbackSpeed = 1.0,
+      sid = -1,
+      subDelay = 0,
+      subSpeed = 1.0,
+      aid = -1,
+      audioDelay = 0,
+      hasBeenWatched = true,
+    )
+
+    val folders = repository.getFlatFolders(
+      playbackStates = listOf(finishedPlaybackState),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertEquals(1, folders.size)
+    assertEquals(0, folders.first().unwatchedVideoCount)
+  }
+
+  @Test
+  fun flatFolders_inProgressVideoBelowThreshold_countsAsUnwatched() = runTest {
+    val clip = media(
+      identity = "file:/storage/A/clip.mp4",
+      location = "/storage/A/clip.mp4",
+      parent = "/storage/A",
+    ).copy(duration = 100_000L)
+    coEvery { dao.getAvailableMedia(true) } returns listOf(clip)
+
+    val inProgressState = PlaybackStateEntity(
+      mediaTitle = clip.location,
+      lastPosition = 94,
+      timeRemaining = 6,
+      playbackSpeed = 1.0,
+      sid = -1,
+      subDelay = 0,
+      subSpeed = 1.0,
+      aid = -1,
+      audioDelay = 0,
+      hasBeenWatched = false,
+    )
+
+    val folders = repository.getFlatFolders(
+      playbackStates = listOf(inProgressState),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertEquals(1, folders.size)
+    assertEquals(1, folders.first().unwatchedVideoCount)
+  }
+
+  @Test
+  fun flatFolders_inProgressVideoAtThreshold_countsAsWatched() = runTest {
+    val clip = media(
+      identity = "file:/storage/A/clip.mp4",
+      location = "/storage/A/clip.mp4",
+      parent = "/storage/A",
+    ).copy(duration = 100_000L)
+    coEvery { dao.getAvailableMedia(true) } returns listOf(clip)
+
+    val inProgressState = PlaybackStateEntity(
+      mediaTitle = clip.location,
+      lastPosition = 95,
+      timeRemaining = 5,
+      playbackSpeed = 1.0,
+      sid = -1,
+      subDelay = 0,
+      subSpeed = 1.0,
+      aid = -1,
+      audioDelay = 0,
+      hasBeenWatched = false,
+    )
+
+    val folders = repository.getFlatFolders(
+      playbackStates = listOf(inProgressState),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertEquals(1, folders.size)
+    assertEquals(0, folders.first().unwatchedVideoCount)
+  }
+
+  @Test
   fun noMediaPolicyIsAppliedWhenReadingPersistentIndex() = runTest {
     coEvery { dao.getAvailableMedia(false) } returns emptyList()
 

--- a/app/src/test/kotlin/xyz/mpv/rex/ui/browser/cards/MediaHighlightAndWatchedStateTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/ui/browser/cards/MediaHighlightAndWatchedStateTest.kt
@@ -1,0 +1,136 @@
+package xyz.mpv.rex.ui.browser.cards
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaHighlightAndWatchedStateTest {
+
+  /**
+   * Evaluates media card highlighting logic as implemented in BaseMediaCard.kt:
+   * val shouldHighlight = isRecentlyPlayed && !isWatched
+   */
+  private fun computeShouldHighlight(isRecentlyPlayed: Boolean, isWatched: Boolean): Boolean {
+    return isRecentlyPlayed && !isWatched
+  }
+
+  /**
+   * Evaluates hasBeenWatched calculation logic as implemented in PlayerActivity.kt:
+   * val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
+   * val isFinished = isEof || ((currentDuration > 0) && (currentPos >= currentDuration - 1))
+   * val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
+   * isCurrentlyWatched || isFinished
+   */
+  private fun computeHasBeenWatched(
+    currentPos: Int,
+    currentDuration: Int,
+    watchedThreshold: Int,
+    isEof: Boolean = false,
+  ): Boolean {
+    val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
+    val isFinished = isEof || ((currentDuration > 0) && (currentPos >= currentDuration - 1))
+    val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
+    return isCurrentlyWatched || isFinished
+  }
+  @Test
+  fun `media card highlight evaluates to false when video is watched even if recently played`() {
+    assertFalse(computeShouldHighlight(isRecentlyPlayed = true, isWatched = true))
+    assertFalse(computeShouldHighlight(isRecentlyPlayed = false, isWatched = true))
+  }
+
+  @Test
+  fun `media card highlight evaluates to true when video is recently played and not watched`() {
+    assertTrue(computeShouldHighlight(isRecentlyPlayed = true, isWatched = false))
+  }
+
+  @Test
+  fun `media card highlight evaluates to false when video is neither recently played nor watched`() {
+    assertFalse(computeShouldHighlight(isRecentlyPlayed = false, isWatched = false))
+  }
+
+  @Test
+  fun `rewatching finished video resets hasBeenWatched to false when progress below threshold`() {
+    // 100s video, watched 20s (20% progress), threshold is 90%, isEof = false
+    val hasBeenWatched = computeHasBeenWatched(
+      currentPos = 20,
+      currentDuration = 100,
+      watchedThreshold = 90,
+      isEof = false,
+    )
+    assertFalse(hasBeenWatched)
+  }
+
+  @Test
+  fun `hasBeenWatched evaluates to false strictly below threshold`() {
+    // 1000s video, watched 899s (89.9% progress), threshold is 90%
+    val hasBeenWatched = computeHasBeenWatched(
+      currentPos = 899,
+      currentDuration = 1000,
+      watchedThreshold = 90,
+      isEof = false,
+    )
+    assertFalse(hasBeenWatched)
+  }
+
+  @Test
+  fun `hasBeenWatched evaluates to true when progress meets or exceeds threshold`() {
+    val hasBeenWatchedAtThreshold = computeHasBeenWatched(
+      currentPos = 90,
+      currentDuration = 100,
+      watchedThreshold = 90,
+      isEof = false,
+    )
+    assertTrue(hasBeenWatchedAtThreshold)
+
+    val hasBeenWatchedAboveThreshold = computeHasBeenWatched(
+      currentPos = 95,
+      currentDuration = 100,
+      watchedThreshold = 90,
+      isEof = false,
+    )
+    assertTrue(hasBeenWatchedAboveThreshold)
+  }
+
+  @Test
+  fun `hasBeenWatched evaluates to true when isEof is true even below threshold`() {
+    val hasBeenWatched = computeHasBeenWatched(
+      currentPos = 10,
+      currentDuration = 100,
+      watchedThreshold = 90,
+      isEof = true,
+    )
+    assertTrue(hasBeenWatched)
+  }
+
+  @Test
+  fun `hasBeenWatched evaluates to true when within 1 second of end even if threshold is 100 percent`() {
+    // 100s video, pos 99 (within 1s of end), threshold 100%
+    val hasBeenWatched = computeHasBeenWatched(
+      currentPos = 99,
+      currentDuration = 100,
+      watchedThreshold = 100,
+      isEof = false,
+    )
+    assertTrue(hasBeenWatched)
+  }
+
+  @Test
+  fun `hasBeenWatched evaluates to false with zero or negative duration and not finished`() {
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 0,
+        currentDuration = 0,
+        watchedThreshold = 90,
+        isEof = false,
+      )
+    )
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 0,
+        currentDuration = -1,
+        watchedThreshold = 90,
+        isEof = false,
+      )
+    )
+  }
+}

--- a/app/src/test/kotlin/xyz/mpv/rex/utils/history/HistoryManagerTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/utils/history/HistoryManagerTest.kt
@@ -1,0 +1,233 @@
+package xyz.mpv.rex.utils.history
+
+import android.content.Context
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.mpv.rex.database.entities.PlaybackStateEntity
+import xyz.mpv.rex.domain.playbackstate.repository.PlaybackStateRepository
+import xyz.mpv.rex.domain.recentlyplayed.repository.RecentlyPlayedRepository
+import xyz.mpv.rex.preferences.AdvancedPreferences
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryManagerTest {
+
+  private val context = mockk<Context>(relaxed = true)
+  private val recentlyPlayedRepository = mockk<RecentlyPlayedRepository>(relaxed = true)
+  private val playbackStateRepository = mockk<PlaybackStateRepository>(relaxed = true)
+  private val advancedPreferences = mockk<AdvancedPreferences>(relaxed = true)
+  private val testScope = TestScope()
+
+  private val historyManager = HistoryManager(
+    context = context,
+    recentlyPlayedRepository = recentlyPlayedRepository,
+    playbackStateRepository = playbackStateRepository,
+    advancedPreferences = advancedPreferences,
+    scope = testScope,
+  )
+
+  @Test
+  fun `markAs Finished sets hasBeenWatched to true and records recently played`() = runTest {
+    val filePath = "/storage/emulated/0/Movies/test.mp4"
+    val fileName = "test.mp4"
+    val durationMs = 120_000L // 120 seconds
+
+    coEvery { playbackStateRepository.getVideoDataByTitle(fileName) } returns null
+
+    val entitySlot = slot<PlaybackStateEntity>()
+    coEvery { playbackStateRepository.upsert(capture(entitySlot)) } returns Unit
+
+    historyManager.markAs(filePath, fileName, durationMs, MarkAsState.Finished)
+
+    coVerify(exactly = 1) { playbackStateRepository.upsert(any()) }
+    val capturedEntity = entitySlot.captured
+    assertEquals(fileName, capturedEntity.mediaTitle)
+    assertEquals(120, capturedEntity.lastPosition)
+    assertEquals(0, capturedEntity.timeRemaining)
+    assertTrue("hasBeenWatched must be true when marked as Finished", capturedEntity.hasBeenWatched)
+
+    coVerify(exactly = 1) {
+      recentlyPlayedRepository.addRecentlyPlayed(
+        filePath = filePath,
+        fileName = fileName,
+        duration = durationMs,
+        launchSource = "mark_as",
+      )
+    }
+  }
+
+  @Test
+  fun `markAs Finished preserves existing audio and subtitle settings while setting hasBeenWatched to true`() = runTest {
+    val filePath = "/storage/emulated/0/Movies/test.mp4"
+    val fileName = "test.mp4"
+    val durationMs = 120_000L
+
+    val existingState = PlaybackStateEntity(
+      mediaTitle = fileName,
+      lastPosition = 30,
+      playbackSpeed = 1.75,
+      videoZoom = 1.2f,
+      sid = 2,
+      secondarySid = 3,
+      subDelay = 500,
+      subSpeed = 0.9,
+      aid = 1,
+      audioDelay = -200,
+      timeRemaining = 90,
+      hasBeenWatched = false,
+    )
+    coEvery { playbackStateRepository.getVideoDataByTitle(fileName) } returns existingState
+
+    val entitySlot = slot<PlaybackStateEntity>()
+    coEvery { playbackStateRepository.upsert(capture(entitySlot)) } returns Unit
+
+    historyManager.markAs(filePath, fileName, durationMs, MarkAsState.Finished)
+
+    coVerify(exactly = 1) { playbackStateRepository.upsert(any()) }
+    val captured = entitySlot.captured
+    assertEquals(fileName, captured.mediaTitle)
+    assertEquals(120, captured.lastPosition)
+    assertEquals(0, captured.timeRemaining)
+    assertEquals(1.75, captured.playbackSpeed, 0.001)
+    assertEquals(1.2f, captured.videoZoom)
+    assertEquals(2, captured.sid)
+    assertEquals(3, captured.secondarySid)
+    assertEquals(500, captured.subDelay)
+    assertEquals(0.9, captured.subSpeed, 0.001)
+    assertEquals(1, captured.aid)
+    assertEquals(-200, captured.audioDelay)
+    assertTrue("hasBeenWatched must be true when marked as Finished", captured.hasBeenWatched)
+  }
+
+  private fun createPlaybackState(
+    mediaTitle: String,
+    lastPosition: Int = 0,
+    timeRemaining: Int = 0,
+    hasBeenWatched: Boolean = false,
+    playbackSpeed: Double = 1.0,
+    videoZoom: Float = 0f,
+    sid: Int = -1,
+    secondarySid: Int = -1,
+    subDelay: Int = 0,
+    subSpeed: Double = 1.0,
+    aid: Int = -1,
+    audioDelay: Int = 0,
+  ) = PlaybackStateEntity(
+    mediaTitle = mediaTitle,
+    lastPosition = lastPosition,
+    playbackSpeed = playbackSpeed,
+    videoZoom = videoZoom,
+    sid = sid,
+    secondarySid = secondarySid,
+    subDelay = subDelay,
+    subSpeed = subSpeed,
+    aid = aid,
+    audioDelay = audioDelay,
+    timeRemaining = timeRemaining,
+    hasBeenWatched = hasBeenWatched,
+  )
+
+  @Test
+  fun `markAs New resets hasBeenWatched to false and removes from recently played`() = runTest {
+    val filePath = "/storage/emulated/0/Movies/test.mp4"
+    val fileName = "test.mp4"
+    val durationMs = 120_000L
+
+    val existingState = createPlaybackState(
+      mediaTitle = fileName,
+      lastPosition = 120,
+      timeRemaining = 0,
+      hasBeenWatched = true,
+    )
+    coEvery { playbackStateRepository.getVideoDataByTitle(fileName) } returns existingState
+
+    val entitySlot = slot<PlaybackStateEntity>()
+    coEvery { playbackStateRepository.upsert(capture(entitySlot)) } returns Unit
+    coEvery { recentlyPlayedRepository.deleteByFilePath(filePath) } returns Unit
+
+    historyManager.markAs(filePath, fileName, durationMs, MarkAsState.New)
+
+    coVerify(exactly = 1) { playbackStateRepository.upsert(any()) }
+    val captured = entitySlot.captured
+    assertEquals(fileName, captured.mediaTitle)
+    assertEquals(0, captured.lastPosition)
+    assertEquals(-1, captured.timeRemaining)
+    assertFalse("hasBeenWatched must be false when marked as New", captured.hasBeenWatched)
+
+    coVerify(exactly = 1) { recentlyPlayedRepository.deleteByFilePath(filePath) }
+  }
+
+  @Test
+  fun `markAs LastPlayed sets hasBeenWatched to false and records recently played`() = runTest {
+    val filePath = "/storage/emulated/0/Movies/test.mp4"
+    val fileName = "test.mp4"
+    val durationMs = 120_000L
+
+    val existingState = createPlaybackState(
+      mediaTitle = fileName,
+      lastPosition = 120,
+      timeRemaining = 0,
+      hasBeenWatched = true,
+    )
+    coEvery { playbackStateRepository.getVideoDataByTitle(fileName) } returns existingState
+
+    val entitySlot = slot<PlaybackStateEntity>()
+    coEvery { playbackStateRepository.upsert(capture(entitySlot)) } returns Unit
+
+    historyManager.markAs(filePath, fileName, durationMs, MarkAsState.LastPlayed)
+
+    coVerify(exactly = 1) { playbackStateRepository.upsert(any()) }
+    val captured = entitySlot.captured
+    assertEquals(fileName, captured.mediaTitle)
+    assertEquals(0, captured.lastPosition)
+    assertEquals(0, captured.timeRemaining)
+    assertFalse("hasBeenWatched must be false when marked as LastPlayed", captured.hasBeenWatched)
+
+    coVerify(exactly = 1) {
+      recentlyPlayedRepository.addRecentlyPlayed(
+        filePath = filePath,
+        fileName = fileName,
+        duration = durationMs,
+        launchSource = "mark_as_last_played",
+      )
+    }
+  }
+
+  @Test
+  fun `markAs None sets hasBeenWatched to false and removes from recently played`() = runTest {
+    val filePath = "/storage/emulated/0/Movies/test.mp4"
+    val fileName = "test.mp4"
+    val durationMs = 120_000L
+
+    val existingState = createPlaybackState(
+      mediaTitle = fileName,
+      lastPosition = 120,
+      timeRemaining = 0,
+      hasBeenWatched = true,
+    )
+    coEvery { playbackStateRepository.getVideoDataByTitle(fileName) } returns existingState
+
+    val entitySlot = slot<PlaybackStateEntity>()
+    coEvery { playbackStateRepository.upsert(capture(entitySlot)) } returns Unit
+    coEvery { recentlyPlayedRepository.deleteByFilePath(filePath) } returns Unit
+
+    historyManager.markAs(filePath, fileName, durationMs, MarkAsState.None)
+
+    coVerify(exactly = 1) { playbackStateRepository.upsert(any()) }
+    val captured = entitySlot.captured
+    assertEquals(fileName, captured.mediaTitle)
+    assertEquals(0, captured.lastPosition)
+    assertEquals(120, captured.timeRemaining)
+    assertFalse("hasBeenWatched must be false when marked as None", captured.hasBeenWatched)
+
+    coVerify(exactly = 1) { recentlyPlayedRepository.deleteByFilePath(filePath) }
+  }
+}


### PR DESCRIPTION
### Summary
Resolves #343 by ensuring that finished videos dim immediately upon completion in folder and browser views, and that re-watching a completed video un-sticks `hasBeenWatched` so active progress and bright title highlighting return while in progress.

### Changes
1. **Immediate Completion Dimming (`BaseMediaCard.kt`)**:
   - Updated highlight condition to `val shouldHighlight = isRecentlyPlayed && !isWatched` in both grid and list views.
   - Finished videos (`isWatched == true`) immediately render in dimmed faint style (60% opacity) without waiting for another video to be played.
   - Removed unused `isNeverPlayed` parameter in `BaseMediaCard` and removed dead forwarding arguments in `FolderCard` and `VideoCard`.

2. **Decoupled Sticky Watched State on Re-Watch (`PlayerActivity.kt`)**:
   - Decoupled `hasBeenWatched` from historical state (`oldState?.hasBeenWatched == true` / session stickiness):
     ```kotlin
     hasBeenWatched = isFinished || progress >= (watchedThreshold / 100f),
     ```
   - Active re-watching below threshold resets `hasBeenWatched = false`, restoring normal bright text and active progress tracking across all screens (including `RecentlyPlayedScreen`).

3. **Unit Tests**:
   - Added `MediaHighlightAndWatchedStateTest` covering highlight logic and threshold calculation boundaries.
   - Added `HistoryManagerTest` testing `markAs` state transitions (`Finished`, `New`, `LastPlayed`, `None`).
   - Added `HybridMediaIndexRepositoryTest` unit tests covering unwatched count calculations.
   - All tests pass cleanly (`./gradlew testDebugUnitTest`).