### PR TITLE
fix(browser): skip audio in folder new and unwatched counts when audio hidden (Closes #368)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepository.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepository.kt
@@ -749,9 +749,11 @@ class HybridMediaIndexRepository(
     thresholdMillis: Long,
     now: Long,
   ): Pair<Int, Int> {
+    val showAudioFiles = browserPreferences.showAudioFiles.get()
     var newCount = 0
     var unwatchedCount = 0
     items.forEach { item ->
+      if (!showAudioFiles && item.isAudio) return@forEach
       val fileName = java.io.File(item.location).name
       val state = stateByIdentity[item.location] ?: stateByIdentity[item.displayName] ?: stateByIdentity[fileName]
       val watched = state?.hasBeenWatched == true ||

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/base/BaseBrowserViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/base/BaseBrowserViewModel.kt
@@ -135,6 +135,16 @@ abstract class BaseBrowserViewModel<T>(
           loadData()
         }
     }
+
+    viewModelScope.launch(Dispatchers.Main) {
+      browserPreferences.showAudioFiles.changes()
+        .drop(1)
+        .collectLatest {
+          Log.d("BaseBrowserViewModel", "showAudioFiles changed to $it")
+          MediaFileRepository.clearCache()
+          loadData()
+        }
+    }
   }
 
   /**

--- a/app/src/main/kotlin/xyz/mpv/rex/utils/storage/CoreMediaScanner.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/utils/storage/CoreMediaScanner.kt
@@ -5,6 +5,7 @@ import android.provider.MediaStore
 import android.util.Log
 import xyz.mpv.rex.database.entities.PlaybackStateEntity
 import xyz.mpv.rex.domain.media.model.MediaFolder
+import xyz.mpv.rex.preferences.BrowserPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -25,6 +26,7 @@ object CoreMediaScanner {
     // Smart cache with configurable TTL
     private var cachedMediaData: Map<String, FolderNode>? = null
     private var cacheTimestamp: Long = 0
+    private var cachedShowAudioFiles: Boolean? = null
     private const val CACHE_TTL_MS = 180_000L // 3 minutes for standard refreshes
     
     /**
@@ -34,6 +36,7 @@ object CoreMediaScanner {
         Log.d(TAG, "Clearing core media scanner cache")
         cachedMediaData = null
         cacheTimestamp = 0
+        cachedShowAudioFiles = null
     }
     
     /**
@@ -270,16 +273,19 @@ object CoreMediaScanner {
         thresholdDays: Int,
         blacklistedFolders: Set<String> = emptySet()
     ): Map<String, FolderNode> {
+        val browserPreferences = org.koin.core.context.GlobalContext.get().get<BrowserPreferences>()
+        val showAudioFiles = browserPreferences.showAudioFiles.get()
         val now = System.currentTimeMillis()
         cachedMediaData?.let { cached ->
-            if (now - cacheTimestamp < CACHE_TTL_MS) {
+            if (now - cacheTimestamp < CACHE_TTL_MS && cachedShowAudioFiles == showAudioFiles) {
                 return cached
             }
         }
         
-        val tree = buildFullMediaTree(context, playbackStates, thresholdDays, blacklistedFolders)
+        val tree = buildFullMediaTree(context, playbackStates, thresholdDays, blacklistedFolders, browserPreferences, showAudioFiles)
         cachedMediaData = tree
         cacheTimestamp = now
+        cachedShowAudioFiles = showAudioFiles
         return tree
     }
 
@@ -290,7 +296,9 @@ object CoreMediaScanner {
         context: Context,
         playbackStates: List<PlaybackStateEntity>,
         thresholdDays: Int,
-        blacklistedFolders: Set<String>
+        blacklistedFolders: Set<String>,
+        browserPreferences: BrowserPreferences,
+        showAudioFiles: Boolean,
     ): Map<String, FolderNode> {
         val allNodes = mutableMapOf<String, FolderNode>()
         val rawMediaByFolder = mutableMapOf<String, MutableList<ScannedItem>>()
@@ -305,7 +313,6 @@ object CoreMediaScanner {
         val thresholdMillis = thresholdDays * 24 * 60 * 60 * 1000L
         
         // Get watched threshold from preferences
-        val browserPreferences = org.koin.core.context.GlobalContext.get().get<xyz.mpv.rex.preferences.BrowserPreferences>()
         val watchedThreshold = browserPreferences.watchedThreshold.get()
 
         // Step 3: Build Nodes for folders with direct media
@@ -332,6 +339,8 @@ object CoreMediaScanner {
                     } else {
                         videoCount++
                     }
+
+                    if (!showAudioFiles && item.isAudio) continue
 
                     // Calculate unwatched status for all media (audio and video)
                     val playbackState = playbackStates.find {
@@ -388,10 +397,12 @@ object CoreMediaScanner {
         context: Context,
         rawMedia: MutableMap<String, MutableList<ScannedItem>>
     ) {
+        val videoUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI ?: return
+        val audioUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI ?: return
         // Step 1: Scan Videos
-        queryMediaStore(context, MediaStore.Video.Media.EXTERNAL_CONTENT_URI, false, rawMedia)
+        queryMediaStore(context, videoUri, false, rawMedia)
         // Step 2: Scan Audio
-        queryMediaStore(context, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, true, rawMedia)
+        queryMediaStore(context, audioUri, true, rawMedia)
     }
 
     private fun queryMediaStore(

--- a/app/src/test/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepositoryTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/database/repository/HybridMediaIndexRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import xyz.mpv.rex.database.dao.HybridMediaDao
 import xyz.mpv.rex.database.entities.HybridMediaEntity
@@ -22,10 +23,13 @@ import android.net.Uri
 class HybridMediaIndexRepositoryTest {
   private val dao = mockk<HybridMediaDao>(relaxed = true)
   private val metadataCacheRepository = mockk<VideoMetadataCacheRepository>()
+  private val browserPreferences = mockk<BrowserPreferences>(relaxed = true) {
+    every { showAudioFiles.get() } returns false
+  }
   private val repository = HybridMediaIndexRepository(
     context = mockk<Context>(relaxed = true),
     dao = dao,
-    browserPreferences = mockk<BrowserPreferences>(relaxed = true),
+    browserPreferences = browserPreferences,
     foldersPreferences = mockk<FoldersPreferences>(relaxed = true),
     metadataCacheRepository = metadataCacheRepository,
   )
@@ -362,10 +366,256 @@ class HybridMediaIndexRepositoryTest {
     assertEquals(2, rootFolders[0].videoCount)
   }
 
+  @Test
+  fun flatFolders_whenShowAudioFilesFalse_excludesAudioFromNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val audioOnly = media(
+      identity = "file:/storage/Music/song.mp3",
+      location = "/storage/Music/song.mp3",
+      parent = "/storage/Music",
+      isAudio = true,
+    )
+    val mixedVideo = media(
+      identity = "file:/storage/Mixed/clip.mp4",
+      location = "/storage/Mixed/clip.mp4",
+      parent = "/storage/Mixed",
+      isAudio = false,
+    )
+    val mixedAudio = media(
+      identity = "file:/storage/Mixed/track.mp3",
+      location = "/storage/Mixed/track.mp3",
+      parent = "/storage/Mixed",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(audioOnly, mixedVideo, mixedAudio)
+
+    val folders = repository.getFlatFolders(
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    val musicFolder = folders.first { it.path == "/storage/Music" }
+    assertEquals(1, musicFolder.audioCount)
+    assertEquals(0, musicFolder.videoCount)
+    assertEquals(0, musicFolder.newCount)
+    assertEquals(0, musicFolder.unwatchedVideoCount)
+
+    val mixedFolder = folders.first { it.path == "/storage/Mixed" }
+    assertEquals(1, mixedFolder.audioCount)
+    assertEquals(1, mixedFolder.videoCount)
+    assertEquals(1, mixedFolder.newCount)
+    assertEquals(1, mixedFolder.unwatchedVideoCount)
+  }
+
+  @Test
+  fun flatFolders_whenShowAudioFilesTrue_includesAudioInNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val audioOnly = media(
+      identity = "file:/storage/Music/song.mp3",
+      location = "/storage/Music/song.mp3",
+      parent = "/storage/Music",
+      isAudio = true,
+    )
+    val mixedVideo = media(
+      identity = "file:/storage/Mixed/clip.mp4",
+      location = "/storage/Mixed/clip.mp4",
+      parent = "/storage/Mixed",
+      isAudio = false,
+    )
+    val mixedAudio = media(
+      identity = "file:/storage/Mixed/track.mp3",
+      location = "/storage/Mixed/track.mp3",
+      parent = "/storage/Mixed",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(audioOnly, mixedVideo, mixedAudio)
+
+    val folders = repository.getFlatFolders(
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    val musicFolder = folders.first { it.path == "/storage/Music" }
+    assertEquals(1, musicFolder.audioCount)
+    assertEquals(0, musicFolder.videoCount)
+    assertEquals(1, musicFolder.newCount)
+    assertEquals(1, musicFolder.unwatchedVideoCount)
+
+    val mixedFolder = folders.first { it.path == "/storage/Mixed" }
+    assertEquals(1, mixedFolder.audioCount)
+    assertEquals(1, mixedFolder.videoCount)
+    assertEquals(2, mixedFolder.newCount)
+    assertEquals(2, mixedFolder.unwatchedVideoCount)
+  }
+
+  @Test
+  fun foldersInDirectory_whenShowAudioFilesFalse_excludesAudioFromNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val audioItem = media(
+      identity = "file:/storage/Music/song.mp3",
+      location = "/storage/Music/song.mp3",
+      parent = "/storage/Music",
+      isAudio = true,
+    )
+    val mixedVideo = media(
+      identity = "file:/storage/Mixed/clip.mp4",
+      location = "/storage/Mixed/clip.mp4",
+      parent = "/storage/Mixed",
+      isAudio = false,
+    )
+    val mixedAudio = media(
+      identity = "file:/storage/Mixed/track.mp3",
+      location = "/storage/Mixed/track.mp3",
+      parent = "/storage/Mixed",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(audioItem, mixedVideo, mixedAudio)
+
+    val folders = repository.getFoldersInDirectory(
+      parentPath = "/storage",
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    val musicFolder = folders.first { it.path == "/storage/Music" }
+    assertEquals(1, musicFolder.audioCount)
+    assertEquals(0, musicFolder.videoCount)
+    assertEquals(0, musicFolder.newCount)
+    assertEquals(0, musicFolder.unwatchedVideoCount)
+
+    val mixedFolder = folders.first { it.path == "/storage/Mixed" }
+    assertEquals(1, mixedFolder.audioCount)
+    assertEquals(1, mixedFolder.videoCount)
+    assertEquals(1, mixedFolder.newCount)
+    assertEquals(1, mixedFolder.unwatchedVideoCount)
+  }
+
+  @Test
+  fun foldersInDirectory_whenShowAudioFilesTrue_includesAudioInNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val audioItem = media(
+      identity = "file:/storage/Music/song.mp3",
+      location = "/storage/Music/song.mp3",
+      parent = "/storage/Music",
+      isAudio = true,
+    )
+    val mixedVideo = media(
+      identity = "file:/storage/Mixed/clip.mp4",
+      location = "/storage/Mixed/clip.mp4",
+      parent = "/storage/Mixed",
+      isAudio = false,
+    )
+    val mixedAudio = media(
+      identity = "file:/storage/Mixed/track.mp3",
+      location = "/storage/Mixed/track.mp3",
+      parent = "/storage/Mixed",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(audioItem, mixedVideo, mixedAudio)
+
+    val folders = repository.getFoldersInDirectory(
+      parentPath = "/storage",
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    val musicFolder = folders.first { it.path == "/storage/Music" }
+    assertEquals(1, musicFolder.audioCount)
+    assertEquals(0, musicFolder.videoCount)
+    assertEquals(1, musicFolder.newCount)
+    assertEquals(1, musicFolder.unwatchedVideoCount)
+
+    val mixedFolder = folders.first { it.path == "/storage/Mixed" }
+    assertEquals(1, mixedFolder.audioCount)
+    assertEquals(1, mixedFolder.videoCount)
+    assertEquals(2, mixedFolder.newCount)
+    assertEquals(2, mixedFolder.unwatchedVideoCount)
+  }
+
+  @Test
+  fun recursiveFolder_whenShowAudioFilesFalse_excludesAudioFromNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val directVideo = media(
+      identity = "file:/storage/Music/clip.mp4",
+      location = "/storage/Music/clip.mp4",
+      parent = "/storage/Music",
+      isAudio = false,
+    )
+    val nestedAudio = media(
+      identity = "file:/storage/Music/Sub/song.mp3",
+      location = "/storage/Music/Sub/song.mp3",
+      parent = "/storage/Music/Sub",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(directVideo, nestedAudio)
+
+    val musicFolder = repository.getRecursiveFolder(
+      path = "/storage/Music",
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertNotNull(musicFolder)
+    assertEquals(1, musicFolder!!.audioCount)
+    assertEquals(1, musicFolder.videoCount)
+    assertEquals(1, musicFolder.newCount)
+    assertEquals(1, musicFolder.unwatchedVideoCount)
+  }
+
+  @Test
+  fun recursiveFolder_whenShowAudioFilesTrue_includesAudioInNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val directVideo = media(
+      identity = "file:/storage/Music/clip.mp4",
+      location = "/storage/Music/clip.mp4",
+      parent = "/storage/Music",
+      isAudio = false,
+    )
+    val nestedAudio = media(
+      identity = "file:/storage/Music/Sub/song.mp3",
+      location = "/storage/Music/Sub/song.mp3",
+      parent = "/storage/Music/Sub",
+      isAudio = true,
+    )
+    coEvery { dao.getAvailableMedia(true) } returns listOf(directVideo, nestedAudio)
+
+    val musicFolder = repository.getRecursiveFolder(
+      path = "/storage/Music",
+      playbackStates = emptyList(),
+      thresholdDays = 7,
+      watchedThreshold = 95,
+      includeNoMedia = true,
+    )
+
+    assertNotNull(musicFolder)
+    assertEquals(1, musicFolder!!.audioCount)
+    assertEquals(1, musicFolder.videoCount)
+    assertEquals(2, musicFolder.newCount)
+    assertEquals(2, musicFolder.unwatchedVideoCount)
+  }
+
   private fun media(
     identity: String,
     location: String,
     parent: String,
+    isAudio: Boolean = false,
+    displayName: String = if (isAudio) "song.mp3" else "clip.mp4",
   ) = HybridMediaEntity(
     identity = identity,
     sourceType = "DIRECT_FILE",
@@ -373,11 +623,11 @@ class HybridMediaIndexRepositoryTest {
     location = location,
     parentIdentity = parent,
     parentDisplayName = parent.substringAfterLast('/'),
-    displayName = "clip.mp4",
-    mimeType = "video/mp4",
+    displayName = displayName,
+    mimeType = if (isAudio) "audio/mp3" else "video/mp4",
     size = 100,
     dateModified = System.currentTimeMillis() / 1000,
-    isAudio = false,
+    isAudio = isAudio,
     isNoMedia = true,
     lastSeenGeneration = 1,
   )

--- a/app/src/test/kotlin/xyz/mpv/rex/utils/storage/CoreMediaScannerTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/utils/storage/CoreMediaScannerTest.kt
@@ -1,0 +1,166 @@
+package xyz.mpv.rex.utils.storage
+
+import android.content.Context
+import android.os.storage.StorageVolume
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import java.io.File
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import xyz.mpv.rex.preferences.BrowserPreferences
+
+class CoreMediaScannerTest {
+  private lateinit var tempDir: File
+  private val context = mockk<Context>(relaxed = true)
+  private val browserPreferences = mockk<BrowserPreferences>(relaxed = true)
+  private val mockVolume = mockk<StorageVolume>(relaxed = true)
+
+  @Before
+  fun setUp() {
+    tempDir = Files.createTempDirectory("core-media-scanner-test").toFile()
+    every { browserPreferences.watchedThreshold.get() } returns 95
+
+    mockkObject(StorageVolumeUtils)
+    every { StorageVolumeUtils.getExternalStorageVolumes(any()) } returns listOf(mockVolume)
+    every { StorageVolumeUtils.getVolumePath(mockVolume) } returns tempDir.absolutePath
+
+    startKoin {
+      modules(
+        module {
+          single { browserPreferences }
+        },
+      )
+    }
+    CoreMediaScanner.clearCache()
+  }
+
+  @After
+  fun tearDown() {
+    stopKoin()
+    unmockkObject(StorageVolumeUtils)
+    CoreMediaScanner.clearCache()
+    tempDir.deleteRecursively()
+  }
+
+  @Test
+  fun flatFolders_whenShowAudioFilesFalse_excludesAudioFromNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val musicFolder = File(tempDir, "Music").apply { mkdirs() }
+    val mixedFolder = File(tempDir, "Mixed").apply { mkdirs() }
+
+    File(musicFolder, "song.mp3").apply { writeText("audio") }
+    File(mixedFolder, "clip.mp4").apply { writeText("video") }
+    File(mixedFolder, "track.mp3").apply { writeText("audio") }
+
+    val folders = CoreMediaScanner.getFlatMediaFolders(context)
+
+    val music = folders.first { it.path == musicFolder.absolutePath }
+    assertEquals(1, music.audioCount)
+    assertEquals(0, music.videoCount)
+    assertEquals(0, music.newCount)
+    assertEquals(0, music.unwatchedVideoCount)
+
+    val mixed = folders.first { it.path == mixedFolder.absolutePath }
+    assertEquals(1, mixed.audioCount)
+    assertEquals(1, mixed.videoCount)
+    assertEquals(1, mixed.newCount)
+    assertEquals(1, mixed.unwatchedVideoCount)
+  }
+
+  @Test
+  fun flatFolders_whenShowAudioFilesTrue_includesAudioInNewAndUnwatchedCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val musicFolder = File(tempDir, "Music").apply { mkdirs() }
+    val mixedFolder = File(tempDir, "Mixed").apply { mkdirs() }
+
+    File(musicFolder, "song.mp3").apply { writeText("audio") }
+    File(mixedFolder, "clip.mp4").apply { writeText("video") }
+    File(mixedFolder, "track.mp3").apply { writeText("audio") }
+
+    val folders = CoreMediaScanner.getFlatMediaFolders(context)
+
+    val music = folders.first { it.path == musicFolder.absolutePath }
+    assertEquals(1, music.audioCount)
+    assertEquals(0, music.videoCount)
+    assertEquals(1, music.newCount)
+    assertEquals(1, music.unwatchedVideoCount)
+
+    val mixed = folders.first { it.path == mixedFolder.absolutePath }
+    assertEquals(1, mixed.audioCount)
+    assertEquals(1, mixed.videoCount)
+    assertEquals(2, mixed.newCount)
+    assertEquals(2, mixed.unwatchedVideoCount)
+  }
+
+  @Test
+  fun foldersInDirectory_whenShowAudioFilesFalse_excludesAudioFromHierarchyCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val parentFolder = File(tempDir, "Media").apply { mkdirs() }
+    val subFolder = File(parentFolder, "Sub").apply { mkdirs() }
+
+    File(parentFolder, "clip.mp4").apply { writeText("video") }
+    File(subFolder, "song.mp3").apply { writeText("audio") }
+
+    val folders = CoreMediaScanner.getFoldersInDirectory(context, parentPath = tempDir.absolutePath)
+    val mediaNode = folders.firstOrNull { it.path == parentFolder.absolutePath }
+
+    assertNotNull(mediaNode)
+    assertEquals(1, mediaNode!!.audioCount)
+    assertEquals(1, mediaNode.videoCount)
+    assertEquals(1, mediaNode.newCount)
+    assertEquals(1, mediaNode.unwatchedVideoCount)
+  }
+
+  @Test
+  fun foldersInDirectory_whenShowAudioFilesTrue_includesAudioInHierarchyCounts() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val parentFolder = File(tempDir, "Media").apply { mkdirs() }
+    val subFolder = File(parentFolder, "Sub").apply { mkdirs() }
+
+    File(parentFolder, "clip.mp4").apply { writeText("video") }
+    File(subFolder, "song.mp3").apply { writeText("audio") }
+
+    val folders = CoreMediaScanner.getFoldersInDirectory(context, parentPath = tempDir.absolutePath)
+    val mediaNode = folders.firstOrNull { it.path == parentFolder.absolutePath }
+
+    assertNotNull(mediaNode)
+    assertEquals(1, mediaNode!!.audioCount)
+    assertEquals(1, mediaNode.videoCount)
+    assertEquals(2, mediaNode.newCount)
+    assertEquals(2, mediaNode.unwatchedVideoCount)
+  }
+
+  @Test
+  fun cachedMediaData_invalidatesWhenShowAudioFilesPreferenceChanges() = runTest {
+    every { browserPreferences.showAudioFiles.get() } returns false
+
+    val musicFolder = File(tempDir, "Music").apply { mkdirs() }
+    File(musicFolder, "song.mp3").apply { writeText("audio") }
+
+    val initialFolders = CoreMediaScanner.getFlatMediaFolders(context)
+    val initialMusic = initialFolders.first { it.path == musicFolder.absolutePath }
+    assertEquals(0, initialMusic.newCount)
+    assertEquals(0, initialMusic.unwatchedVideoCount)
+
+    every { browserPreferences.showAudioFiles.get() } returns true
+
+    val updatedFolders = CoreMediaScanner.getFlatMediaFolders(context)
+    val updatedMusic = updatedFolders.first { it.path == musicFolder.absolutePath }
+    assertEquals(1, updatedMusic.newCount)
+    assertEquals(1, updatedMusic.unwatchedVideoCount)
+  }
+}


### PR DESCRIPTION
### Summary
Resolves #368 by skipping audio files (`item.isAudio`) from folder `newCount` and `unwatchedCount` calculations when the "Show audio files" preference (`browserPreferences.showAudioFiles.get()`) is disabled.

Previously, adding audio files to a folder caused folders to display a "NEW" badge and inflated unwatched counts even when audio was toggled off, leaving the badge stuck until audio was re-enabled and played.

### Changes
1. **Repository Presentation Counts (`HybridMediaIndexRepository.kt`)**:
   - In `presentationCounts`, early-return for audio items when `browserPreferences.showAudioFiles.get()` is `false`:
     ```kotlin
     if (!showAudioFiles && item.isAudio) return@forEach
     ```
   - Normal counting continues when `showAudioFiles` is `true`.

2. **Core Media Scanner (`CoreMediaScanner.kt`)**:
   - In `buildFullMediaTree`, skip audio items before calculating unwatched and NEW status when `showAudioFiles` is `false`:
     ```kotlin
     if (!showAudioFiles && item.isAudio) continue
     ```
   - Discovered audio files still update `directAudioCount` and `totalSize`.
   - Added cache invalidation when `showAudioFiles` preference state toggles in `getOrBuildMediaTree` so folder badge counts refresh immediately upon preference change.
   - Added null-safe checks for `EXTERNAL_CONTENT_URI` when scanning MediaStore in non-framework test environments.

3. **Unit Tests**:
   - Added test cases in `HybridMediaIndexRepositoryTest` covering flat, directory, and recursive folder queries with both `showAudioFiles = false` and `showAudioFiles = true`.
   - Added `CoreMediaScannerTest` verifying flat and directory folder node calculations with audio toggling and cache invalidation.
   - Verified all unit tests pass cleanly (`./gradlew testDebugUnitTest`).