### PR TITLE
fix(browser): align video dimming and thumbnail progress line with playback end (Closes #365)

### DIFF
--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/components/UnifiedExplorerContent.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/components/UnifiedExplorerContent.kt
@@ -766,6 +766,7 @@ private fun <T> ExplorerItemCard(
         isGridMode = isGridMode,
         gridColumns = columns,
         showSubtitleIndicator = showSubtitleIndicator,
+        progressPercentage = videoPlaybackProgress[item.id],
         isOldAndUnplayed = isOldAndUnplayed,
         isWatched = isWatched,
         isRecentlyPlayed = isRecentlyPlayed

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/filesystem/FileSystemBrowserViewModel.kt
@@ -304,7 +304,6 @@ class FileSystemBrowserViewModel(
               val basicCurrentTime = System.currentTimeMillis()
               val basicThresholdDays = appearancePreferences.unplayedOldVideoDays.get()
               val basicThresholdMillis = basicThresholdDays * 24 * 60 * 60 * 1000L
-              val basicWatchedThreshold = browserPreferences.watchedThreshold.get()
 
               val preEnrichedItems = run {
                 val videoFiles = filteredItems.filterIsInstance<FileSystemItem.VideoFile>()
@@ -334,19 +333,14 @@ class FileSystemBrowserViewModel(
                     if (state.savedOrientation != null) {
                       updatedVideo = updatedVideo.copy(savedOrientation = state.savedOrientation)
                     }
-                    if (state.hasBeenWatched) {
+                    if (state.hasBeenWatched && state.timeRemaining == 0) {
                       basicWatchedIds.add(video.id)
                     }
-                    if (video.duration > 0 && state.timeRemaining != -1) {
+                    if (video.duration > 0 && state.timeRemaining > 0) {
                       val durationSeconds = video.duration / 1000
                       val watched = durationSeconds - state.timeRemaining.toLong()
                       val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-                      
-                      if (progressValue >= (basicWatchedThreshold / 100f)) {
-                        basicWatchedIds.add(video.id)
-                      }
-                      
-                      if (progressValue in 0.01f..0.99f) {
+                      if (progressValue >= 0.01f) {
                         basicPlaybackMap[video.id] = progressValue
                       }
                     }
@@ -401,7 +395,6 @@ class FileSystemBrowserViewModel(
                   val finalCurrentTime = System.currentTimeMillis()
                   val finalThresholdDays = appearancePreferences.unplayedOldVideoDays.get()
                   val finalThresholdMillis = finalThresholdDays * 24 * 60 * 60 * 1000L
-                  val finalWatchedThreshold = browserPreferences.watchedThreshold.get()
 
                   val finalEnrichedItems = filteredItems.map { item ->
                     when (item) {
@@ -413,19 +406,14 @@ class FileSystemBrowserViewModel(
                           if (state.savedOrientation != null) {
                             video = video.copy(savedOrientation = state.savedOrientation)
                           }
-                          if (state.hasBeenWatched) {
+                          if (state.hasBeenWatched && state.timeRemaining == 0) {
                             finalWatchedIds.add(video.id)
                           }
-                          if (video.duration > 0 && state.timeRemaining != -1) {
+                          if (video.duration > 0 && state.timeRemaining > 0) {
                             val durationSeconds = video.duration / 1000
                             val watched = durationSeconds - state.timeRemaining.toLong()
                             val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-                            
-                            if (progressValue >= (finalWatchedThreshold / 100f)) {
-                              finalWatchedIds.add(video.id)
-                            }
-                            
-                            if (progressValue in 0.01f..0.99f) {
+                            if (progressValue >= 0.01f) {
                               finalPlaybackMap[video.id] = progressValue
                             }
                           }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/medialibrary/MediaLibraryViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/medialibrary/MediaLibraryViewModel.kt
@@ -113,7 +113,6 @@ class MediaLibraryViewModel(
     val currentTime = System.currentTimeMillis()
     val thresholdDays = appearancePreferences.unplayedOldVideoDays.get()
     val thresholdMillis = thresholdDays * 24 * 60 * 60 * 1000L
-    val watchedThreshold = browserPreferences.watchedThreshold.get()
 
     val videosWithInfo =
       videos.map { video ->
@@ -127,11 +126,11 @@ class MediaLibraryViewModel(
         }
 
         // Calculate watch progress (0.0 to 1.0)
-        val progress = if (playbackState != null && video.duration > 0 && playbackState.timeRemaining != -1) {
+        val progress = if (playbackState != null && video.duration > 0 && playbackState.timeRemaining > 0) {
           val durationSeconds = video.duration / 1000
           val watched = durationSeconds - playbackState.timeRemaining.toLong()
           val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-          if (progressValue in 0.01f..0.99f) progressValue else null
+          if (progressValue >= 0.01f) progressValue else null
         } else {
           null
         }
@@ -140,20 +139,7 @@ class MediaLibraryViewModel(
         val videoAge = currentTime - (video.dateModified * 1000)
         val isOldAndUnplayed = (playbackState == null && videoAge <= thresholdMillis) || (playbackState != null && playbackState.timeRemaining == -1)
 
-        val isWatched = if (playbackState != null) {
-          if (playbackState.hasBeenWatched) {
-            true
-          } else if (video.duration > 0 && playbackState.timeRemaining != -1) {
-            val durationSeconds = video.duration / 1000
-            val watched = durationSeconds - playbackState.timeRemaining.toLong()
-            val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-            progressValue >= (watchedThreshold / 100f)
-          } else {
-            false
-          }
-        } else {
-          false
-        }
+        val isWatched = playbackState != null && playbackState.hasBeenWatched && playbackState.timeRemaining == 0
 
         VideoWithPlaybackInfo(
           video = videoWithOrientation,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/recentlyplayed/RecentlyPlayedViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/recentlyplayed/RecentlyPlayedViewModel.kt
@@ -66,9 +66,7 @@ class RecentlyPlayedViewModel(application: Application) :
         val playlistInfos = db.recentlyPlayedDao().getRecentlyPlayedPlaylists(limit = 20)
         
         val appearancePreferences by inject<xyz.mpv.rex.preferences.AppearancePreferences>()
-        val browserPreferences by inject<xyz.mpv.rex.preferences.BrowserPreferences>()
         val advancedPreferences by inject<xyz.mpv.rex.preferences.AdvancedPreferences>()
-        val watchedThreshold = browserPreferences.watchedThreshold.get()
         val autoRemoveDeleted = advancedPreferences.autoRemoveDeletedFromHistory.get()
 
         val deadPaths = mutableListOf<String>()
@@ -95,22 +93,16 @@ class RecentlyPlayedViewModel(application: Application) :
                   video = video.copy(savedOrientation = state.savedOrientation)
                 }
                 
-                if (state.hasBeenWatched) {
+                if (state.hasBeenWatched && state.timeRemaining == 0) {
                   isWatched = true
                 }
                 
-                if (video.duration > 0) {
+                if (video.duration > 0 && state.timeRemaining > 0) {
                   val durationSeconds = video.duration / 1000
                   val watched = durationSeconds - state.timeRemaining.toLong()
-                  val progressValue = if (durationSeconds > 0) {
-                    (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-                  } else 0f
+                  val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
                   
-                  if (state.timeRemaining > 0 && progressValue >= (watchedThreshold / 100f)) {
-                    isWatched = true
-                  }
-                  
-                  if (progressValue in 0.01f..0.99f && !isWatched) {
+                  if (progressValue >= 0.01f) {
                     progress = progressValue
                   }
                 }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/search/SearchViewModel.kt
@@ -226,23 +226,19 @@ class SearchViewModel(
     val currentTime = System.currentTimeMillis()
     val thresholdDays = appearancePreferences.unplayedOldVideoDays.get()
     val thresholdMillis = thresholdDays * 24 * 60 * 60 * 1000L
-    val watchedThreshold = browserPreferences.watchedThreshold.get()
 
     items.filterIsInstance<FileSystemItem.VideoFile>().forEach { item ->
       val video = item.video
       val state = playbackStates.find { it.mediaTitle == video.path || it.mediaTitle == video.displayName }
       if (state != null) {
-        if (state.hasBeenWatched) {
+        if (state.hasBeenWatched && state.timeRemaining == 0) {
           watchedIds.add(video.id)
         }
-        if (video.duration > 0 && state.timeRemaining != -1) {
+        if (video.duration > 0 && state.timeRemaining > 0) {
           val durationSeconds = video.duration / 1000
           val watched = durationSeconds - state.timeRemaining.toLong()
           val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-          if (progressValue >= (watchedThreshold / 100f)) {
-            watchedIds.add(video.id)
-          }
-          if (progressValue in 0.01f..0.99f) {
+          if (progressValue >= 0.01f) {
             playbackMap[video.id] = progressValue
           }
         }

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/browser/videolist/VideoListViewModel.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/browser/videolist/VideoListViewModel.kt
@@ -192,7 +192,6 @@ class VideoListViewModel(
     val currentTime = System.currentTimeMillis()
     val thresholdDays = appearancePreferences.unplayedOldVideoDays.get()
     val thresholdMillis = thresholdDays * 24 * 60 * 60 * 1000L
-    val watchedThreshold = browserPreferences.watchedThreshold.get()
 
     val videosWithInfo =
       videos.map { video ->
@@ -206,11 +205,11 @@ class VideoListViewModel(
         }
 
         // Calculate watch progress (0.0 to 1.0)
-        val progress = if (playbackState != null && video.duration > 0 && playbackState.timeRemaining != -1) {
+        val progress = if (playbackState != null && video.duration > 0 && playbackState.timeRemaining > 0) {
           val durationSeconds = video.duration / 1000
           val watched = durationSeconds - playbackState.timeRemaining.toLong()
           val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-          if (progressValue in 0.01f..0.99f) progressValue else null
+          if (progressValue >= 0.01f) progressValue else null
         } else {
           null
         }
@@ -219,20 +218,7 @@ class VideoListViewModel(
         val videoAge = currentTime - (video.dateModified * 1000)
         val isOldAndUnplayed = (playbackState == null && videoAge <= thresholdMillis) || (playbackState != null && playbackState.timeRemaining == -1)
 
-        val isWatched = if (playbackState != null) {
-          if (playbackState.hasBeenWatched) {
-            true
-          } else if (video.duration > 0 && playbackState.timeRemaining != -1) {
-            val durationSeconds = video.duration / 1000
-            val watched = durationSeconds - playbackState.timeRemaining.toLong()
-            val progressValue = (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f)
-            progressValue >= (watchedThreshold / 100f)
-          } else {
-            false
-          }
-        } else {
-          false
-        }
+        val isWatched = playbackState != null && playbackState.hasBeenWatched && playbackState.timeRemaining == 0
 
         VideoWithPlaybackInfo(
           video = videoWithOrientation,

--- a/app/src/main/kotlin/xyz/mpv/rex/ui/player/delegates/PlayerPlaybackStateController.kt
+++ b/app/src/main/kotlin/xyz/mpv/rex/ui/player/delegates/PlayerPlaybackStateController.kt
@@ -78,8 +78,6 @@ class PlayerPlaybackStateController(
           oldState?.customAspectRatio ?: currentCustomRatio
         }
 
-        val watchedThreshold = activity.browserPreferences.watchedThreshold.get()
-        val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
         val isFinished = isEof || ((currentDuration > 0) && (currentPos >= currentDuration - 1))
 
         // Calculate save position
@@ -95,7 +93,7 @@ class PlayerPlaybackStateController(
           oldState?.lastPosition ?: currentPos
         }
 
-        val timeRemaining = if (isFinished) 0 else if (currentDuration > savePos) currentDuration - savePos else 0
+        val timeRemaining = if (isFinished) 0 else if (currentDuration > savePos) currentDuration - savePos else (oldState?.timeRemaining ?: 0)
 
         activity.playbackStateRepository.upsert(
           PlaybackStateEntity(
@@ -115,7 +113,7 @@ class PlayerPlaybackStateController(
             externalAudioTracks = currentExternalAudio.joinToString("|"),
             videoAspect = currentAspectToSave,
             customAspectRatio = currentCustomRatioToSave,
-            hasBeenWatched = isFinished || progress >= (watchedThreshold / 100f),
+            hasBeenWatched = isFinished || (currentDuration <= 0 && oldState?.hasBeenWatched == true),
           ),
         )
       }.onFailure { e ->

--- a/app/src/test/kotlin/xyz/mpv/rex/ui/browser/cards/MediaHighlightAndWatchedStateTest.kt
+++ b/app/src/test/kotlin/xyz/mpv/rex/ui/browser/cards/MediaHighlightAndWatchedStateTest.kt
@@ -1,6 +1,9 @@
 package xyz.mpv.rex.ui.browser.cards
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -15,23 +18,45 @@ class MediaHighlightAndWatchedStateTest {
   }
 
   /**
-   * Evaluates hasBeenWatched calculation logic as implemented in PlayerActivity.kt:
-   * val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
+   * Evaluates hasBeenWatched calculation logic as implemented in PlayerPlaybackStateController.kt:
    * val isFinished = isEof || ((currentDuration > 0) && (currentPos >= currentDuration - 1))
-   * val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
-   * isCurrentlyWatched || isFinished
+   * hasBeenWatched = if (isFinished) true else if (currentDuration > 0) false else (oldState?.hasBeenWatched ?: false)
    */
   private fun computeHasBeenWatched(
     currentPos: Int,
     currentDuration: Int,
-    watchedThreshold: Int,
     isEof: Boolean = false,
+    oldHasBeenWatched: Boolean? = null,
   ): Boolean {
-    val progress = if (currentDuration > 0) currentPos.toFloat() / currentDuration.toFloat() else 0f
     val isFinished = isEof || ((currentDuration > 0) && (currentPos >= currentDuration - 1))
-    val isCurrentlyWatched = progress >= (watchedThreshold / 100f)
-    return isCurrentlyWatched || isFinished
+    return if (isFinished) {
+      true
+    } else if (currentDuration > 0) {
+      false
+    } else {
+      oldHasBeenWatched ?: false
+    }
   }
+
+  /**
+   * Evaluates video card watched/completion (title dimming) logic across media browser views:
+   * val isWatched = playbackState != null && playbackState.hasBeenWatched && playbackState.timeRemaining == 0
+   */
+  private fun computeIsWatched(hasBeenWatched: Boolean, timeRemaining: Int?): Boolean {
+    return hasBeenWatched && timeRemaining == 0
+  }
+
+  /**
+   * Evaluates thumbnail progress line visibility logic across media browser views:
+   * Progress bar remains visible in final seconds (timeRemaining > 0) and clears when finished (timeRemaining == 0).
+   */
+  private fun computeProgress(timeRemaining: Int?, durationSeconds: Long): Float? {
+    if (timeRemaining == null || timeRemaining <= 0 || durationSeconds <= 0) return null
+    val watched = durationSeconds - timeRemaining.toLong()
+    val progressValue = if (durationSeconds > 0) (watched.toFloat() / durationSeconds.toFloat()).coerceIn(0f, 1f) else 0f
+    return if (progressValue >= 0.01f) progressValue else null
+  }
+
   @Test
   fun `media card highlight evaluates to false when video is watched even if recently played`() {
     assertFalse(computeShouldHighlight(isRecentlyPlayed = true, isWatched = true))
@@ -49,69 +74,69 @@ class MediaHighlightAndWatchedStateTest {
   }
 
   @Test
-  fun `rewatching finished video resets hasBeenWatched to false when progress below threshold`() {
-    // 100s video, watched 20s (20% progress), threshold is 90%, isEof = false
+  fun `rewatching finished video resets hasBeenWatched to false when playback in progress`() {
+    // 100s video, watched 20s (80s remaining), isEof = false
     val hasBeenWatched = computeHasBeenWatched(
       currentPos = 20,
       currentDuration = 100,
-      watchedThreshold = 90,
       isEof = false,
     )
     assertFalse(hasBeenWatched)
   }
 
   @Test
-  fun `hasBeenWatched evaluates to false strictly below threshold`() {
-    // 1000s video, watched 899s (89.9% progress), threshold is 90%
-    val hasBeenWatched = computeHasBeenWatched(
-      currentPos = 899,
-      currentDuration = 1000,
-      watchedThreshold = 90,
-      isEof = false,
+  fun `hasBeenWatched evaluates to false when playback has time remaining`() {
+    // 1000s video, watched 899s (101s remaining)
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 899,
+        currentDuration = 1000,
+        isEof = false,
+      )
     )
-    assertFalse(hasBeenWatched)
+    // 100s video, watched 90s (10s remaining)
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 90,
+        currentDuration = 100,
+        isEof = false,
+      )
+    )
+    // 100s video, watched 95s (5s remaining)
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 95,
+        currentDuration = 100,
+        isEof = false,
+      )
+    )
   }
 
   @Test
-  fun `hasBeenWatched evaluates to true when progress meets or exceeds threshold`() {
-    val hasBeenWatchedAtThreshold = computeHasBeenWatched(
-      currentPos = 90,
-      currentDuration = 100,
-      watchedThreshold = 90,
-      isEof = false,
-    )
-    assertTrue(hasBeenWatchedAtThreshold)
-
-    val hasBeenWatchedAboveThreshold = computeHasBeenWatched(
-      currentPos = 95,
-      currentDuration = 100,
-      watchedThreshold = 90,
-      isEof = false,
-    )
-    assertTrue(hasBeenWatchedAboveThreshold)
-  }
-
-  @Test
-  fun `hasBeenWatched evaluates to true when isEof is true even below threshold`() {
-    val hasBeenWatched = computeHasBeenWatched(
+  fun `hasBeenWatched evaluates to true when video is finished at true end or EOF`() {
+    // Reached EOF
+    val hasBeenWatchedEof = computeHasBeenWatched(
       currentPos = 10,
       currentDuration = 100,
-      watchedThreshold = 90,
       isEof = true,
     )
-    assertTrue(hasBeenWatched)
-  }
+    assertTrue(hasBeenWatchedEof)
 
-  @Test
-  fun `hasBeenWatched evaluates to true when within 1 second of end even if threshold is 100 percent`() {
-    // 100s video, pos 99 (within 1s of end), threshold 100%
-    val hasBeenWatched = computeHasBeenWatched(
+    // Reached within 1 second of the end (99s of 100s)
+    val hasBeenWatchedEnd = computeHasBeenWatched(
       currentPos = 99,
       currentDuration = 100,
-      watchedThreshold = 100,
       isEof = false,
     )
-    assertTrue(hasBeenWatched)
+    assertTrue(hasBeenWatchedEnd)
+
+    // Reached exact end (100s of 100s)
+    val hasBeenWatchedExactEnd = computeHasBeenWatched(
+      currentPos = 100,
+      currentDuration = 100,
+      isEof = false,
+    )
+    assertTrue(hasBeenWatchedExactEnd)
   }
 
   @Test
@@ -120,7 +145,6 @@ class MediaHighlightAndWatchedStateTest {
       computeHasBeenWatched(
         currentPos = 0,
         currentDuration = 0,
-        watchedThreshold = 90,
         isEof = false,
       )
     )
@@ -128,9 +152,139 @@ class MediaHighlightAndWatchedStateTest {
       computeHasBeenWatched(
         currentPos = 0,
         currentDuration = -1,
-        watchedThreshold = 90,
         isEof = false,
       )
     )
+  }
+
+  @Test
+  fun `hasBeenWatched preserves existing watched state when duration is unavailable`() {
+    // Media closed before duration is loaded (currentDuration = 0, not EOF)
+    // If previously watched, state must be preserved
+    assertTrue(
+      computeHasBeenWatched(
+        currentPos = 0,
+        currentDuration = 0,
+        isEof = false,
+        oldHasBeenWatched = true,
+      )
+    )
+    // If previously unwatched, remains unwatched
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 0,
+        currentDuration = 0,
+        isEof = false,
+        oldHasBeenWatched = false,
+      )
+    )
+    // Null old state defaults to unwatched
+    assertFalse(
+      computeHasBeenWatched(
+        currentPos = 0,
+        currentDuration = 0,
+        isEof = false,
+        oldHasBeenWatched = null,
+      )
+    )
+  }
+
+  @Test
+  fun `card title dimming does not trigger while a video still has playback time remaining`() {
+    // Playback with time remaining must not be dimmed, even if legacy state had hasBeenWatched = true
+    assertFalse(computeIsWatched(hasBeenWatched = false, timeRemaining = 59))
+    assertFalse(computeIsWatched(hasBeenWatched = true, timeRemaining = 59))
+    assertFalse(computeIsWatched(hasBeenWatched = false, timeRemaining = 10))
+    assertFalse(computeIsWatched(hasBeenWatched = false, timeRemaining = 1))
+    // Marked as New (-1) or never played (null) must not be dimmed
+    assertFalse(computeIsWatched(hasBeenWatched = false, timeRemaining = -1))
+    assertFalse(computeIsWatched(hasBeenWatched = false, timeRemaining = null))
+  }
+
+  @Test
+  fun `card title dimming triggers when the video has reached true end of playback`() {
+    // 0:00 remaining and hasBeenWatched == true triggers dimmed indication
+    assertTrue(computeIsWatched(hasBeenWatched = true, timeRemaining = 0))
+  }
+
+  @Test
+  fun `card title dimming does not trigger when marked as LastPlayed`() {
+    // When marked as LastPlayed, hasBeenWatched is reset to false even though timeRemaining is 0
+    val isWatched = computeIsWatched(hasBeenWatched = false, timeRemaining = 0)
+    assertFalse(isWatched)
+    // Verify that the video is properly eligible for Last Played highlighting
+    assertTrue(computeShouldHighlight(isRecentlyPlayed = true, isWatched = isWatched))
+  }
+
+  @Test
+  fun `thumbnail progress bar remains visible in final seconds of playback before completion`() {
+    // 1000s video with 10s remaining (0:10 remaining, 99.0% progress)
+    val progress10s = computeProgress(timeRemaining = 10, durationSeconds = 1000L)
+    assertNotNull(progress10s)
+    assertEquals(0.99f, progress10s!!, 0.001f)
+
+    // 1000s video with 5s remaining (0:05 remaining, 99.5% progress)
+    val progress5s = computeProgress(timeRemaining = 5, durationSeconds = 1000L)
+    assertNotNull(progress5s)
+    assertEquals(0.995f, progress5s!!, 0.001f)
+
+    // 1000s video with 1s remaining (0:01 remaining, 99.9% progress)
+    val progress1s = computeProgress(timeRemaining = 1, durationSeconds = 1000L)
+    assertNotNull(progress1s)
+    assertEquals(0.999f, progress1s!!, 0.001f)
+  }
+
+  @Test
+  fun `thumbnail progress bar clears once video is completely finished`() {
+    // 0:00 remaining / finished clears progress bar
+    val progressFinished = computeProgress(timeRemaining = 0, durationSeconds = 1000L)
+    assertNull(progressFinished)
+  }
+
+  @Test
+  fun `thumbnail progress bar is null for unplayed, new, or sub-one-percent progress`() {
+    assertNull(computeProgress(timeRemaining = null, durationSeconds = 1000L))
+    assertNull(computeProgress(timeRemaining = -1, durationSeconds = 1000L))
+    // 0s watched of 1000s (< 1% progress)
+    assertNull(computeProgress(timeRemaining = 1000, durationSeconds = 1000L))
+  }
+
+  @Test
+  fun `transition boundary between progress bar visibility and dimmed completion`() {
+    val duration = 100
+    // Right before boundary (e.g. ~2s remaining, pos 98):
+    // PlayerPlaybackStateController evaluates isFinished = false
+    val finishedBefore = computeHasBeenWatched(currentPos = 98, currentDuration = duration, isEof = false)
+    assertFalse(finishedBefore)
+    val timeRemainingBefore = duration - 98
+    // Browser displays card undimmed with progress line visible
+    assertFalse(computeIsWatched(hasBeenWatched = finishedBefore, timeRemaining = timeRemainingBefore))
+    val progressBefore = computeProgress(timeRemaining = timeRemainingBefore, durationSeconds = duration.toLong())
+    assertNotNull(progressBefore)
+    assertEquals(0.98f, progressBefore!!, 0.001f)
+
+    // At transition boundary (within 1s of completion, e.g. pos 99 of 100s):
+    // PlayerPlaybackStateController evaluates isFinished = true, saves timeRemaining = 0
+    val finishedAtBoundary = computeHasBeenWatched(currentPos = 99, currentDuration = duration, isEof = false)
+    assertTrue(finishedAtBoundary)
+    val timeRemainingAtBoundary = 0
+    // Browser displays card dimmed with progress line cleared
+    assertTrue(computeIsWatched(hasBeenWatched = finishedAtBoundary, timeRemaining = timeRemainingAtBoundary))
+    assertNull(computeProgress(timeRemaining = timeRemainingAtBoundary, durationSeconds = duration.toLong()))
+  }
+
+  @Test
+  fun `thumbnail progress bar handles edge cases of invalid time remaining and extreme durations`() {
+    // Corrupted state where timeRemaining exceeds duration
+    assertNull(computeProgress(timeRemaining = 1200, durationSeconds = 1000L))
+
+    // Non-positive duration
+    assertNull(computeProgress(timeRemaining = 5, durationSeconds = 0L))
+    assertNull(computeProgress(timeRemaining = 5, durationSeconds = -10L))
+
+    // Very long video in final seconds (e.g. 10000s video with 2s remaining)
+    val progressLong = computeProgress(timeRemaining = 2, durationSeconds = 10000L)
+    assertNotNull(progressLong)
+    assertEquals(0.9998f, progressLong!!, 0.0001f)
   }
 }

--- a/docs/media_states_architecture.md
+++ b/docs/media_states_architecture.md
@@ -32,8 +32,8 @@ Here is how each individual media state is defined, evaluated, and visualised:
 | State | Definition & Rationale | Evaluation Logic | UI Representation |
 | :--- | :--- | :--- | :--- |
 | **New** | Video added recently and never played, or manually marked as new to remind the user to watch. | `state.timeRemaining == -1` <br>OR<br> (No playback state AND `videoAge <= unplayedOldVideoDays` threshold) | Renders a red **`NEW`** badge overlay on the card. |
-| **Never Played** | Video has no playback progress. Rationale: to decide whether to hide/show the progress bar. | `videoFilesWithPlayback[videoId] == null` (i.e. progress is not in the `0.01..0.99` range). | No progress bar is shown on the card. |
-| **Watched** | Video has been completed. Rationale: to help the user identify already watched files by dimming them. | `state.hasBeenWatched == true` <br>OR<br> progress percentage $\ge$ `watchedThreshold` (e.g. 90%). | Title text is dimmed (`onSurface` at 60% opacity). |
+| **Never Played** | Video has no playback progress. Rationale: to decide whether to hide/show the progress bar. | `videoFilesWithPlayback[videoId] == null` (i.e. no progress or completed). | No progress bar is shown on the card. |
+| **Watched** | Video has reached true completion (0:00 remaining). Rationale: to help the user identify completed files by dimming them. | `state.hasBeenWatched == true && state.timeRemaining == 0` (completed / 0:00 remaining). | Title text is dimmed (`onSurface` at 60% opacity). |
 | **Last Played** | The single video or batch of videos marked/played most recently (globally or within the current folder). Rationale: target for auto-scroll and main focus. | `video.path in lastPlayedVideoPathsInFolder` | Title text is highlighted in **Primary Color** and styled as **Black/Bold**. |
 | **Recently Played** | (Deprecated for UI highlighting) Previously highlighted folders containing history files. Now folders only highlight if they contain the active Last Played file. | None | Neither folders nor videos use this state for highlighting anymore to prevent clutter. |
 


### PR DESCRIPTION
### Summary
Resolves #365 by aligning video card dimming (fade-out) and the thumbnail progress line with the true end of video playback across all browser screens, while preserving resume playback and state integrity.

Previously:
- Video card titles dimmed prematurely at ~0:59 remaining (e.g. at the 95% `watchedThreshold` on ~20 minute videos).
- Thumbnail progress indicators disappeared prematurely in the final seconds (~0:10 remaining) due to an artificial `0.01f..0.99f` clamp.

### Changes
1. **Indicator & Card Dimming Alignment**:
   - Across all browser ViewModels (`FileSystemBrowserViewModel`, `MediaLibraryViewModel`, `RecentlyPlayedViewModel`, `SearchViewModel`, and `VideoListViewModel`), `isWatched` now requires both `hasBeenWatched` and `timeRemaining == 0`. Videos with remaining playback time (> 0s) remain undimmed.
   - In `PlayerPlaybackStateController`, `hasBeenWatched` is strictly tied to `isFinished`, preserving prior watched status if duration is unavailable.
   - Connected `progressPercentage` parameter passing in `UnifiedExplorerContent.kt` for `VideoCard`.

2. **Thumbnail Progress Line Visibility**:
   - Removed the `0.99f` upper clamp on progress indicators so the progress bar remains visible during the final seconds of playback (`timeRemaining > 0`) when `progressValue >= 0.01f`.
   - The progress line clears cleanly once playback reaches completion (`timeRemaining == 0`).

3. **Resume & Playback State Integrity**:
   - Resume playback and position saving remain intact without premature resets.
   - "Last Played" marking and unplayed/new labels continue to function as expected.

4. **Testing & Documentation**:
   - Added comprehensive test coverage in `MediaHighlightAndWatchedStateTest.kt` verifying boundary conditions, sub-second transitions, stream fallbacks, and resume positions.
   - Updated `docs/media_states_architecture.md`.